### PR TITLE
[NETBEANS-161] Changed license header introducer to simple slash-star

### DIFF
--- a/ant.browsetask/antsrc/org/netbeans/modules/ant/browsetask/NbBrowse.java
+++ b/ant.browsetask/antsrc/org/netbeans/modules/ant/browsetask/NbBrowse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebuggerEngineProvider.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebuggerEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/CallStackModel.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/CallStackModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAnnotation.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerBreakpointAnnotation.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerBreakpointAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetAction.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/SessionsTableModelFilter.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/SessionsTableModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/Task.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/ToolTipAnnotation.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/ToolTipAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/Utils.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/VariablesModel.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/VariablesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/VerticalGridLayout.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/VerticalGridLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/WatchesModel.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/WatchesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/AntBreakpoint.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/AntBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/AntBreakpointActionProvider.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/AntBreakpointActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointAnnotationListener.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointAnnotationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointModel.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointsReader.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointsReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/PersistenceManager.java
+++ b/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/PersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.debugger/test/unit/src/org/netbeans/modules/ant/debugger/StepTest.java
+++ b/ant.debugger/test/unit/src/org/netbeans/modules/ant/debugger/StepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/Accessor.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/Actions.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/Actions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ArtifactProvider.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ArtifactProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformEvaluator.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformFileEncodingQueryImpl.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformFileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProject.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProjectGenerator.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProjectOperations.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProjectOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProjectType.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformProjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformSharabilityQuery.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformSharabilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformSources.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformTemplateAttributesProvider.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/FreeformTemplateAttributesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/LookupMergerImpl.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/LookupMergerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/Subprojects.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/Subprojects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/Util.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/AccessorImpl.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/HelpIDFragmentProvider.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/HelpIDFragmentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/ProjectAccessor.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/ProjectAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/ProjectConstants.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/ProjectConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/ProjectNature.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/ProjectNature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/TargetDescriptor.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/TargetDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/support/NewFreeformProjectSupport.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/support/NewFreeformProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/support/Util.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/spi/support/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoPanel.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoWizardPanel.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/FolderNodeFactory.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/FolderNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/GeneralInformationCategoryProvider.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/GeneralInformationCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/GeneralInformationPanel.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/GeneralInformationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/ProjectCustomizerProvider.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/ProjectCustomizerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingCategoryProvider.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingPanel.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingWizardPanel.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/UnboundTargetAlert.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/UnboundTargetAlert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/View.java
+++ b/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/extsrcroot/src/org/foo/Foo.java
+++ b/ant.freeform/test/unit/data/example-projects/extsrcroot/src/org/foo/Foo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/extsrcroot/src2/org/bar/Bar.java
+++ b/ant.freeform/test/unit/data/example-projects/extsrcroot/src2/org/bar/Bar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/freeforminside/FreeForm/src/javaapplication1/Main.java
+++ b/ant.freeform/test/unit/data/example-projects/freeforminside/FreeForm/src/javaapplication1/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/freeforminside/src/javaapplication1/Main.java
+++ b/ant.freeform/test/unit/data/example-projects/freeforminside/src/javaapplication1/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple/antsrc/org/foo/ant/SpecialTask.java
+++ b/ant.freeform/test/unit/data/example-projects/simple/antsrc/org/foo/ant/SpecialTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple/src/org/foo/myapp/MyApp.java
+++ b/ant.freeform/test/unit/data/example-projects/simple/src/org/foo/myapp/MyApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple/src/org/foo/myapp/SomeFile.java
+++ b/ant.freeform/test/unit/data/example-projects/simple/src/org/foo/myapp/SomeFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple2/src1/pkg1/Clazz.java
+++ b/ant.freeform/test/unit/data/example-projects/simple2/src1/pkg1/Clazz.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple2/src1a/pkg1/Clazz2.java
+++ b/ant.freeform/test/unit/data/example-projects/simple2/src1a/pkg1/Clazz2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple2/src2/pkg2/Clazz.java
+++ b/ant.freeform/test/unit/data/example-projects/simple2/src2/pkg2/Clazz.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple2/test1/pkg1/Clazz2Test.java
+++ b/ant.freeform/test/unit/data/example-projects/simple2/test1/pkg1/Clazz2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple2/test1/pkg1/ClazzTest.java
+++ b/ant.freeform/test/unit/data/example-projects/simple2/test1/pkg1/ClazzTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple2/test2/pkg2/ClazzTest.java
+++ b/ant.freeform/test/unit/data/example-projects/simple2/test2/pkg2/ClazzTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simple3/src/javaapplication1/Main.java
+++ b/ant.freeform/test/unit/data/example-projects/simple3/src/javaapplication1/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simplewithlicense/src/org/foo/NewClass.java
+++ b/ant.freeform/test/unit/data/example-projects/simplewithlicense/src/org/foo/NewClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/simplewithlicense/src2/org/foo/AnotherClass.java
+++ b/ant.freeform/test/unit/data/example-projects/simplewithlicense/src2/org/foo/AnotherClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/data/example-projects/web_jakarta/src/mypackage/HelloWorld.java
+++ b/ant.freeform/test/unit/data/example-projects/web_jakarta/src/mypackage/HelloWorld.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ActionsTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ArtifactProviderTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ArtifactProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformEvaluatorTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformFileEncodingQueryImplTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformFileEncodingQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformProjectGeneratorTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformProjectGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformProjectTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformSharabilityQueryTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformSharabilityQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformSourcesTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformSourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformTemplateAttributesProviderTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformTemplateAttributesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/LookupMergerImplTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/LookupMergerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/SubprojectsTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/SubprojectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/TestBase.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/TestInstalledFileLocator.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/TestInstalledFileLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/spi/support/UtilTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/spi/support/UtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoPanelTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ui/UnboundTargetAlertTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ui/UnboundTargetAlertTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ui/ViewTest.java
+++ b/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/ui/ViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammar.java
+++ b/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
+++ b/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/src/org/netbeans/modules/ant/grammar/AntHighlightsContainer.java
+++ b/ant.grammar/src/org/netbeans/modules/ant/grammar/AntHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/src/org/netbeans/modules/ant/grammar/AntHighlightsLayerFactory.java
+++ b/ant.grammar/src/org/netbeans/modules/ant/grammar/AntHighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/AntGrammarTest.java
+++ b/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/AntGrammarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/AntHighlightsContainerTest.java
+++ b/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/AntHighlightsContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/TestUtil.java
+++ b/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/TestUtilTest.java
+++ b/ant.grammar/test/unit/src/org/netbeans/modules/ant/grammar/TestUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/CheckForNull.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/CheckForNull.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/CheckReturnValue.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/CheckReturnValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/NonNull.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/NonNull.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/NullAllowed.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/NullAllowed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/NullUnknown.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/NullUnknown.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/StaticResource.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/StaticResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/SuppressWarnings.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/SuppressWarnings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/package-info.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.annotations.common/src/org/netbeans/api/annotations/common/proc/StaticResourceProcessor.java
+++ b/api.annotations.common/src/org/netbeans/api/annotations/common/proc/StaticResourceProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/AbstractDICookie.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/AbstractDICookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/AttachingDICookie.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/AttachingDICookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/CallStackFrame.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/CallStackFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ClassLoadUnloadBreakpoint.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ClassLoadUnloadBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ClassVariable.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ClassVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/DeadlockDetector.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/DeadlockDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/DebuggerStartException.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/DebuggerStartException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Field.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/FieldBreakpoint.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/FieldBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/InvalidExpressionException.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/InvalidExpressionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAArrayType.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAArrayType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDABreakpoint.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDABreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDABreakpointBeanInfo.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDABreakpointBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAClassType.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAClassType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDADebugger.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDADebugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAStep.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAThread.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAThreadGroup.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAThreadGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAWatch.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/JPDAWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LaunchingDICookie.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LaunchingDICookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LineBreakpoint.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LineBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ListeningDICookie.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ListeningDICookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LocalVariable.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LocalVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MethodBreakpoint.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MethodBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MonitorInfo.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MonitorInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MutableVariable.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MutableVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ObjectVariable.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ObjectVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ReturnVariable.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ReturnVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/SmartSteppingFilter.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/SmartSteppingFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Super.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Super.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/This.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/This.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ThreadBreakpoint.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ThreadBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ThreadsCollector.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ThreadsCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Variable.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Variable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/VariableType.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/VariableType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/event/JPDABreakpointEvent.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/event/JPDABreakpointEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/event/JPDABreakpointListener.java
+++ b/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/event/JPDABreakpointListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/modules/debugger/jpda/apiregistry/DebuggerProcessor.java
+++ b/api.debugger.jpda/src/org/netbeans/modules/debugger/jpda/apiregistry/DebuggerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/BreakpointsClassFilter.java
+++ b/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/BreakpointsClassFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/EditorContext.java
+++ b/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/EditorContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/Evaluator.java
+++ b/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/Evaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/SmartSteppingCallback.java
+++ b/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/SmartSteppingCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/SourcePathProvider.java
+++ b/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/SourcePathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingdebugger/src/org/netbeans/examples/debugger/delegating/AAAActionsProvider.java
+++ b/api.debugger/examples/delegatingdebugger/src/org/netbeans/examples/debugger/delegating/AAAActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingdebugger/src/org/netbeans/examples/debugger/delegating/AAAEngineProvider.java
+++ b/api.debugger/examples/delegatingdebugger/src/org/netbeans/examples/debugger/delegating/AAAEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingdebugger/src/org/netbeans/examples/debugger/delegating/AAAWatchesProvider.java
+++ b/api.debugger/examples/delegatingdebugger/src/org/netbeans/examples/debugger/delegating/AAAWatchesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/BreakpointsView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/BreakpointsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/CallStackView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/CallStackView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/ClassesView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/ClassesView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/DVModule.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/DVModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/SessionsView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/SessionsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/ThreadsView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/ThreadsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/ToolbarView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/ToolbarView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/VariablesView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/VariablesView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/WatchesView.java
+++ b/api.debugger/examples/delegatingview/org/netbeans/modules/debugger/delegatingview/WatchesView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebugger.java
+++ b/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerImpl.java
+++ b/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerInfo.java
+++ b/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerModule.java
+++ b/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerType.java
+++ b/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerTypeBeanInfo.java
+++ b/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportDebuggerTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportWatch.java
+++ b/api.debugger/examples/importdebug/org/netbeans/modules/debugger/importd/ImportWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebugger.java
+++ b/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerImpl.java
+++ b/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerInfo.java
+++ b/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerModule.java
+++ b/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerType.java
+++ b/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerTypeBeanInfo.java
+++ b/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportDebuggerTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportWatch.java
+++ b/api.debugger/examples/importdebugII/org/netbeans/modules/debugger/importd2/ImportWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/ActionsManager.java
+++ b/api.debugger/src/org/netbeans/api/debugger/ActionsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/ActionsManagerAdapter.java
+++ b/api.debugger/src/org/netbeans/api/debugger/ActionsManagerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/ActionsManagerListener.java
+++ b/api.debugger/src/org/netbeans/api/debugger/ActionsManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/ActiveBreakpoints.java
+++ b/api.debugger/src/org/netbeans/api/debugger/ActiveBreakpoints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/Breakpoint.java
+++ b/api.debugger/src/org/netbeans/api/debugger/Breakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/DebuggerEngine.java
+++ b/api.debugger/src/org/netbeans/api/debugger/DebuggerEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/DebuggerInfo.java
+++ b/api.debugger/src/org/netbeans/api/debugger/DebuggerInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/DebuggerManagerAdapter.java
+++ b/api.debugger/src/org/netbeans/api/debugger/DebuggerManagerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/DebuggerManagerListener.java
+++ b/api.debugger/src/org/netbeans/api/debugger/DebuggerManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/GestureSubmitter.java
+++ b/api.debugger/src/org/netbeans/api/debugger/GestureSubmitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/IdentityHashSet.java
+++ b/api.debugger/src/org/netbeans/api/debugger/IdentityHashSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/LazyActionsManagerListener.java
+++ b/api.debugger/src/org/netbeans/api/debugger/LazyActionsManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/LazyArrayList.java
+++ b/api.debugger/src/org/netbeans/api/debugger/LazyArrayList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/LazyDebuggerManagerListener.java
+++ b/api.debugger/src/org/netbeans/api/debugger/LazyDebuggerManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/Lookup.java
+++ b/api.debugger/src/org/netbeans/api/debugger/Lookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/PathLookup.java
+++ b/api.debugger/src/org/netbeans/api/debugger/PathLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/PositionedList.java
+++ b/api.debugger/src/org/netbeans/api/debugger/PositionedList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/Properties.java
+++ b/api.debugger/src/org/netbeans/api/debugger/Properties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/Session.java
+++ b/api.debugger/src/org/netbeans/api/debugger/Session.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/SessionBridge.java
+++ b/api.debugger/src/org/netbeans/api/debugger/SessionBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/api/debugger/Watch.java
+++ b/api.debugger/src/org/netbeans/api/debugger/Watch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/debugger/registry/ContextAwareServiceHandler.java
+++ b/api.debugger/src/org/netbeans/debugger/registry/ContextAwareServiceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/debugger/registry/ContextAwareServicePath.java
+++ b/api.debugger/src/org/netbeans/debugger/registry/ContextAwareServicePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
+++ b/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/ActionsProvider.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/ActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderListener.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/BreakpointsActivationProvider.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/BreakpointsActivationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/ContextAwareService.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/ContextAwareService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/ContextAwareSupport.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/ContextAwareSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/ContextProvider.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/ContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/DebuggerEngineProvider.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/DebuggerEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/DebuggerServiceRegistration.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/DebuggerServiceRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/DebuggerServiceRegistrations.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/DebuggerServiceRegistrations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/DelegatingDebuggerEngineProvider.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/DelegatingDebuggerEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/DelegatingSessionProvider.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/DelegatingSessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.debugger/src/org/netbeans/spi/debugger/SessionProvider.java
+++ b/api.debugger/src/org/netbeans/spi/debugger/SessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/api/htmlui/HTMLComponent.java
+++ b/api.htmlui/src/org/netbeans/api/htmlui/HTMLComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/api/htmlui/HTMLDialog.java
+++ b/api.htmlui/src/org/netbeans/api/htmlui/HTMLDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/api/htmlui/OpenHTMLRegistration.java
+++ b/api.htmlui/src/org/netbeans/api/htmlui/OpenHTMLRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/Buttons.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/Buttons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/FreeGeoProvider.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/FreeGeoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogImpl.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogProcessor.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/HTMLViewProcessor.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/HTMLViewProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/HtmlComponent.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/HtmlComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/NbBrowsers.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/NbBrowsers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/NbFxPanel.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/NbFxPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/src/org/netbeans/modules/htmlui/Pages.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/Pages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/api/htmlui/Compile.java
+++ b/api.htmlui/test/unit/src/org/netbeans/api/htmlui/Compile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/api/htmlui/HTMLViewProcessorTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/api/htmlui/HTMLViewProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ATech.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ATech.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ComponentsTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ComponentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/DialogsTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/DialogsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/FreeGeoProviderTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/FreeGeoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/HtmlComponentTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/HtmlComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/NbResloc.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/NbResloc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/OpenHTMLRegistrationTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/OpenHTMLRegistrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ShowDialogFromEDTTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ShowDialogFromEDTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ShowDialogFromFXThreadTest.java
+++ b/api.htmlui/test/unit/src/org/netbeans/modules/htmlui/ShowDialogFromFXThreadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/api/intent/Callback.java
+++ b/api.intent/src/org/netbeans/api/intent/Callback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/api/intent/Intent.java
+++ b/api.intent/src/org/netbeans/api/intent/Intent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/api/intent/IntentAction.java
+++ b/api.intent/src/org/netbeans/api/intent/IntentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/api/intent/NoAvailableHandlerException.java
+++ b/api.intent/src/org/netbeans/api/intent/NoAvailableHandlerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/api/intent/package-info.java
+++ b/api.intent/src/org/netbeans/api/intent/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/modules/intent/CallbackResult.java
+++ b/api.intent/src/org/netbeans/modules/intent/CallbackResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/modules/intent/IntentHandler.java
+++ b/api.intent/src/org/netbeans/modules/intent/IntentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/modules/intent/OpenUriHandlerProcessor.java
+++ b/api.intent/src/org/netbeans/modules/intent/OpenUriHandlerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/modules/intent/SettableResult.java
+++ b/api.intent/src/org/netbeans/modules/intent/SettableResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/spi/intent/IntentHandlerRegistration.java
+++ b/api.intent/src/org/netbeans/spi/intent/IntentHandlerRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/spi/intent/Result.java
+++ b/api.intent/src/org/netbeans/spi/intent/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/src/org/netbeans/spi/intent/package-info.java
+++ b/api.intent/src/org/netbeans/spi/intent/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.intent/test/unit/src/org/netbeans/api/intent/IntentTest.java
+++ b/api.intent/test/unit/src/org/netbeans/api/intent/IntentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/Fold.java
+++ b/api.io/src/org/netbeans/api/io/Fold.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/Hyperlink.java
+++ b/api.io/src/org/netbeans/api/io/Hyperlink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/HyperlinkAccessorImpl.java
+++ b/api.io/src/org/netbeans/api/io/HyperlinkAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/IOProvider.java
+++ b/api.io/src/org/netbeans/api/io/IOProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/InputOutput.java
+++ b/api.io/src/org/netbeans/api/io/InputOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/OutputColor.java
+++ b/api.io/src/org/netbeans/api/io/OutputColor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/OutputColorAccessorImpl.java
+++ b/api.io/src/org/netbeans/api/io/OutputColorAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/OutputWriter.java
+++ b/api.io/src/org/netbeans/api/io/OutputWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/Position.java
+++ b/api.io/src/org/netbeans/api/io/Position.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/api/io/ShowOperation.java
+++ b/api.io/src/org/netbeans/api/io/ShowOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/modules/io/HyperlinkAccessor.java
+++ b/api.io/src/org/netbeans/modules/io/HyperlinkAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/modules/io/OutputColorAccessor.java
+++ b/api.io/src/org/netbeans/modules/io/OutputColorAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/spi/io/InputOutputProvider.java
+++ b/api.io/src/org/netbeans/spi/io/InputOutputProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/spi/io/support/HyperlinkType.java
+++ b/api.io/src/org/netbeans/spi/io/support/HyperlinkType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/spi/io/support/Hyperlinks.java
+++ b/api.io/src/org/netbeans/spi/io/support/Hyperlinks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/spi/io/support/OutputColorType.java
+++ b/api.io/src/org/netbeans/spi/io/support/OutputColorType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/src/org/netbeans/spi/io/support/OutputColors.java
+++ b/api.io/src/org/netbeans/spi/io/support/OutputColors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/test/unit/src/org/netbeans/api/io/IOProviderTest.java
+++ b/api.io/test/unit/src/org/netbeans/api/io/IOProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/test/unit/src/org/netbeans/api/io/InputOutputTest.java
+++ b/api.io/test/unit/src/org/netbeans/api/io/InputOutputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/test/unit/src/org/netbeans/api/io/OutputColorTest.java
+++ b/api.io/test/unit/src/org/netbeans/api/io/OutputColorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/test/unit/src/org/netbeans/api/io/OutputWriterTest.java
+++ b/api.io/test/unit/src/org/netbeans/api/io/OutputWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.io/test/unit/src/org/netbeans/spi/io/support/HyperlinksTest.java
+++ b/api.io/test/unit/src/org/netbeans/spi/io/support/HyperlinksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/api/java/classpath/ClassLoaderSupport.java
+++ b/api.java.classpath/src/org/netbeans/api/java/classpath/ClassLoaderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
+++ b/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/api/java/classpath/GlobalPathRegistry.java
+++ b/api.java.classpath/src/org/netbeans/api/java/classpath/GlobalPathRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/api/java/classpath/GlobalPathRegistryEvent.java
+++ b/api.java.classpath/src/org/netbeans/api/java/classpath/GlobalPathRegistryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/api/java/classpath/GlobalPathRegistryListener.java
+++ b/api.java.classpath/src/org/netbeans/api/java/classpath/GlobalPathRegistryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/api/java/queries/BinaryForSourceQuery.java
+++ b/api.java.classpath/src/org/netbeans/api/java/queries/BinaryForSourceQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/api/java/queries/SourceForBinaryQuery.java
+++ b/api.java.classpath/src/org/netbeans/api/java/queries/SourceForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/modules/java/classpath/ClassPathAccessor.java
+++ b/api.java.classpath/src/org/netbeans/modules/java/classpath/ClassPathAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/modules/java/classpath/DefaultGlobalPathRegistryImplementation.java
+++ b/api.java.classpath/src/org/netbeans/modules/java/classpath/DefaultGlobalPathRegistryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/modules/java/classpath/ProxyClassPathImplementation.java
+++ b/api.java.classpath/src/org/netbeans/modules/java/classpath/ProxyClassPathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/modules/java/classpath/SPIAccessor.java
+++ b/api.java.classpath/src/org/netbeans/modules/java/classpath/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/modules/java/classpath/SimpleClassPathImplementation.java
+++ b/api.java.classpath/src/org/netbeans/modules/java/classpath/SimpleClassPathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/modules/java/classpath/SimplePathResourceImplementation.java
+++ b/api.java.classpath/src/org/netbeans/modules/java/classpath/SimplePathResourceImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/modules/java/queries/SFBQImpl2Result.java
+++ b/api.java.classpath/src/org/netbeans/modules/java/queries/SFBQImpl2Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/ClassPathFactory.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/ClassPathFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/ClassPathImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/ClassPathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/ClassPathProvider.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/ClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/FilteringPathResourceImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/FilteringPathResourceImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/FlaggedClassPathImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/FlaggedClassPathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/GlobalPathRegistryImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/GlobalPathRegistryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/PathResourceImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/PathResourceImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/support/ClassPathSupport.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/support/ClassPathSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/support/CompositePathResourceBase.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/support/CompositePathResourceBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/support/MuxClassPathImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/support/MuxClassPathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/classpath/support/PathResourceBase.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/classpath/support/PathResourceBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/queries/BinaryForSourceQueryImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/queries/BinaryForSourceQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation2.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/src/org/netbeans/spi/java/queries/support/SourceForBinaryQueryImpl2Base.java
+++ b/api.java.classpath/src/org/netbeans/spi/java/queries/support/SourceForBinaryQueryImpl2Base.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/FlaggedClassPathImpl.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/FlaggedClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/GlobalPathRegistryTest.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/GlobalPathRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/BinaryForSourceQueryTest.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/BinaryForSourceQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/SourceForBinaryQueryTest.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/SourceForBinaryQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/modules/java/classpath/ProxyClassPathImplementationTest.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/modules/java/classpath/ProxyClassPathImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/modules/java/classpath/SimplePathResourceImplementationTest.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/modules/java/classpath/SimplePathResourceImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java.classpath/test/unit/src/org/netbeans/spi/java/classpath/support/MuxClassPathImplementationTest.java
+++ b/api.java.classpath/test/unit/src/org/netbeans/spi/java/classpath/support/MuxClassPathImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/classpath/JavaClassPathConstants.java
+++ b/api.java/src/org/netbeans/api/java/classpath/JavaClassPathConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/queries/AccessibilityQuery.java
+++ b/api.java/src/org/netbeans/api/java/queries/AccessibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/queries/AnnotationProcessingQuery.java
+++ b/api.java/src/org/netbeans/api/java/queries/AnnotationProcessingQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/queries/CompilerOptionsQuery.java
+++ b/api.java/src/org/netbeans/api/java/queries/CompilerOptionsQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/queries/JavadocForBinaryQuery.java
+++ b/api.java/src/org/netbeans/api/java/queries/JavadocForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/queries/SourceJavadocAttacher.java
+++ b/api.java/src/org/netbeans/api/java/queries/SourceJavadocAttacher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/queries/SourceLevelQuery.java
+++ b/api.java/src/org/netbeans/api/java/queries/SourceLevelQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/api/java/queries/UnitTestForSourceQuery.java
+++ b/api.java/src/org/netbeans/api/java/queries/UnitTestForSourceQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation2.java
+++ b/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/AnnotationProcessingQueryImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/AnnotationProcessingQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/CompilerOptionsQueryImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/CompilerOptionsQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/JavadocForBinaryQueryImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/JavadocForBinaryQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/MultipleRootsUnitTestForSourceQueryImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/MultipleRootsUnitTestForSourceQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/SourceLevelQueryImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/SourceLevelQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/SourceLevelQueryImplementation2.java
+++ b/api.java/src/org/netbeans/spi/java/queries/SourceLevelQueryImplementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/src/org/netbeans/spi/java/queries/UnitTestForSourceQueryImplementation.java
+++ b/api.java/src/org/netbeans/spi/java/queries/UnitTestForSourceQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.java/test/unit/src/org/netbeans/api/java/queries/SourceLevelQueryTest.java
+++ b/api.java/test/unit/src/org/netbeans/api/java/queries/SourceLevelQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.maven/src/org/netbeans/api/maven/archetype/Archetype.java
+++ b/api.maven/src/org/netbeans/api/maven/archetype/Archetype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.maven/src/org/netbeans/api/maven/archetype/ArchetypeWizards.java
+++ b/api.maven/src/org/netbeans/api/maven/archetype/ArchetypeWizards.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.maven/src/org/netbeans/api/maven/archetype/ProjectInfo.java
+++ b/api.maven/src/org/netbeans/api/maven/archetype/ProjectInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.maven/test/unit/src/org/netbeans/modules/api/maven/archetype/ArchetypeTest.java
+++ b/api.maven/test/unit/src/org/netbeans/modules/api/maven/archetype/ArchetypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.maven/test/unit/src/org/netbeans/modules/api/maven/archetype/ProjectInfoTest.java
+++ b/api.maven/test/unit/src/org/netbeans/modules/api/maven/archetype/ProjectInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.compat8/src/org/netbeans/modules/progress/spi/ControllerCompat.java
+++ b/api.progress.compat8/src/org/netbeans/modules/progress/spi/ControllerCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.compat8/src/org/netbeans/modules/progress/spi/InternalHandleCompat.java
+++ b/api.progress.compat8/src/org/netbeans/modules/progress/spi/InternalHandleCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/api/progress/ProgressHandleFactory.java
+++ b/api.progress.nb/src/org/netbeans/api/progress/ProgressHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/api/progress/ProgressUtils.java
+++ b/api.progress.nb/src/org/netbeans/api/progress/ProgressUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/api/progress/aggregate/AggregateProgressFactory.java
+++ b/api.progress.nb/src/org/netbeans/api/progress/aggregate/AggregateProgressFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/modules/progress/spi/ExtractedProgressUIWorker.java
+++ b/api.progress.nb/src/org/netbeans/modules/progress/spi/ExtractedProgressUIWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/modules/progress/spi/ProgressUIWorkerProvider.java
+++ b/api.progress.nb/src/org/netbeans/modules/progress/spi/ProgressUIWorkerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/modules/progress/spi/SwingController.java
+++ b/api.progress.nb/src/org/netbeans/modules/progress/spi/SwingController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/modules/progress/spi/UIInternalHandle.java
+++ b/api.progress.nb/src/org/netbeans/modules/progress/spi/UIInternalHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/src/org/netbeans/progress/module/TrivialProgressUIWorkerProvider.java
+++ b/api.progress.nb/src/org/netbeans/progress/module/TrivialProgressUIWorkerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/test/unit/src/org/netbeans/api/progress/ProgressHandleFactoryTest.java
+++ b/api.progress.nb/test/unit/src/org/netbeans/api/progress/ProgressHandleFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/test/unit/src/org/netbeans/api/progress/ProgressHandleTest.java
+++ b/api.progress.nb/test/unit/src/org/netbeans/api/progress/ProgressHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/test/unit/src/org/netbeans/api/progress/RunOffEDTTest.java
+++ b/api.progress.nb/test/unit/src/org/netbeans/api/progress/RunOffEDTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress.nb/test/unit/src/org/netbeans/modules/progress/spi/ProgressAPICompatTest.java
+++ b/api.progress.nb/test/unit/src/org/netbeans/modules/progress/spi/ProgressAPICompatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/api/progress/BaseProgressUtils.java
+++ b/api.progress/src/org/netbeans/api/progress/BaseProgressUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/api/progress/ProgressHandle.java
+++ b/api.progress/src/org/netbeans/api/progress/ProgressHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/api/progress/ProgressRunnable.java
+++ b/api.progress/src/org/netbeans/api/progress/ProgressRunnable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/api/progress/aggregate/AggregateProgressHandle.java
+++ b/api.progress/src/org/netbeans/api/progress/aggregate/AggregateProgressHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/api/progress/aggregate/BasicAggregateProgressFactory.java
+++ b/api.progress/src/org/netbeans/api/progress/aggregate/BasicAggregateProgressFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/api/progress/aggregate/ProgressContributor.java
+++ b/api.progress/src/org/netbeans/api/progress/aggregate/ProgressContributor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/api/progress/aggregate/ProgressMonitor.java
+++ b/api.progress/src/org/netbeans/api/progress/aggregate/ProgressMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/Controller.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/Controller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/InternalHandle.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/InternalHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/ProgressEnvironment.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/ProgressEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/ProgressEvent.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/ProgressEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/ProgressUIWorker.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/ProgressUIWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/ProgressUIWorkerWithModel.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/ProgressUIWorkerWithModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/RunOffEDTProvider.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/RunOffEDTProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/TaskModel.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/TaskModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/modules/progress/spi/package-info.java
+++ b/api.progress/src/org/netbeans/modules/progress/spi/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/progress/module/DefaultHandleFactory.java
+++ b/api.progress/src/org/netbeans/progress/module/DefaultHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/progress/module/LoggingUtils.java
+++ b/api.progress/src/org/netbeans/progress/module/LoggingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/progress/module/ProgressApiAccessor.java
+++ b/api.progress/src/org/netbeans/progress/module/ProgressApiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/src/org/netbeans/progress/module/TrivialProgressBaseWorkerProvider.java
+++ b/api.progress/src/org/netbeans/progress/module/TrivialProgressBaseWorkerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.progress/test/unit/src/org/netbeans/api/progress/aggregate/AggregateProgressHandleTest.java
+++ b/api.progress/test/unit/src/org/netbeans/api/progress/aggregate/AggregateProgressHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/RegexpUtil.java
+++ b/api.search/src/org/netbeans/api/search/RegexpUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/ReplacePattern.java
+++ b/api.search/src/org/netbeans/api/search/ReplacePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/SearchControl.java
+++ b/api.search/src/org/netbeans/api/search/SearchControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/SearchHistory.java
+++ b/api.search/src/org/netbeans/api/search/SearchHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/SearchPattern.java
+++ b/api.search/src/org/netbeans/api/search/SearchPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/SearchRoot.java
+++ b/api.search/src/org/netbeans/api/search/SearchRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/SearchScopeOptions.java
+++ b/api.search/src/org/netbeans/api/search/SearchScopeOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/FileNameMatcher.java
+++ b/api.search/src/org/netbeans/api/search/provider/FileNameMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/SearchFilter.java
+++ b/api.search/src/org/netbeans/api/search/provider/SearchFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/SearchInfo.java
+++ b/api.search/src/org/netbeans/api/search/provider/SearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/SearchInfoUtils.java
+++ b/api.search/src/org/netbeans/api/search/provider/SearchInfoUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/SearchListener.java
+++ b/api.search/src/org/netbeans/api/search/provider/SearchListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/AbstractCompoundIterator.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/AbstractCompoundIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/AbstractFileObjectIterator.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/AbstractFileObjectIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/CompoundSearchInfo.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/CompoundSearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/DefinitionUtils.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/DefinitionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/DelegatingSearchFilter.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/DelegatingSearchFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/DelegatingSearchInfo.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/DelegatingSearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/EmptySearchInfo.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/EmptySearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/FilterHelper.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/FilterHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/FlatSearchIterator.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/FlatSearchIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/provider/impl/SimpleSearchIterator.java
+++ b/api.search/src/org/netbeans/api/search/provider/impl/SimpleSearchIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/ui/ComponentController.java
+++ b/api.search/src/org/netbeans/api/search/ui/ComponentController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/ui/ComponentUtils.java
+++ b/api.search/src/org/netbeans/api/search/ui/ComponentUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/ui/FileNameController.java
+++ b/api.search/src/org/netbeans/api/search/ui/FileNameController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/ui/ScopeController.java
+++ b/api.search/src/org/netbeans/api/search/ui/ScopeController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/ui/ScopeOptionsController.java
+++ b/api.search/src/org/netbeans/api/search/ui/ScopeOptionsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/api/search/ui/SearchPatternController.java
+++ b/api.search/src/org/netbeans/api/search/ui/SearchPatternController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ActionManager.java
+++ b/api.search/src/org/netbeans/modules/search/ActionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ArraySet.java
+++ b/api.search/src/org/netbeans/modules/search/ArraySet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/BasicComposition.java
+++ b/api.search/src/org/netbeans/modules/search/BasicComposition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/BasicSearchCriteria.java
+++ b/api.search/src/org/netbeans/modules/search/BasicSearchCriteria.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
+++ b/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/BasicSearchProvider.java
+++ b/api.search/src/org/netbeans/modules/search/BasicSearchProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/CleanTask.java
+++ b/api.search/src/org/netbeans/modules/search/CleanTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/Constants.java
+++ b/api.search/src/org/netbeans/modules/search/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ContextView.java
+++ b/api.search/src/org/netbeans/modules/search/ContextView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/DefaultSearchScopeProvider.java
+++ b/api.search/src/org/netbeans/modules/search/DefaultSearchScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/FindDialogMemory.java
+++ b/api.search/src/org/netbeans/modules/search/FindDialogMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/FindInFilesAction.java
+++ b/api.search/src/org/netbeans/modules/search/FindInFilesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/GraphicalSearchListener.java
+++ b/api.search/src/org/netbeans/modules/search/GraphicalSearchListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/IgnoreListPanel.java
+++ b/api.search/src/org/netbeans/modules/search/IgnoreListPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/Installer.java
+++ b/api.search/src/org/netbeans/modules/search/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/Item.java
+++ b/api.search/src/org/netbeans/modules/search/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ListComboBoxModel.java
+++ b/api.search/src/org/netbeans/modules/search/ListComboBoxModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/Manager.java
+++ b/api.search/src/org/netbeans/modules/search/Manager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/MatchingObject.java
+++ b/api.search/src/org/netbeans/modules/search/MatchingObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/OpenFilesSearchScopeProvider.java
+++ b/api.search/src/org/netbeans/modules/search/OpenFilesSearchScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/PatternSandbox.java
+++ b/api.search/src/org/netbeans/modules/search/PatternSandbox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/PrintDetailsTask.java
+++ b/api.search/src/org/netbeans/modules/search/PrintDetailsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/Removable.java
+++ b/api.search/src/org/netbeans/modules/search/Removable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ReplaceInFilesAction.java
+++ b/api.search/src/org/netbeans/modules/search/ReplaceInFilesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ReplaceTask.java
+++ b/api.search/src/org/netbeans/modules/search/ReplaceTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ResultDisplayer.java
+++ b/api.search/src/org/netbeans/modules/search/ResultDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ResultModel.java
+++ b/api.search/src/org/netbeans/modules/search/ResultModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ResultView.java
+++ b/api.search/src/org/netbeans/modules/search/ResultView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ResultViewPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ResultViewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/SearchDisplayer.java
+++ b/api.search/src/org/netbeans/modules/search/SearchDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/SearchPanel.java
+++ b/api.search/src/org/netbeans/modules/search/SearchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/SearchScopeBrowse.java
+++ b/api.search/src/org/netbeans/modules/search/SearchScopeBrowse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/SearchScopeList.java
+++ b/api.search/src/org/netbeans/modules/search/SearchScopeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/SearchTask.java
+++ b/api.search/src/org/netbeans/modules/search/SearchTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/Selectable.java
+++ b/api.search/src/org/netbeans/modules/search/Selectable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/TextDetail.java
+++ b/api.search/src/org/netbeans/modules/search/TextDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/TextDisplayer.java
+++ b/api.search/src/org/netbeans/modules/search/TextDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/TextFetcher.java
+++ b/api.search/src/org/netbeans/modules/search/TextFetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/TextRegexpUtil.java
+++ b/api.search/src/org/netbeans/modules/search/TextRegexpUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/Utils.java
+++ b/api.search/src/org/netbeans/modules/search/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/AbstractMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/AbstractMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/AsciiMultiLineMappedMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/AsciiMultiLineMappedMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/BufferedCharSequence.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/BufferedCharSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/DefaultMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/DefaultMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/FastMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/FastMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/FinishingTextDetailList.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/FinishingTextDetailList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/LineReader.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/LineReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/MatcherUtils.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/MatcherUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/MultiLineMappedMatcherBig.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/MultiLineMappedMatcherBig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/MultiLineMappedMatcherSmall.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/MultiLineMappedMatcherSmall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/MultiLineStreamMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/MultiLineStreamMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/ReadLineBuffer.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/ReadLineBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/SingleLineStreamMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/SingleLineStreamMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/matcher/TrivialFileMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/TrivialFileMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/AbstractSearchResultsPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/AbstractSearchResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/BasicAbstractResultsPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/BasicAbstractResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/BasicReplaceResultsPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/BasicReplaceResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/BasicSearchResultsPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/BasicSearchResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/CheckBoxWithButtonPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/CheckBoxWithButtonPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/DefaultSearchResultsPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/DefaultSearchResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/FileObjectPropertySet.java
+++ b/api.search/src/org/netbeans/modules/search/ui/FileObjectPropertySet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/FormLayoutHelper.java
+++ b/api.search/src/org/netbeans/modules/search/ui/FormLayoutHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/HideResultAction.java
+++ b/api.search/src/org/netbeans/modules/search/ui/HideResultAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/IssuesPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/IssuesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/LinkButtonPanel.java
+++ b/api.search/src/org/netbeans/modules/search/ui/LinkButtonPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/MatchingObjectNode.java
+++ b/api.search/src/org/netbeans/modules/search/ui/MatchingObjectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/MoreAction.java
+++ b/api.search/src/org/netbeans/modules/search/ui/MoreAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/OpenMatchingObjectsAction.java
+++ b/api.search/src/org/netbeans/modules/search/ui/OpenMatchingObjectsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/PatternChangeListener.java
+++ b/api.search/src/org/netbeans/modules/search/ui/PatternChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/RefreshAction.java
+++ b/api.search/src/org/netbeans/modules/search/ui/RefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/ReplaceCheckableNode.java
+++ b/api.search/src/org/netbeans/modules/search/ui/ReplaceCheckableNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/ResultsOutlineCellRenderer.java
+++ b/api.search/src/org/netbeans/modules/search/ui/ResultsOutlineCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/ResultsOutlineSupport.java
+++ b/api.search/src/org/netbeans/modules/search/ui/ResultsOutlineSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/SelectInAction.java
+++ b/api.search/src/org/netbeans/modules/search/ui/SelectInAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/ShorteningCellRenderer.java
+++ b/api.search/src/org/netbeans/modules/search/ui/ShorteningCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/TextFieldFocusListener.java
+++ b/api.search/src/org/netbeans/modules/search/ui/TextFieldFocusListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/modules/search/ui/UiUtils.java
+++ b/api.search/src/org/netbeans/modules/search/ui/UiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/SearchFilterDefinition.java
+++ b/api.search/src/org/netbeans/spi/search/SearchFilterDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
+++ b/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/SearchInfoDefinitionFactory.java
+++ b/api.search/src/org/netbeans/spi/search/SearchInfoDefinitionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/SearchScopeDefinition.java
+++ b/api.search/src/org/netbeans/spi/search/SearchScopeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/SearchScopeDefinitionProvider.java
+++ b/api.search/src/org/netbeans/spi/search/SearchScopeDefinitionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/SubTreeSearchOptions.java
+++ b/api.search/src/org/netbeans/spi/search/SubTreeSearchOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/impl/CompoundSearchInfoDefinition.java
+++ b/api.search/src/org/netbeans/spi/search/impl/CompoundSearchInfoDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/impl/FlatSearchInfoDefinition.java
+++ b/api.search/src/org/netbeans/spi/search/impl/FlatSearchInfoDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/impl/SearchInfoDefinitionUtils.java
+++ b/api.search/src/org/netbeans/spi/search/impl/SearchInfoDefinitionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/impl/SharabilityFilter.java
+++ b/api.search/src/org/netbeans/spi/search/impl/SharabilityFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/impl/SimpleSearchInfoDefinition.java
+++ b/api.search/src/org/netbeans/spi/search/impl/SimpleSearchInfoDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/impl/SubnodesSearchInfoDefinition.java
+++ b/api.search/src/org/netbeans/spi/search/impl/SubnodesSearchInfoDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/impl/VisibilityFilter.java
+++ b/api.search/src/org/netbeans/spi/search/impl/VisibilityFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/provider/DefaultSearchResultsDisplayer.java
+++ b/api.search/src/org/netbeans/spi/search/provider/DefaultSearchResultsDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/provider/SearchComposition.java
+++ b/api.search/src/org/netbeans/spi/search/provider/SearchComposition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/provider/SearchProvider.java
+++ b/api.search/src/org/netbeans/spi/search/provider/SearchProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/src/org/netbeans/spi/search/provider/SearchResultsDisplayer.java
+++ b/api.search/src/org/netbeans/spi/search/provider/SearchResultsDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/qa-functional/data/projects/UtilitiesTestProject/src/org/netbeans/test/utilities/basicsearch/TopLevelFile.java
+++ b/api.search/test/qa-functional/data/projects/UtilitiesTestProject/src/org/netbeans/test/utilities/basicsearch/TopLevelFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/qa-functional/data/projects/UtilitiesTestProject/src/org/netbeans/test/utilities/basicsearch/p1/P1File.java
+++ b/api.search/test/qa-functional/data/projects/UtilitiesTestProject/src/org/netbeans/test/utilities/basicsearch/p1/P1File.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/qa-functional/data/projects/UtilitiesTestProject/src/org/netbeans/test/utilities/basicsearch/p2/P2File.java
+++ b/api.search/test/qa-functional/data/projects/UtilitiesTestProject/src/org/netbeans/test/utilities/basicsearch/p2/P2File.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/qa-functional/src/org/netbeans/test/utilities/actions/SearchResultsViewAction.java
+++ b/api.search/test/qa-functional/src/org/netbeans/test/utilities/actions/SearchResultsViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/src/RootClass.java
+++ b/api.search/test/unit/data/projects/Project1/src/RootClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass.java
+++ b/api.search/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_invisible.java
+++ b/api.search/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_invisible.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_unsharable.java
+++ b/api.search/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_unsharable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/src/foo/bar/baz_unsharable/SomeClass.java
+++ b/api.search/test/unit/data/projects/Project1/src/foo/bar/baz_unsharable/SomeClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/src/foo/bar_invisible/AnotherClass.java
+++ b/api.search/test/unit/data/projects/Project1/src/foo/bar_invisible/AnotherClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/src/foo_sharable/DummyClass_unsharable.java
+++ b/api.search/test/unit/data/projects/Project1/src/foo_sharable/DummyClass_unsharable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/data/projects/Project1/test/abc/xyz/SimpleTest.java
+++ b/api.search/test/unit/data/projects/Project1/test/abc/xyz/SimpleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/RegexpUtilTest.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/RegexpUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/ReplacePatternTest.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/ReplacePatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/SearchHistoryTest.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/SearchHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/SearchPatternTest.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/SearchPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/provider/impl/FileNameMatcherTest.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/provider/impl/FileNameMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/provider/impl/SearchIteratorTest.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/provider/impl/SearchIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/provider/impl/SharabilityQueryImpl.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/provider/impl/SharabilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/provider/impl/VisibilityQueryImpl.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/provider/impl/VisibilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/api/search/ui/SearchPatternControllerTest.java
+++ b/api.search/test/unit/src/org/netbeans/api/search/ui/SearchPatternControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/BasicSearchCriteriaTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/BasicSearchCriteriaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/BasicSearchFormTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/BasicSearchFormTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/FindDialogMemoryTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/FindDialogMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/MatchingObjectTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/MatchingObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/SearchPanelTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/SearchPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/SearchScopeListTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/SearchScopeListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/SearchTestUtils.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/SearchTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/SpecialSearchGroupTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/SpecialSearchGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/TextDetailTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/TextDetailTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/TextRegexpUtilTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/TextRegexpUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/AbstractMatcherTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/AbstractMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/BufferedCharSequenceTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/BufferedCharSequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/DefaultMatcherTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/DefaultMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/LineReaderTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/LineReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/MatcherTestUtils.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/MatcherTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/MatchersTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/MatchersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/ReadLineBufferTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/ReadLineBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/matcher/SearchPerformanceComparator.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/matcher/SearchPerformanceComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/ui/BasicSearchResultsPanelTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/ui/BasicSearchResultsPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/ui/MatchingObjectNodeTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/ui/MatchingObjectNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/modules/search/ui/ResultsOutlineSupportTest.java
+++ b/api.search/test/unit/src/org/netbeans/modules/search/ui/ResultsOutlineSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/spi/search/SearchScopeDefinitionTest.java
+++ b/api.search/test/unit/src/org/netbeans/spi/search/SearchScopeDefinitionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.search/test/unit/src/org/netbeans/spi/search/impl/SimpleSearchInfoDefinitionTest.java
+++ b/api.search/test/unit/src/org/netbeans/spi/search/impl/SimpleSearchInfoDefinitionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/CreateDescriptor.java
+++ b/api.templates/src/org/netbeans/api/templates/CreateDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/CreateFromTemplateAttributes.java
+++ b/api.templates/src/org/netbeans/api/templates/CreateFromTemplateAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/CreateFromTemplateDecorator.java
+++ b/api.templates/src/org/netbeans/api/templates/CreateFromTemplateDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/CreateFromTemplateHandler.java
+++ b/api.templates/src/org/netbeans/api/templates/CreateFromTemplateHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/CreateFromTemplateImpl.java
+++ b/api.templates/src/org/netbeans/api/templates/CreateFromTemplateImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/FileBuilder.java
+++ b/api.templates/src/org/netbeans/api/templates/FileBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/TemplateRegistration.java
+++ b/api.templates/src/org/netbeans/api/templates/TemplateRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/api/templates/TemplateRegistrations.java
+++ b/api.templates/src/org/netbeans/api/templates/TemplateRegistrations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/modules/templates/HTMLWizard.java
+++ b/api.templates/src/org/netbeans/modules/templates/HTMLWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/modules/templates/ScriptingCreateFromTemplateHandler.java
+++ b/api.templates/src/org/netbeans/modules/templates/ScriptingCreateFromTemplateHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/src/org/netbeans/modules/templates/TemplateProcessor.java
+++ b/api.templates/src/org/netbeans/modules/templates/TemplateProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/test/unit/src/org/netbeans/modules/templates/Bug138973Test.java
+++ b/api.templates/test/unit/src/org/netbeans/modules/templates/Bug138973Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/test/unit/src/org/netbeans/modules/templates/CreateFromTemplateDecoratorTest.java
+++ b/api.templates/test/unit/src/org/netbeans/modules/templates/CreateFromTemplateDecoratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/test/unit/src/org/netbeans/modules/templates/CreateFromTemplateHandlerTest.java
+++ b/api.templates/test/unit/src/org/netbeans/modules/templates/CreateFromTemplateHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/test/unit/src/org/netbeans/modules/templates/DefaultCreationNoTest.java
+++ b/api.templates/test/unit/src/org/netbeans/modules/templates/DefaultCreationNoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/test/unit/src/org/netbeans/modules/templates/DefaultCreationTest.java
+++ b/api.templates/test/unit/src/org/netbeans/modules/templates/DefaultCreationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/test/unit/src/org/netbeans/modules/templates/SCFTHandlerTest.java
+++ b/api.templates/test/unit/src/org/netbeans/modules/templates/SCFTHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.templates/test/unit/src/org/netbeans/modules/templates/ScriptingCreateFromTemplateTest.java
+++ b/api.templates/test/unit/src/org/netbeans/modules/templates/ScriptingCreateFromTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/AcceptProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/AcceptProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ActionFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ActionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/AlignWithMoveDecorator.java
+++ b/api.visual/src/org/netbeans/api/visual/action/AlignWithMoveDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/AlignWithWidgetCollector.java
+++ b/api.visual/src/org/netbeans/api/visual/action/AlignWithWidgetCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ConnectDecorator.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ConnectDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ConnectProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ConnectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ConnectorState.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ConnectorState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ContiguousSelectEvent.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ContiguousSelectEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ContiguousSelectProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ContiguousSelectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/CycleFocusProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/CycleFocusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/EditProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/EditProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/HoverProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/HoverProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/InplaceEditorProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/InplaceEditorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/MoveControlPointProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/MoveControlPointProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/MoveProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/MoveProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/MoveStrategy.java
+++ b/api.visual/src/org/netbeans/api/visual/action/MoveStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/PopupMenuProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/PopupMenuProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ReconnectDecorator.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ReconnectDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ReconnectProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ReconnectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/RectangularSelectDecorator.java
+++ b/api.visual/src/org/netbeans/api/visual/action/RectangularSelectDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/RectangularSelectProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/RectangularSelectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ResizeControlPointResolver.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ResizeControlPointResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ResizeProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ResizeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/ResizeStrategy.java
+++ b/api.visual/src/org/netbeans/api/visual/action/ResizeStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/SelectProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/SelectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/TextFieldInplaceEditor.java
+++ b/api.visual/src/org/netbeans/api/visual/action/TextFieldInplaceEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/TwoStateHoverProvider.java
+++ b/api.visual/src/org/netbeans/api/visual/action/TwoStateHoverProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/action/WidgetAction.java
+++ b/api.visual/src/org/netbeans/api/visual/action/WidgetAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/anchor/Anchor.java
+++ b/api.visual/src/org/netbeans/api/visual/anchor/Anchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/anchor/AnchorFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/anchor/AnchorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/anchor/AnchorShape.java
+++ b/api.visual/src/org/netbeans/api/visual/anchor/AnchorShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/anchor/AnchorShapeFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/anchor/AnchorShapeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/anchor/AnchorShapeLocationResolver.java
+++ b/api.visual/src/org/netbeans/api/visual/anchor/AnchorShapeLocationResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/anchor/PointShape.java
+++ b/api.visual/src/org/netbeans/api/visual/anchor/PointShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/anchor/PointShapeFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/anchor/PointShapeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/animator/Animator.java
+++ b/api.visual/src/org/netbeans/api/visual/animator/Animator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/animator/AnimatorEvent.java
+++ b/api.visual/src/org/netbeans/api/visual/animator/AnimatorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/animator/AnimatorListener.java
+++ b/api.visual/src/org/netbeans/api/visual/animator/AnimatorListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/animator/SceneAnimator.java
+++ b/api.visual/src/org/netbeans/api/visual/animator/SceneAnimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/border/Border.java
+++ b/api.visual/src/org/netbeans/api/visual/border/Border.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/border/BorderFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/border/BorderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/border/BorderSupport.java
+++ b/api.visual/src/org/netbeans/api/visual/border/BorderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/export/SceneExporter.java
+++ b/api.visual/src/org/netbeans/api/visual/export/SceneExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/export/WidgetPolygonalCoordinates.java
+++ b/api.visual/src/org/netbeans/api/visual/export/WidgetPolygonalCoordinates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/GraphPinScene.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/GraphPinScene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/GraphScene.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/GraphScene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayout.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayoutFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayoutFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayoutListener.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayoutListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayoutSupport.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/GraphLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/GridGraphLayout.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/GridGraphLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/TreeGraphLayout.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/TreeGraphLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/TreeGraphLayoutAlignment.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/TreeGraphLayoutAlignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/graph/layout/UniversalGraph.java
+++ b/api.visual/src/org/netbeans/api/visual/graph/layout/UniversalGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/laf/InputBindings.java
+++ b/api.visual/src/org/netbeans/api/visual/laf/InputBindings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/laf/LookFeel.java
+++ b/api.visual/src/org/netbeans/api/visual/laf/LookFeel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/layout/Layout.java
+++ b/api.visual/src/org/netbeans/api/visual/layout/Layout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/layout/LayoutFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/layout/LayoutFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/layout/SceneLayout.java
+++ b/api.visual/src/org/netbeans/api/visual/layout/SceneLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/model/ObjectScene.java
+++ b/api.visual/src/org/netbeans/api/visual/model/ObjectScene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/model/ObjectSceneEvent.java
+++ b/api.visual/src/org/netbeans/api/visual/model/ObjectSceneEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/model/ObjectSceneEventType.java
+++ b/api.visual/src/org/netbeans/api/visual/model/ObjectSceneEventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/model/ObjectSceneListener.java
+++ b/api.visual/src/org/netbeans/api/visual/model/ObjectSceneListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/model/ObjectState.java
+++ b/api.visual/src/org/netbeans/api/visual/model/ObjectState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/model/StateModel.java
+++ b/api.visual/src/org/netbeans/api/visual/model/StateModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/print/ScenePrinter.java
+++ b/api.visual/src/org/netbeans/api/visual/print/ScenePrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/router/CollisionsCollector.java
+++ b/api.visual/src/org/netbeans/api/visual/router/CollisionsCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/router/ConnectionWidgetCollisionsCollector.java
+++ b/api.visual/src/org/netbeans/api/visual/router/ConnectionWidgetCollisionsCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/router/Router.java
+++ b/api.visual/src/org/netbeans/api/visual/router/Router.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/router/RouterFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/router/RouterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDColorScheme.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDColorScheme.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDConnectionWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDConnectionWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDFactory.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDGlyphSetWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDGlyphSetWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDGraphScene.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDGraphScene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDMinimizeAbility.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDMinimizeAbility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDNodeAnchor.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDNodeAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDNodeBorder.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDNodeBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDNodeWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDNodeWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/vmd/VMDPinWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/vmd/VMDPinWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/BirdViewController.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/BirdViewController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/ComponentWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/ComponentWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/ConnectionWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/ConnectionWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/ConvolveWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/ConvolveWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/EventProcessingType.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/EventProcessingType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/FreeConnectionWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/FreeConnectionWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/ImageWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/ImageWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/LabelWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/LabelWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/LayerWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/LayerWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/LevelOfDetailsWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/LevelOfDetailsWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/ResourceTable.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/ResourceTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/Scene.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/Scene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/SceneComponent.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/SceneComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/ScrollWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/ScrollWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/SeparatorWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/SeparatorWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/SwingScrollWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/SwingScrollWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/Widget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/Widget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/general/IconNodeWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/general/IconNodeWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/general/ListItemWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/general/ListItemWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/api/visual/widget/general/ListWidget.java
+++ b/api.visual/src/org/netbeans/api/visual/widget/general/ListWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/AcceptAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/AcceptAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ActionMapAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ActionMapAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/AddRemoveControlPointAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/AddRemoveControlPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/AlignWithMoveStrategyProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/AlignWithMoveStrategyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/AlignWithResizeStrategyProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/AlignWithResizeStrategyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/AlignWithSupport.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/AlignWithSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/CenteredZoomAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/CenteredZoomAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ConnectAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ConnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ContiguousSelectAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ContiguousSelectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/CycleFocusAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/CycleFocusAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/CycleObjectSceneFocusProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/CycleObjectSceneFocusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/DefaultRectangularSelectDecorator.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/DefaultRectangularSelectDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/EditAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/EditAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ExtendedConnectAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ExtendedConnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ForwardKeyEventsAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ForwardKeyEventsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/FreeMoveControlPointProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/FreeMoveControlPointProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/InplaceEditorAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/InplaceEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/MouseCenteredZoomAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/MouseCenteredZoomAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/MouseHoverAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/MouseHoverAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/MoveAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/MoveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/MoveControlPointAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/MoveControlPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ObjectSceneRectangularSelectProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ObjectSceneRectangularSelectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/OrthogonalMoveControlPointProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/OrthogonalMoveControlPointProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/PanAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/PanAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/PopupMenuAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/PopupMenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ReconnectAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ReconnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/RectangularSelectAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/RectangularSelectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ResizeAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ResizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ResizeCornersControlPointResolver.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ResizeCornersControlPointResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/SelectAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/SelectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/SingleLayerAlignWithWidgetCollector.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/SingleLayerAlignWithWidgetCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/SnapToGridMoveStrategy.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/SnapToGridMoveStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/SwitchCardProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/SwitchCardProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/TextFieldInplaceEditorProvider.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/TextFieldInplaceEditorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/TwoStatedMouseHoverAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/TwoStatedMouseHoverAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/WheelPanAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/WheelPanAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/action/ZoomAction.java
+++ b/api.visual/src/org/netbeans/modules/visual/action/ZoomAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/ArrowAnchorShape.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/ArrowAnchorShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/AttachableAnchorShape.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/AttachableAnchorShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/CenterAnchor.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/CenterAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/CircularAnchor.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/CircularAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/DefaultAnchorShapeResolver.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/DefaultAnchorShapeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/DirectionalAnchor.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/DirectionalAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/FixedAnchor.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/FixedAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/FreeRectangularAnchor.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/FreeRectangularAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/ImageAnchorShape.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/ImageAnchorShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/ImagePointShape.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/ImagePointShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/ProxyAnchor.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/ProxyAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/RectangularAnchor.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/RectangularAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/SquarePointShape.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/SquarePointShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/anchor/TriangleAnchorShape.java
+++ b/api.visual/src/org/netbeans/modules/visual/anchor/TriangleAnchorShape.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/animator/ColorAnimator.java
+++ b/api.visual/src/org/netbeans/modules/visual/animator/ColorAnimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/animator/PreferredBoundsAnimator.java
+++ b/api.visual/src/org/netbeans/modules/visual/animator/PreferredBoundsAnimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/animator/PreferredLocationAnimator.java
+++ b/api.visual/src/org/netbeans/modules/visual/animator/PreferredLocationAnimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/animator/ZoomAnimator.java
+++ b/api.visual/src/org/netbeans/modules/visual/animator/ZoomAnimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/BevelBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/BevelBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/CompositeBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/CompositeBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/DashedBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/DashedBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/EmptyBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/EmptyBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/FancyDashedBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/FancyDashedBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/ImageBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/ImageBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/LineBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/LineBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/ResizeBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/ResizeBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/RoundedBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/RoundedBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/border/SwingBorder.java
+++ b/api.visual/src/org/netbeans/modules/visual/border/SwingBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/experimental/widget/general/ListItemWidget.java
+++ b/api.visual/src/org/netbeans/modules/visual/experimental/widget/general/ListItemWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/experimental/widget/general/ListWidget.java
+++ b/api.visual/src/org/netbeans/modules/visual/experimental/widget/general/ListWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/export/Scene2Image.java
+++ b/api.visual/src/org/netbeans/modules/visual/export/Scene2Image.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/HierarchicalLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/HierarchicalLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/OrthogonalLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/OrthogonalLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/TreeGraphLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/TreeGraphLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/BarycenterCrossingMinimizer.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/BarycenterCrossingMinimizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/BarycenterXCoordinateAssigner.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/BarycenterXCoordinateAssigner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/DirectedGraph.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/DirectedGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/EdgeReversingCycleRemover.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/EdgeReversingCycleRemover.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/LayeredGraph.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/LayeredGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/MixedGraph.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/MixedGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/VertexInsertionLayerAssigner.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/hierarchicalsupport/VertexInsertionLayerAssigner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/DirectionalGraph.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/DirectionalGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/DualGraph.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/DualGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/EmbeddedPlanarGraph.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/EmbeddedPlanarGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/Face.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/Face.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/FlowNetwork.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/FlowNetwork.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/GTPlanarizer.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/GTPlanarizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/GeometryUtils.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/GeometryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/Logger.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/Logger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/MGraph.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/MGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/MinimumBendOrthogonalizer.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/MinimumBendOrthogonalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/OrthogonalRepresentation.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/OrthogonalRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/RectangularCompactor.java
+++ b/api.visual/src/org/netbeans/modules/visual/graph/layout/orthogonalsupport/RectangularCompactor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/laf/DefaultLookFeel.java
+++ b/api.visual/src/org/netbeans/modules/visual/laf/DefaultLookFeel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/layout/AbsoluteLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/layout/AbsoluteLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/layout/CardLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/layout/CardLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/layout/ConnectionWidgetLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/layout/ConnectionWidgetLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/layout/DevolveWidgetLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/layout/DevolveWidgetLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/layout/FlowLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/layout/FlowLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/layout/OverlayLayout.java
+++ b/api.visual/src/org/netbeans/modules/visual/layout/OverlayLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/print/PageableScene.java
+++ b/api.visual/src/org/netbeans/modules/visual/print/PageableScene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/router/DirectRouter.java
+++ b/api.visual/src/org/netbeans/modules/visual/router/DirectRouter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/router/FreeRouter.java
+++ b/api.visual/src/org/netbeans/modules/visual/router/FreeRouter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/router/OrthogonalSearchRouter.java
+++ b/api.visual/src/org/netbeans/modules/visual/router/OrthogonalSearchRouter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/router/OrthogonalSearchRouterCore.java
+++ b/api.visual/src/org/netbeans/modules/visual/router/OrthogonalSearchRouterCore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/router/OrthogonalSearchRouterRegion.java
+++ b/api.visual/src/org/netbeans/modules/visual/router/OrthogonalSearchRouterRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/router/WidgetsCollisionCollector.java
+++ b/api.visual/src/org/netbeans/modules/visual/router/WidgetsCollisionCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/util/GeomUtil.java
+++ b/api.visual/src/org/netbeans/modules/visual/util/GeomUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/util/RenderUtil.java
+++ b/api.visual/src/org/netbeans/modules/visual/util/RenderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/vmd/VMDNetBeans60ColorScheme.java
+++ b/api.visual/src/org/netbeans/modules/visual/vmd/VMDNetBeans60ColorScheme.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/vmd/VMDOriginalColorScheme.java
+++ b/api.visual/src/org/netbeans/modules/visual/vmd/VMDOriginalColorScheme.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/widget/BirdViewWindow.java
+++ b/api.visual/src/org/netbeans/modules/visual/widget/BirdViewWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/widget/SatelliteComponent.java
+++ b/api.visual/src/org/netbeans/modules/visual/widget/SatelliteComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/src/org/netbeans/modules/visual/widget/WidgetAccessibleContext.java
+++ b/api.visual/src/org/netbeans/modules/visual/widget/WidgetAccessibleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/AnchorNotificationTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/AnchorNotificationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/AnimatorListenerTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/AnimatorListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/ConnectionWidgetCollisionsCollectorTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/ConnectionWidgetCollisionsCollectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/LabelOrientationTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/LabelOrientationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/OffscreenRenderingTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/OffscreenRenderingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/SwingBorderGetterTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/SwingBorderGetterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/WidgetPaintBorderTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/apichanges/WidgetPaintBorderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/basic/BasicTest.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/basic/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/FlowLayout105400Test.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/FlowLayout105400Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/FlowLayoutWeightOverflow108052Test.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/FlowLayoutWeightOverflow108052Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/GraphLayoutListenerRemoval197502Test.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/GraphLayoutListenerRemoval197502Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/LayerWidget103528Test.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/LayerWidget103528Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/ObjectScene100275Test.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/bugs/ObjectScene100275Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.visual/test/unit/src/org/netbeans/modules/visual/framework/VisualTestCase.java
+++ b/api.visual/test/unit/src/org/netbeans/modules/visual/framework/VisualTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/api/xml/cookies/CheckXMLCookie.java
+++ b/api.xml.ui/src/org/netbeans/api/xml/cookies/CheckXMLCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/api/xml/cookies/CookieMessage.java
+++ b/api.xml.ui/src/org/netbeans/api/xml/cookies/CookieMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/api/xml/cookies/CookieObserver.java
+++ b/api.xml.ui/src/org/netbeans/api/xml/cookies/CookieObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/api/xml/cookies/TransformableCookie.java
+++ b/api.xml.ui/src/org/netbeans/api/xml/cookies/TransformableCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/api/xml/cookies/ValidateXMLCookie.java
+++ b/api.xml.ui/src/org/netbeans/api/xml/cookies/ValidateXMLCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/api/xml/cookies/XMLProcessorDetail.java
+++ b/api.xml.ui/src/org/netbeans/api/xml/cookies/XMLProcessorDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/CheckXMLSupport.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/CheckXMLSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/DataObjectAdapters.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/DataObjectAdapters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/DefaultXMLProcessorDetail.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/DefaultXMLProcessorDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/ShareableInputSource.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/ShareableInputSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/SharedXMLSupport.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/SharedXMLSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/TransformableSupport.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/TransformableSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/Util.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/src/org/netbeans/spi/xml/cookies/ValidateXMLSupport.java
+++ b/api.xml.ui/src/org/netbeans/spi/xml/cookies/ValidateXMLSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/SharedXMLSupportTest.java
+++ b/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/SharedXMLSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/TransformableSupportTest.java
+++ b/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/TransformableSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml/src/org/netbeans/api/xml/parsers/DocumentInputSource.java
+++ b/api.xml/src/org/netbeans/api/xml/parsers/DocumentInputSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml/src/org/netbeans/api/xml/parsers/SAXEntityParser.java
+++ b/api.xml/src/org/netbeans/api/xml/parsers/SAXEntityParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml/src/org/netbeans/api/xml/parsers/Util.java
+++ b/api.xml/src/org/netbeans/api/xml/parsers/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml/src/org/netbeans/api/xml/services/UserCatalog.java
+++ b/api.xml/src/org/netbeans/api/xml/services/UserCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/api.xml/test/unit/src/org/netbeans/api/xml/parsers/SAXEntityParserTest.java
+++ b/api.xml/test/unit/src/org/netbeans/api/xml/parsers/SAXEntityParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/antsrc/org/netbeans/modules/apisupport/ant/InstallModuleTask.java
+++ b/apisupport.ant/antsrc/org/netbeans/modules/apisupport/ant/InstallModuleTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ApisupportAntUtils.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ApisupportAntUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/Evaluator.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/Evaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ModuleDependency.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ModuleDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProject.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProjectGenerator.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleType.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbProjectProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbProjectProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbRefactoringProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbRefactoringProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ProjectXMLManager.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ProjectXMLManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/SuiteProvider.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/SuiteProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/java/hints/errors/SearchModuleDependency.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/java/hints/errors/SearchModuleDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/AccessibilityQueryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/AccessibilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/AnnotationProcessingQueryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/AnnotationProcessingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/AntArtifactProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/AntArtifactProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/BinaryForSourceImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/BinaryForSourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ClassPathProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ClassPathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/FileEncodingQueryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/FileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/GlobalJavadocForBinaryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/GlobalJavadocForBinaryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/GlobalSourceForBinaryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/GlobalSourceForBinaryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/JavadocForBinaryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/JavadocForBinaryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ModuleProjectClassPathExtender.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ModuleProjectClassPathExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/OSGiSourceForBinaryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/OSGiSourceForBinaryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SourceForBinaryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SourceForBinaryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SourceLevelQueryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SubprojectProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SubprojectProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/TemplateAttributesProvider.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/TemplateAttributesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/UnitTestForSourceQueryImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/UnitTestForSourceQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/UpdateTrackingFileOwnerQuery.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/UpdateTrackingFileOwnerQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingModel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingSupport.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteProject.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectGenerator.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectType.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteSubprojectProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteSubprojectProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteType.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ActionFilterNode.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ActionFilterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/AnnotatedNode.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/AnnotatedNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ApisupportAntUIUtils.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ApisupportAntUIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ImportantFilesNodeFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ImportantFilesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/LibrariesNode.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/LibrariesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/LibrariesNodeFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/LibrariesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/LibrariesSourceGroup.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/LibrariesSourceGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleActions.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleLogicalView.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleLogicalView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleOperations.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleUISettings.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModuleUISettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModulesNodeFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ModulesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/PlatformNode.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/PlatformNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ShowJavadocAction.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ShowJavadocAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SourcesNodeFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SourcesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SuiteActions.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SuiteActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SuiteLogicalView.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SuiteLogicalView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SuiteOperations.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/SuiteOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/TestDataDirsNodeFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/TestDataDirsNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/UnitTestLibrariesNode.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/UnitTestLibrariesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/AddFriendPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/AddFriendPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModuleFilter.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModuleFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModulePanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModulePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/BasicCustomizer.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/BasicCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterInfo.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/Clusterize.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/Clusterize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeAction.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeInfo.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeVisualPanel1.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeVisualPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeVisualPanel2.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeVisualPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeVisualPanel3.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeVisualPanel3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeWizardPanel1.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeWizardPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeWizardPanel2.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeWizardPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeWizardPanel3.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterizeWizardPanel3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerCompiling.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerCompiling.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerCompilingFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerCompilingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerComponentFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerDisplay.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerDisplay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerDisplayFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerDisplayFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerLibraries.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerLibraries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerLibrariesFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerLibrariesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerPackaging.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerPackaging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerPackagingFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerPackagingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSourcesFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSourcesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerVersioning.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerVersioning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerVersioningFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerVersioningFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/EditClusterPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/EditClusterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/EditDependencyPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/EditDependencyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/EditTestDependencyPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/EditTestDependencyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/JavaPlatformComponentFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/JavaPlatformComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ModuleProperties.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/ModuleProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/NbModulePackageModifierImplementation.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/NbModulePackageModifierImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/NbPropertyPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/NbPropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizer.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerBasicBranding.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerBasicBranding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerBasicBrandingFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerBasicBrandingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibraries.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibraries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibrariesFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibrariesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerSources.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerSourcesFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerSourcesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteProperties.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteUtils.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/package-info.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/HarnessUpgrader.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/HarnessUpgrader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizer.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerHarness.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerHarness.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerJavadoc.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerJavadoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerModules.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerModules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerSources.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformChooserVisualPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformChooserVisualPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformChooserWizardPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformChooserWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformComponentFactory.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformInfoVisualPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformInfoVisualPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformInfoWizardPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformInfoWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicConfVisualPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicConfVisualPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicConfWizardPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicConfWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicInfoVisualPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicInfoVisualPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicInfoWizardPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/BasicInfoWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/DefaultSuiteProjectDeletePanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/DefaultSuiteProjectDeletePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/DefaultSuiteProjectOperations.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/DefaultSuiteProjectOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/DefaultSuiteProjectOperationsImplementation.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/DefaultSuiteProjectOperationsImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryConfWizardPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryConfWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartVisualPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartVisualPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartWizardPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewModuleProjectData.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewModuleProjectData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewTemplatePanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewTemplatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewTemplateVisualPanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewTemplateVisualPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/TypeChooserPanelImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/TypeChooserPanelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/spi/ModuleTypePanel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/spi/ModuleTypePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractBinaryEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractBinaryEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntryWithSources.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntryWithSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/BinaryClusterEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/BinaryClusterEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/BinaryEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/BinaryEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ClusterUtils.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ClusterUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/DestDirProvider.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/DestDirProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ExternalEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ExternalEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/HarnessVersion.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/HarnessVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/JavadocRootsProvider.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/JavadocRootsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/JavadocRootsSupport.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/JavadocRootsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/LocalizedBundleInfo.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/LocalizedBundleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/NbPlatform.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/NbPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/NetBeansOrgEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/NetBeansOrgEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/NonexistentModuleEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/NonexistentModuleEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/PlatformLayersCacheManager.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/PlatformLayersCacheManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/SourceRootsProvider.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/SourceRootsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/SourceRootsSupport.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/SourceRootsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/TestEntry.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/TestEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/TestModuleDependency.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/TestModuleDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/html4j/src/org/netbeans/test/html4j/UseJSB.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/html4j/src/org/netbeans/test/html4j/UseJSB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/html4j/test/unit/src/org/netbeans/test/html4j/UseJSBTest.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/html4j/test/unit/src/org/netbeans/test/html4j/UseJSBTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/javafx/src/org/netbeans/test/fx/UseFx.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/javafx/src/org/netbeans/test/fx/UseFx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/suite1/action-project/src/org/netbeans/examples/modules/action/MagicAction.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/suite1/action-project/src/org/netbeans/examples/modules/action/MagicAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/suite1/support/lib-project/src/org/netbeans/examples/modules/lib/LibClass.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/suite1/support/lib-project/src/org/netbeans/examples/modules/lib/LibClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/suite1/support/lib-project/test/unit/src/org/netbeans/examples/modules/lib/LibClassTest.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/suite1/support/lib-project/test/unit/src/org/netbeans/examples/modules/lib/LibClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/suite2/misc-project/src/org/netbeans/examples/modules/misc/Misc.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/suite2/misc-project/src/org/netbeans/examples/modules/misc/Misc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/suite2/misc-project/test/unit/src/org/netbeans/examples/modules/misc/MiscTest.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/suite2/misc-project/test/unit/src/org/netbeans/examples/modules/misc/MiscTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/suite4/module1/test/unit/src/aa/ATest.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/suite4/module1/test/unit/src/aa/ATest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/data/example-external-projects/suite4/module2/test/unit/src/a/DepsTest.java
+++ b/apisupport.ant/test/unit/data/example-external-projects/suite4/module2/test/unit/src/a/DepsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ApisupportAntUtilsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ApisupportAntUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/AvoidModuleListInProjectConstructorTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/AvoidModuleListInProjectConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/BrokenPlatformReferenceTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/BrokenPlatformReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/CompilationDependencyTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/CompilationDependencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/EvaluatorTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/EvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ExternalBuildDirTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ExternalBuildDirTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ModuleDependencyTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ModuleDependencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleProjectGeneratorTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleProjectGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleProjectTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleProviderImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleTestingTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/NbModuleTestingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ProjectXMLManagerTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ProjectXMLManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/TestBase.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/UseFxTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/UseFxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/UseHtml4JavaTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/UseHtml4JavaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/api/LayerHandleTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/api/LayerHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/jnlp/GenerateJNLPApplicationTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/jnlp/GenerateJNLPApplicationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/layers/LayerUtilsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/layers/LayerUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/AccessibilityQueryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/AccessibilityQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/AntArtifactProviderImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/AntArtifactProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/BinaryForSourceImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/BinaryForSourceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/ClassPathProviderImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/ClassPathProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/GlobalJavadocForBinaryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/GlobalJavadocForBinaryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/GlobalSourceForBinaryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/GlobalSourceForBinaryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/JavadocForBinaryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/JavadocForBinaryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/ModuleProjectClassPathExtenderTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/ModuleProjectClassPathExtenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/OSGiSourceForBinaryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/OSGiSourceForBinaryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SourceForBinaryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SourceForBinaryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SourceLevelQueryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SourceLevelQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SubprojectProviderImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SubprojectProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/TemplateAttributesProviderTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/TemplateAttributesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/UnitTestForSourceQueryImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/UnitTestForSourceQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/UpdateTrackingFileOwnerQueryTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/UpdateTrackingFileOwnerQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/spi/BrandingSupportTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/spi/BrandingSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildNBMSTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildNBMSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildZipDistributionTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildZipDistributionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/MainCallback.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/MainCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingModelTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectGeneratorTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteSubprojectProviderImplTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteSubprojectProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/LibrariesNodeTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/LibrariesNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/ModuleActionsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/ModuleActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/ModuleLogicalViewTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/ModuleLogicalViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/ModuleOperationsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/ModuleOperationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/SuiteLogicalViewTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/SuiteLogicalViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/SuiteOperationsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/SuiteOperationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/UnitTestLibrariesNodeTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/UnitTestLibrariesNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModuleFilterTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModuleFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModulePanelTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModulePanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterUtilsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/ClusterUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerLibrariesTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerLibrariesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModulePropertiesTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModulePropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibrariesTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibrariesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerModuleListTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerModuleListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuitePropertiesTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuitePropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteUtilsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformChooserVisualPanelTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformChooserVisualPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformComponentFactoryTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/platform/PlatformComponentFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartVisualPanelTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartVisualPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFilesTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/spi/ModuleTypePanelTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/spi/ModuleTypePanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/ClusterUtilsTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/ClusterUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/Issue167725DeadlockTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/Issue167725DeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/LocalizedBundleInfoTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/LocalizedBundleInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/ModuleListTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/ModuleListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/NbPlatformTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/NbPlatformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/NetigsoModuleListTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/NetigsoModuleListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/PlatformLayersCacheManagerTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/PlatformLayersCacheManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/TestEntryTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/TestEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/TestModuleDependencyTest.java
+++ b/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/universe/TestModuleDependencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/jnlp-src/org/netbeans/modules/apisupport/jnlplauncher/InstalledFileLocatorImpl.java
+++ b/apisupport.harness/jnlp-src/org/netbeans/modules/apisupport/jnlplauncher/InstalledFileLocatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/jnlp-src/org/netbeans/modules/apisupport/jnlplauncher/Main.java
+++ b/apisupport.harness/jnlp-src/org/netbeans/modules/apisupport/jnlplauncher/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/jnlp-src/org/netbeans/modules/apisupport/jnlplauncher/RuntimePolicy.java
+++ b/apisupport.harness/jnlp-src/org/netbeans/modules/apisupport/jnlplauncher/RuntimePolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/test/unit/src/org/netbeans/modules/apisupport/jnlplauncher/FixPolicyTest.java
+++ b/apisupport.harness/test/unit/src/org/netbeans/modules/apisupport/jnlplauncher/FixPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/test/unit/src/org/netbeans/modules/apisupport/jnlplauncher/ReplaceUserDirTest.java
+++ b/apisupport.harness/test/unit/src/org/netbeans/modules/apisupport/jnlplauncher/ReplaceUserDirTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/windows-launcher-src/app.cpp
+++ b/apisupport.harness/windows-launcher-src/app.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/windows-launcher-src/applauncher.cpp
+++ b/apisupport.harness/windows-launcher-src/applauncher.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.harness/windows-launcher-src/applauncher.h
+++ b/apisupport.harness/windows-launcher-src/applauncher.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.installer.maven/src/org/netbeans/modules/apisupport/installer/maven/actions/BuildInstallersAction.java
+++ b/apisupport.installer.maven/src/org/netbeans/modules/apisupport/installer/maven/actions/BuildInstallersAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.installer.maven/src/org/netbeans/modules/apisupport/installer/maven/ui/ExtraPanel.java
+++ b/apisupport.installer.maven/src/org/netbeans/modules/apisupport/installer/maven/ui/ExtraPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.installer/src/org/netbeans/modules/apisupport/installer/actions/BuildInstallersAction.java
+++ b/apisupport.installer/src/org/netbeans/modules/apisupport/installer/actions/BuildInstallersAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/ExtraPanel.java
+++ b/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/ExtraPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/InstallerPanel.java
+++ b/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/InstallerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/LicenseComboBoxModel.java
+++ b/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/LicenseComboBoxModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/SuiteInstallerProjectProperties.java
+++ b/apisupport.installer/src/org/netbeans/modules/apisupport/installer/ui/SuiteInstallerProjectProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/BasicVisualPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/BasicVisualPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/BasicWizardPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/BasicWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/BrandingUtils.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/BrandingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/EditableManifest.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/EditableManifest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/LayerHandle.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/LayerHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/ManifestManager.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/ManifestManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/NodeFactoryUtils.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/NodeFactoryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/UIUtil.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/UIUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/Util.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/hyperlink/ApisupportHyperlinkProvider.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/hyperlink/ApisupportHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/hyperlink/ManifestHyperlinkProvider.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/hyperlink/ManifestHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/BadgingSupport.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/BadgingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/HiddenDataObject.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/HiddenDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerDataObject.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerFileSystem.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerFilterNode.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerFilterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerNode.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerUtils.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/OpenLayerFilesAction.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/OpenLayerFilesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/PathCompletions.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/PathCompletions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/PickIconAction.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/PickIconAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/PickNameAction.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/PickNameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/SynchronousStatus.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/SynchronousStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystem.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingModel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/ExecProject.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/ExecProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/LayerUtil.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/LayerUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbModuleProvider.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbModuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbProjectProvider.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbProjectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbRefactoringContext.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbRefactoringContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbRefactoringProvider.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/NbRefactoringProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/PlatformJarProvider.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/PlatformJarProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/AbstractBrandingPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/AbstractBrandingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/BasicBrandingPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/BasicBrandingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/BrandingEditorPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/BrandingEditorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/DragManager.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/DragManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleBrandingPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleBrandingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleKeyPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleKeyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/SplashBrandingPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/SplashBrandingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/SplashComponentPreview.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/SplashComponentPreview.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/SplashUISupport.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/SplashUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/WindowSystemBrandingPanel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/WindowSystemBrandingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/DialogDisplayerImpl.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/DialogDisplayerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/ErrorManagerImpl.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/ErrorManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/FsDtdEntityCatalog.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/FsDtdEntityCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/InputOutputProviderImpl.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/InputOutputProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/InstalledFileLocatorImpl.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/InstalledFileLocatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/NetigsoManifestManagerTest.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/NetigsoManifestManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestAntLogger.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestAntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestUtil.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/EditableManifestTest.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/EditableManifestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/ManifestManagerTest.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/ManifestManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/UtilTest.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/UtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/layers/LayerTestBase.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/layers/LayerTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystemTest.java
+++ b/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/ActionRegistrationHinter.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/ActionRegistrationHinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/DataObjectRegistrationHinter.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/DataObjectRegistrationHinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/HelpCtxHint.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/HelpCtxHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/HelpSetHinter.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/HelpSetHinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/Hinter.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/Hinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/LayerHints.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/LayerHints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/NavigatorHinter.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/NavigatorHinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/SystemFileSystemAttrHinter.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/SystemFileSystemAttrHinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/TemplateHinter.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/TemplateHinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/UseNbBundleMessages.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/UseNbBundleMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/projectbridge/ProjectConfiguration.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/projectbridge/ProjectConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/projectbridge/SuiteConfiguration.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/hints/projectbridge/SuiteConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringElement.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringPlugin.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbMoveRefactoringPlugin.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbMoveRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbRefactoringFactory.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbRefactoringFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbRenameRefactoringPlugin.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbRenameRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbSafeDeleteRefactoringPlugin.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbSafeDeleteRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbWhereUsedRefactoringPlugin.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/NbWhereUsedRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/RetoucheUtils.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/RetoucheUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/Utility.java
+++ b/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/Utility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyAction.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataLoader.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataLoaderBeanInfo.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataNode.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataObject.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/MyDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedAction.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataLoader.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataLoaderBeanInfo.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataNode.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataObject.java
+++ b/apisupport.refactoring/test/qa-functional/data/testRename/src/testRename/WhereUsedDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/src/org/netbeans/modules/apisupport/refactoring/RenameTest.java
+++ b/apisupport.refactoring/test/qa-functional/src/org/netbeans/modules/apisupport/refactoring/RenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/qa-functional/src/org/netbeans/modules/apisupport/refactoring/TestUtility.java
+++ b/apisupport.refactoring/test/qa-functional/src/org/netbeans/modules/apisupport/refactoring/TestUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/unit/src/org/netbeans/modules/apisupport/hints/HelpCtxHintTest.java
+++ b/apisupport.refactoring/test/unit/src/org/netbeans/modules/apisupport/hints/HelpCtxHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.refactoring/test/unit/src/org/netbeans/modules/apisupport/hints/UseNbBundleMessagesTest.java
+++ b/apisupport.refactoring/test/unit/src/org/netbeans/modules/apisupport/hints/UseNbBundleMessagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/ActionTypePanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/ActionTypePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/DataModel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/DataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/NameIconLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/NameIconLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/NewActionIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/NewActionIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/ShortcutEnterPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/ShortcutEnterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/codegenerator/CodeGeneratorPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/codegenerator/CodeGeneratorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/codegenerator/NewCodeGeneratorIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/codegenerator/NewCodeGeneratorIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/BasicWizardIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/BasicWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFiles.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/WizardUtils.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/WizardUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/html/HTMLIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/html/HTMLIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/html/NameAndLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/html/NameAndLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahelp/JavaHelpPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahelp/JavaHelpPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahelp/NewJavaHelpIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahelp/NewJavaHelpIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/JavaHintDataPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/JavaHintDataPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/JavaHintLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/JavaHintLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/NewJavaHintIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/NewJavaHintIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/layer/LayerPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/layer/LayerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/layer/NewLayerIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/layer/NewLayerIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/CreatedModifiedFilesProvider.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/CreatedModifiedFilesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/NameAndLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/NameAndLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/NewLibraryDescriptor.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/NewLibraryDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/SelectLibraryPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/SelectLibraryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/FileRecognitionPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/FileRecognitionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/NameAndLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/NameAndLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/NewLoaderIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/NewLoaderIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/moduleinstall/DataModel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/moduleinstall/DataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/moduleinstall/ModuleInstallPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/moduleinstall/ModuleInstallPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/moduleinstall/NewModuleInstallIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/moduleinstall/NewModuleInstallIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/NewOptionsIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/NewOptionsIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/OptionsPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/OptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/OptionsPanel0.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/OptionsPanel0.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/NameAndLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/NameAndLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/NewProjectIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/NewProjectIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/SelectProjectPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/SelectProjectPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/quicksearch/NewQuickSearchIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/quicksearch/NewQuickSearchIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/quicksearch/QuickSearchPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/quicksearch/QuickSearchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/DataModel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/DataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/NewUpdateCenterIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/NewUpdateCenterIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/UpdateCenterRegistrationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/UpdateCenterRegistrationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/BasicSettingsPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/BasicSettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupport.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutLaunchingPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutLaunchingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutSummaryPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutSummaryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutWarningPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutWarningPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/NameAndLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/NameAndLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/NewTCIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/NewTCIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/DataModel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/DataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/NameIconLocationPanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/NameIconLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/NewWizardIterator.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/NewWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/WizardTypePanel.java
+++ b/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/WizardTypePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/action/DataModelTest.java
+++ b/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/action/DataModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/common/WizardUtilsTest.java
+++ b/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/common/WizardUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/DataModelTest.java
+++ b/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/DataModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/FileRecognitionPanelTest.java
+++ b/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/FileRecognitionPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/DataModelTest.java
+++ b/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/updatecenter/DataModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupportTest.java
+++ b/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/DataModelTest.java
+++ b/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/wizard/DataModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/applemenu/src/org/netbeans/modules/applemenu/CtrlClickHack.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/CtrlClickHack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/applemenu/src/org/netbeans/modules/applemenu/Install.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/Install.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/applemenu/src/org/netbeans/modules/applemenu/MinimizeWindowAction.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/MinimizeWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapter.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK8.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK9.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/applemenu/src/org/netbeans/modules/applemenu/ShowInFinder.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/ShowInFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
+++ b/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/PrintTable.java
+++ b/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/PrintTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/Status.java
+++ b/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.cli/test/unit/src/org/netbeans/modules/autoupdate/cli/ListModulesTest.java
+++ b/autoupdate.cli/test/unit/src/org/netbeans/modules/autoupdate/cli/ListModulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ClusterUpdateProvider.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ClusterUpdateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ImportManager.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ImportManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Installer.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/PluginImporter.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/PluginImporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/libinstaller/InstallLibraryTask.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/libinstaller/InstallLibraryTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/libinstaller/JUnitLibraryInstaller.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/libinstaller/JUnitLibraryInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/Localization.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/Localization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/ModuleDeactivator.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/ModuleDeactivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/ModuleUpdate.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/ModuleUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/ModuleUpdater.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/ModuleUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/UpdaterDispatcher.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/UpdaterDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/UpdaterInternal.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/UpdaterInternal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/UpdatingContext.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/UpdatingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/libsrc/org/netbeans/updater/XMLUtil.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/XMLUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/InstallSupport.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/InstallSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/OperationContainer.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/OperationContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/OperationException.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/OperationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/OperationSupport.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/OperationSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/TrampolineAPI.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/TrampolineAPI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateElement.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateManager.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateUnit.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateUnitProvider.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateUnitProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateUnitProviderFactory.java
+++ b/autoupdate.services/src/org/netbeans/api/autoupdate/UpdateUnitProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/AutoupdateSettings.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/AutoupdateSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/DependencyAggregator.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/DependencyAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/DependencyChecker.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/DependencyChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateElementImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateUnitImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallManager.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallSupportImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/KitModuleUpdateElementImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/KitModuleUpdateElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/KitModuleUpdateUnitImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/KitModuleUpdateUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/LocalizationUpdateElementImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/LocalizationUpdateElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/LocalizationUpdateUnitImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/LocalizationUpdateUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleCache.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleDeleterImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleDeleterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateElementImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateUnitImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/NativeComponentUpdateElementImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/NativeComponentUpdateElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/NativeComponentUpdateUnitImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/NativeComponentUpdateUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationContainerImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationContainerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationSupportImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationValidator.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Trampoline.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Trampoline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateElementImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateItemDeploymentImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateItemDeploymentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateLicenseImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateLicenseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateManagerImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateProblemHandler.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateProblemHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitFactory.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitProviderImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/ArtificialFeaturesProvider.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/ArtificialFeaturesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogCache.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogFactory.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParser.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogProvider.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateInfoParser.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateInfoParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/BackupUpdateProvider.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/BackupUpdateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/DownloadListener.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/DownloadListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/DummyModuleInfo.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/DummyModuleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/FeatureItem.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/FeatureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstallInfo.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstallInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstalledModuleItem.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstalledModuleItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstalledModuleProvider.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstalledModuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstalledUpdateProvider.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/InstalledUpdateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/LocalNBMsProvider.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/LocalNBMsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/LocalizationItem.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/LocalizationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/ModuleItem.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/ModuleItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/NativeComponentItem.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/NativeComponentItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/NetworkAccess.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/NetworkAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/ProviderCategory.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/ProviderCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/UpdateItemImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/UpdateItemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/AutoupdateClusterCreator.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/AutoupdateClusterCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/CustomInstaller.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/CustomInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/CustomUninstaller.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/CustomUninstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/KeyStoreProvider.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/KeyStoreProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/TrampolineSPI.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/TrampolineSPI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateItem.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateLicense.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateLicense.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateProvider.java
+++ b/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DeclarationOfUpdateUnitProviderTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DeclarationOfUpdateUnitProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DefaultTestCase.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DefaultTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DifferentReleaseVersionsTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DifferentReleaseVersionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/IDEInitializer.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/IDEInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/InternalUpdatesTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/InternalUpdatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/OperationContainerTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/OperationContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshItemsTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshItemsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshProvidersTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshProvidersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RequiredElementsForUninstallTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RequiredElementsForUninstallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/TestUtils.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateElementTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateManagerTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateProviderFactoryCreateTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateProviderFactoryCreateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateProviderFactoryTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateProviderFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateUnitTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/UpdateUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/AutoupdateCatalogFactoryTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/AutoupdateCatalogFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/CrossDependencyTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/CrossDependencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/DependencyAggregatorTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/DependencyAggregatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/EnableDisableTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/EnableDisableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureDependsOnFeatureTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureDependsOnFeatureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureIncompleteTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureIncompleteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureNotUpToDateTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureNotUpToDateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallCustomInstalledTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallCustomInstalledTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallDependentTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallDependentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallDisabledModuleTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallDisabledModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallFeatureWithDependentModulesTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallFeatureWithDependentModulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallHiddenModuleTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallHiddenModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallIntoNewClusterTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallIntoNewClusterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallOSGiBundleTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallOSGiBundleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallWhenDependsOnUpdateTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallWhenDependsOnUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/JavaDepenenciesTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/JavaDepenenciesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/ModuleProviderTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/ModuleProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmAdvancedTestCase.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmAdvancedTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmExternalTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmExternalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmsInDownloadedTabTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmsInDownloadedTabTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NewClustersRebootCallback.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NewClustersRebootCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NewClustersRebootTestDisabled.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NewClustersRebootTestDisabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/OperationsTestImpl.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/OperationsTestImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/ScheduleForRestartTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/ScheduleForRestartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterTestCase.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenGlobalUndeclaredTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenGlobalUndeclaredTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenTargerClusterDeclaredTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenTargerClusterDeclaredTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenUpdateGloballyTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenUpdateGloballyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenUpdateLocallyTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/TargetClusterWhenUpdateLocallyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UninstallDependentTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UninstallDependentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UninstallDisabledTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UninstallDisabledTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UninstallTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UninstallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateDisabledModuleTestDisabled.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateDisabledModuleTestDisabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateManagerImplTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateUnitProviderImplTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateUnitProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateUnitWithOsFactoryTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateUnitWithOsFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/VerifyFileTestDisabled.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/VerifyFileTestDisabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParserTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogProviderTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateInfoParserTestDisabled.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateInfoParserTestDisabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/CatalogCacheTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/updateprovider/CatalogCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/spi/autoupdate/CustomProviderFactory.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/spi/autoupdate/CustomProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/spi/autoupdate/CustomUpdateProviderTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/spi/autoupdate/CustomUpdateProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/spi/autoupdate/UpdateItemTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/spi/autoupdate/UpdateItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/updater/ModuleUpdaterConfigTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/updater/ModuleUpdaterConfigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/updater/UpdateTrackingTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/updater/UpdateTrackingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.services/test/unit/src/org/netbeans/updater/UpdaterDispatcherTest.java
+++ b/autoupdate.services/test/unit/src/org/netbeans/updater/UpdaterDispatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/AvailableTableModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/AvailableTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ColorHighlighter.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ColorHighlighter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Containers.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Containers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/DetailsPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/DetailsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/HTMLEditorKitEx.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/HTMLEditorKitEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/HeaderPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/HeaderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/InstalledTableModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/InstalledTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/LocalDownloadSupport.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/LocalDownloadSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/LocallDownloadDnD.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/LocallDownloadDnD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/LocallyDownloadedTableModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/LocallyDownloadedTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ModuleInstallerSupport.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ModuleInstallerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/PluginManagerUI.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/PluginManagerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ProblemPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ProblemPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/SettingsTab.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/SettingsTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/SettingsTableModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/SettingsTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Unit.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Unit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitCategory.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitCategoryTableModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitCategoryTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitDetails.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTab.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTable.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UpdateTableModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UpdateTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UpdateUnitListener.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UpdateUnitListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UpdateUnitProviderPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UpdateUnitProviderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Utilities.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateCheckScheduler.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateCheckScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateSettings.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/CheckForUpdatesAction.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/CheckForUpdatesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/CheckForUpdatesProviderImpl.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/CheckForUpdatesProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/Installer.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/PluginManagerAction.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/PluginManagerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/ShowNotifications.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/ShowNotifications.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/api/PluginManager.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/api/PluginManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/CustomHandleStep.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/CustomHandleStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallStep.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizard.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizardIterator.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizardModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizardModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LazyInstallUnitWizardIterator.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LazyInstallUnitWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LazyOperationDescriptionStep.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LazyOperationDescriptionStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LicenseApprovalPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LicenseApprovalPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LicenseApprovalStep.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LicenseApprovalStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationDescriptionPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationDescriptionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationDescriptionStep.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationDescriptionStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationWizardModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationWizardModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/PanelBodyContainer.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/PanelBodyContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallStep.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizard.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardIterator.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardModel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/ValidationWarningPanel.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/ValidationWarningPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/Autoupdate.java
+++ b/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/Autoupdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/xml/xml.java
+++ b/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/xml/xml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/xml/xml_0001.java
+++ b/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/xml/xml_0001.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/xml/xml_0002.java
+++ b/autoupdate.ui/test/qa-functional/src/org/netbeans/test/autoupdate/xml/xml_0002.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/InitialTabTest.java
+++ b/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/InitialTabTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/MockInstalledModuleProvider.java
+++ b/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/MockInstalledModuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/MockModuleInfo.java
+++ b/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/MockModuleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/MockUpdateProvider.java
+++ b/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/MockUpdateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/UtilitiesTest.java
+++ b/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/UtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/actions/PluginManagerActionTest.java
+++ b/autoupdate.ui/test/unit/src/org/netbeans/modules/autoupdate/ui/actions/PluginManagerActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/BeanNavigatorJavaSourceFactory.java
+++ b/beans/src/org/netbeans/modules/beans/BeanNavigatorJavaSourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/BeanPanel.java
+++ b/beans/src/org/netbeans/modules/beans/BeanPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/BeanPanelUI.java
+++ b/beans/src/org/netbeans/modules/beans/BeanPanelUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/BeanPatternGenerator.java
+++ b/beans/src/org/netbeans/modules/beans/BeanPatternGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/BeanScanningTask.java
+++ b/beans/src/org/netbeans/modules/beans/BeanScanningTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/BeanUtils.java
+++ b/beans/src/org/netbeans/modules/beans/BeanUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/ClassPattern.java
+++ b/beans/src/org/netbeans/modules/beans/ClassPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/EventSetInheritanceAnalyser.java
+++ b/beans/src/org/netbeans/modules/beans/EventSetInheritanceAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/EventSetPattern.java
+++ b/beans/src/org/netbeans/modules/beans/EventSetPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/EventSetPatternNode.java
+++ b/beans/src/org/netbeans/modules/beans/EventSetPatternNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/EventSetPatternPanel.java
+++ b/beans/src/org/netbeans/modules/beans/EventSetPatternPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/EventTypeEditor.java
+++ b/beans/src/org/netbeans/modules/beans/EventTypeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/GenerateBeanException.java
+++ b/beans/src/org/netbeans/modules/beans/GenerateBeanException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/HelpCtxKeys.java
+++ b/beans/src/org/netbeans/modules/beans/HelpCtxKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/IconBases.java
+++ b/beans/src/org/netbeans/modules/beans/IconBases.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/IdxPropertyPattern.java
+++ b/beans/src/org/netbeans/modules/beans/IdxPropertyPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/IdxPropertyPatternNode.java
+++ b/beans/src/org/netbeans/modules/beans/IdxPropertyPatternNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/IdxPropertyPatternPanel.java
+++ b/beans/src/org/netbeans/modules/beans/IdxPropertyPatternPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/IdxPropertyTypeEditor.java
+++ b/beans/src/org/netbeans/modules/beans/IdxPropertyTypeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/ModePropertyEditor.java
+++ b/beans/src/org/netbeans/modules/beans/ModePropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/Pattern.java
+++ b/beans/src/org/netbeans/modules/beans/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PatternAnalyser.java
+++ b/beans/src/org/netbeans/modules/beans/PatternAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PatternChildren.java
+++ b/beans/src/org/netbeans/modules/beans/PatternChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PatternFilter.java
+++ b/beans/src/org/netbeans/modules/beans/PatternFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PatternGroupNode.java
+++ b/beans/src/org/netbeans/modules/beans/PatternGroupNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PatternNode.java
+++ b/beans/src/org/netbeans/modules/beans/PatternNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PatternProperties.java
+++ b/beans/src/org/netbeans/modules/beans/PatternProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PropertyPattern.java
+++ b/beans/src/org/netbeans/modules/beans/PropertyPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PropertyPatternNode.java
+++ b/beans/src/org/netbeans/modules/beans/PropertyPatternNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PropertyPatternPanel.java
+++ b/beans/src/org/netbeans/modules/beans/PropertyPatternPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/PropertyTypeEditor.java
+++ b/beans/src/org/netbeans/modules/beans/PropertyTypeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/TmpPattern.java
+++ b/beans/src/org/netbeans/modules/beans/TmpPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/UEventSetPatternPanel.java
+++ b/beans/src/org/netbeans/modules/beans/UEventSetPatternPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyCodeGenerator.java
+++ b/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyConfig.java
+++ b/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyGenerator.java
+++ b/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyPanel.java
+++ b/beans/src/org/netbeans/modules/beans/addproperty/AddPropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/addproperty/GeneratorUtils.java
+++ b/beans/src/org/netbeans/modules/beans/addproperty/GeneratorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BIDataLoader.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BIDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BIDataLoaderBeanInfo.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BIDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BIDataNode.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BIDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BIDataObject.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BIDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BIGuardedBlockHandlerFactory.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BIGuardedBlockHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BeanInfoSource.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BeanInfoSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiAnalyser.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiChildren.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiExcludeAllAction.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiExcludeAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiFeature.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiFeatureNode.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiFeatureNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiIconEditor.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiIconEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiIncludeAllAction.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiIncludeAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiNode.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiPanel.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/BiToggleAction.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/BiToggleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/CustomCodeEditor.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/CustomCodeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/GenerateBeanInfoAction.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/GenerateBeanInfoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/beaninfo/IconBases.java
+++ b/beans/src/org/netbeans/modules/beans/beaninfo/IconBases.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/src/org/netbeans/modules/beans/resources/templates/Templates.java
+++ b/beans/src/org/netbeans/modules/beans/resources/templates/Templates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/BeanInfoGeneration.java
+++ b/beans/test/qa-func/src/gui/BeanInfoGeneration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/BeansTemplates.java
+++ b/beans/test/qa-func/src/gui/BeansTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/ChangingOfBeanPropertyProperties.java
+++ b/beans/test/qa-func/src/gui/ChangingOfBeanPropertyProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/CreateNewIndexedProperty.java
+++ b/beans/test/qa-func/src/gui/CreateNewIndexedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/CreateNewNonIndexedProperty.java
+++ b/beans/test/qa-func/src/gui/CreateNewNonIndexedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/NewMulticastEventSource.java
+++ b/beans/test/qa-func/src/gui/NewMulticastEventSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/NewUnicastEventSource.java
+++ b/beans/test/qa-func/src/gui/NewUnicastEventSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/Utilities.java
+++ b/beans/test/qa-func/src/gui/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-func/src/gui/data/TestFile.java
+++ b/beans/test/qa-func/src/gui/data/TestFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/data/projects/Beans/src/beans/Add.java
+++ b/beans/test/qa-functional/data/projects/Beans/src/beans/Add.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/data/projects/Beans/src/beans/AddBeanInfo.java
+++ b/beans/test/qa-functional/data/projects/Beans/src/beans/AddBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/data/projects/Beans/src/beans/Beans.java
+++ b/beans/test/qa-functional/data/projects/Beans/src/beans/Beans.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/data/projects/Beans/src/beans/Generate.java
+++ b/beans/test/qa-functional/data/projects/Beans/src/beans/Generate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/data/projects/Beans/src/beans/Source.java
+++ b/beans/test/qa-functional/data/projects/Beans/src/beans/Source.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/data/projects/Beans/src/beans/SourceBeanInfo.java
+++ b/beans/test/qa-functional/data/projects/Beans/src/beans/SourceBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/data/projects/Beans/src/members/Test_A_A.java
+++ b/beans/test/qa-functional/data/projects/Beans/src/members/Test_A_A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/BeanInfoEditorTest.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/BeanInfoEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/BeansTestCase.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/BeansTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/PatternsTest.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/PatternsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/PropertyGeneration.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/PropertyGeneration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/operators/AddProperty.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/operators/AddProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/operators/BeanInfoOperator.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/operators/BeanInfoOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/operators/Navigator.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/operators/Navigator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/beans/test/qa-functional/src/org/netbeans/test/beans/suites/StableSuite.java
+++ b/beans/test/qa-functional/src/org/netbeans/test/beans/suites/StableSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/exportdiff/AttachPanel.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/exportdiff/AttachPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/exportdiff/ExportDiffProviderImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/exportdiff/ExportDiffProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/nodes/BugtrackingRootNode.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/nodes/BugtrackingRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/nodes/RepositoryNode.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/bridge/nodes/RepositoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/hyperlink/EditorHyperlinkProviderImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/hyperlink/EditorHyperlinkProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/hyperlink/VcsHyperlinkProviderImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/hyperlink/VcsHyperlinkProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/FormatPanel.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/FormatPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/GitHookFactoryImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/GitHookFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/GitHookImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/GitHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgHookFactoryImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgHookFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgHookImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookFactoryImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookPanel.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HookImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HookPanel.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HookPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HookUtils.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HookUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/SvnHookFactoryImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/SvnHookFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/SvnHookImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/SvnHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/VCSBugtrackingSupportImpl.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/VCSBugtrackingSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/VCSHooksConfig.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/VCSHooksConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/VCSQueueHooksConfig.java
+++ b/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/VCSQueueHooksConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HgHookTest.java
+++ b/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HgHookTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HookConnector.java
+++ b/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HookConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HookIssue.java
+++ b/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HookIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HookRepository.java
+++ b/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/HookRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/SvnHookTest.java
+++ b/bugtracking.bridge/test/unit/src/org/netbeans/modules/bugtracking/vcs/SvnHookTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/ColumnDescriptor.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/ColumnDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/Filter.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/FindInQueryBar.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/FindInQueryBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/FindInQuerySupport.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/FindInQuerySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueNode.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableHeaderRenderer.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableHeaderRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/SummaryTextFilter.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/SummaryTextFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/TableSorter.java
+++ b/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/TableSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/test/unit/src/org/netbeans/modules/bugtracking/issuetable/IssueTableTestCase.java
+++ b/bugtracking.commons/test/unit/src/org/netbeans/modules/bugtracking/issuetable/IssueTableTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking.commons/test/unit/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRendererTest.java
+++ b/bugtracking.commons/test/unit/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/APIAccessor.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/APIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingManager.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingOwnerSupport.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingOwnerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRegistrationProcessor.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRepositoryOwnerImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRepositoryOwnerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/DelegatingConnector.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/DelegatingConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/IssueContainerImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/IssueContainerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/IssueImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/IssueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/IssuePrioritySupport.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/IssuePrioritySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/QueryImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/QueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryRegistry.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/SPIAccessor.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/APIAccessorImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/APIAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/Issue.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/Issue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/IssueQuickSearch.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/IssueQuickSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/Query.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/Repository.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/Repository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/RepositoryManager.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/RepositoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/RepositoryQuery.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/RepositoryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/api/Util.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/api/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/jira/FakeJiraConnector.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/jira/FakeJiraConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/settings/DashboardOptions.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/settings/DashboardOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/settings/DashboardSettings.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/settings/DashboardSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/BugtrackingConnector.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/BugtrackingConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/BugtrackingSupport.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/BugtrackingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueController.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueFinder.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssuePriorityInfo.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssuePriorityInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssuePriorityProvider.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssuePriorityProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueProvider.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueScheduleInfo.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueScheduleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueScheduleProvider.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueScheduleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueStatusProvider.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/IssueStatusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/QueryController.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/QueryController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/QueryProvider.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/QueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryController.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryInfo.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryProvider.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryQueryImplementation.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/RepositoryQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/SPIAccessorImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/SPIAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/spi/SchedulePicker.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/spi/SchedulePicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/ActiveTaskPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/ActiveTaskPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/Category.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/Category.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/CategoryNamePanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/CategoryNamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/CategoryPicker.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/CategoryPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardToolbar.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardTopComponent.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardTransferHandler.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardTransferHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardTransferable.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardTransferable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardUtils.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/DashboardUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/FilterPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/FilterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/LinkLabel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/LinkLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/NotificationManager.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/NotificationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/QuickSearchPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/QuickSearchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/RecentCategory.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/RecentCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/ScheduleCategory.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/ScheduleCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/SchedulingPickerImpl.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/SchedulingPickerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/SortAttributePanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/SortAttributePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/SortPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/SortPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskAttribute.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskNotificationPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskNotificationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskSchedulingManager.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskSchedulingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskSorter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/TaskSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/UnsubmittedCategory.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/UnsubmittedCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/Actions.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/Actions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/CategoryAction.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/CategoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/DummyAction.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/DummyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/QueryAction.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/QueryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/RepositoryAction.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/RepositoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/TaskAction.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/TaskAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/CategoryEntry.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/CategoryEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/DashboardStorage.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/DashboardStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/StorageUtils.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/StorageUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/TaskEntry.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/TaskEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/CategoryNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/CategoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ClosedCategoryNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ClosedCategoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ClosedRepositoryNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ClosedRepositoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/DashboardRefresher.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/DashboardRefresher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/DashboardViewer.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/DashboardViewer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/EmptyContentNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/EmptyContentNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/EmptyNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/EmptyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ErrorNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ErrorNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/RecentCategoryNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/RecentCategoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/Refreshable.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/Refreshable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/RepositoryNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/RepositoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ScheduleCategoryNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ScheduleCategoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ShowNextNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ShowNextNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/Submitable.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/Submitable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/TaskContainerNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/TaskContainerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/TaskNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/TaskNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/TitleNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/TitleNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/UnsubmittedCategoryNode.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/UnsubmittedCategoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/AppliedFilters.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/AppliedFilters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/DashboardFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/DashboardFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/DisplayTextTaskFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/DisplayTextTaskFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/EmptyTaskFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/EmptyTaskFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/OpenedCategorizedTaskFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/OpenedCategorizedTaskFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/OpenedCategoryFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/OpenedCategoryFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/OpenedRepositoryFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/OpenedRepositoryFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/ScheduleCategoryFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/ScheduleCategoryFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/UnsubmittedCategoryFilter.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/filter/UnsubmittedCategoryFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/team/TeamRepositories.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/team/TeamRepositories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/team/TeamRepositoryPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/team/TeamRepositoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/FindBar.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/FindBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/FindSupport.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/FindSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/IssueAction.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/IssueAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/IssueTopComponent.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/IssueTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/QueryAction.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/QueryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/QueryTopComponent.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/QueryTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/RepoSelectorPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/RepoSelectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboModel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboRenderer.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboSupport.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComparator.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/PopupItem.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/PopupItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/QuickSearchComboBar.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/QuickSearchComboBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/QuickSearchPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/QuickSearchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/QuickSearchPopup.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/QuickSearchPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/ResultsModel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/ResultsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/SearchResultRenderer.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/search/SearchResultRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/ConnectorComparator.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/ConnectorComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositoryFormPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositoryFormPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositorySelectorBuilder.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositorySelectorBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/SelectorPanel.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/SelectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/util/BugtrackingUtil.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/util/BugtrackingUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/src/org/netbeans/modules/bugtracking/util/IssueFinderUtils.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/util/IssueFinderUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/LogHandler.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/LogHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ManagerTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/RecentIssuesTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/RecentIssuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/RepositoryImplTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/RepositoryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/RepositoryRegistryTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/RepositoryRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestIssue.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestIssueProvider.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestIssueProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestKit.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestQuery.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestQueryProvider.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestRepository.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestRepositoryProvider.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestRepositoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestStatusProvider.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/TestStatusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestConnector.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestIssue.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestKit.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestQuery.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestRepository.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/APITestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/BugtrackingViewsTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/BugtrackingViewsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/IssueTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/IssueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/QueryTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/QueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/RepositoryManagerTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/RepositoryManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/RepositoryQueryTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/RepositoryQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/RepositoryTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/RepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/UtilTestCase.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/api/UtilTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyBugtrackingConnector.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyBugtrackingConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyBugtrackingOwnerSupport.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyBugtrackingOwnerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyNode.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyProjectServices.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyProjectServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyRepository.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyTopComponentRegistry.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyTopComponentRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyWindowManager.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/dummies/DummyWindowManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/kenai/DummyKenaiRepositories.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/kenai/DummyKenaiRepositories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/spi/RepositoryInfoTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/spi/RepositoryInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/spi/SchedulingPickerTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/spi/SchedulingPickerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/tasks/cache/DashboardStorageTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/tasks/cache/DashboardStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/query/KenaiTestHidden.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/query/KenaiTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/query/QTCTestHidden.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/query/QTCTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboModelTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboSupportTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/selectors/RepositorySelectorTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/ui/selectors/RepositorySelectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/util/BugtrackingUtilTest.java
+++ b/bugtracking/test/unit/src/org/netbeans/modules/bugtracking/util/BugtrackingUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla.exceptionreporter/src/org/netbeans/modules/bugzilla/exceptionreporter/NBBugzillaAccessorImpl.java
+++ b/bugzilla.exceptionreporter/src/org/netbeans/modules/bugzilla/exceptionreporter/NBBugzillaAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla.exceptionreporter/src/org/netbeans/modules/bugzilla/exceptionreporter/ReportNBIssueAction.java
+++ b/bugzilla.exceptionreporter/src/org/netbeans/modules/bugzilla/exceptionreporter/ReportNBIssueAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/Bugzilla.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/Bugzilla.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaConfig.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaConnector.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaIssueProvider.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaIssueProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaQueryProvider.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaRepositoryProvider.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/BugzillaRepositoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/MylynRepositoryConnectorProvider.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/MylynRepositoryConnectorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/api/NBBugzillaUtils.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/api/NBBugzillaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaAutoupdate.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaAutoupdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/commands/AddAttachmentCommand.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/commands/AddAttachmentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/commands/BugzillaExecutor.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/commands/BugzillaExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/commands/GetAttachmentCommand.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/commands/GetAttachmentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/commands/GetConfigurationCommand.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/commands/GetConfigurationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/commands/HtmlPanel.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/commands/HtmlPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/commands/ValidateCommand.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/commands/ValidateCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/issue/AttachmentHyperlinkSupport.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/issue/AttachmentHyperlinkSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/issue/BugzillaIssue.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/issue/BugzillaIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/issue/BugzillaIssueController.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/issue/BugzillaIssueController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/issue/BugzillaIssueNode.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/issue/BugzillaIssueNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/issue/CommentsPanel.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/issue/CommentsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/issue/IssuePanel.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/issue/IssuePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/issue/ResolveIssuePanel.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/issue/ResolveIssuePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiConfiguration.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiQuery.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiQueryController.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiQueryController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiRepository.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/kenai/KenaiRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/query/BugzillaQuery.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/query/BugzillaQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/query/BugzillaQueryCellRenderer.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/query/BugzillaQueryCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryController.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryNotifyListener.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryNotifyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryPanel.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryParameter.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaConfiguration.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepository.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepositoryController.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepositoryController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/CustomIssueField.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/CustomIssueField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/IssueField.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/IssueField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/NBLoginPanel.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/NBLoginPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/NBRepositorySupport.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/NBRepositorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/repository/RepositoryPanel.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/repository/RepositoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/util/BugzillaConstants.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/util/BugzillaConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/util/BugzillaUtil.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/util/BugzillaUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/util/FileUtils.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/util/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/src/org/netbeans/modules/bugzilla/util/NbBugzillaConstants.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/util/NbBugzillaConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/BugzillaTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/BugzillaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/HtmlPanel.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/HtmlPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/LogHandler.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/LogHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/MylynStorageTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/MylynStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/TestConstants.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/TestConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/TestQueryNotifyListener.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/TestQueryNotifyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/TestUtil.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaNotSupportedTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaNotSupportedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaPluginUCTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaPluginUCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaSupportedTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaSupportedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/commands/ExceptionHandlerTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/commands/ExceptionHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/AttachmentHyperlinkSupportTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/AttachmentHyperlinkSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/CurrentNBVersionTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/CurrentNBVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/IssueTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/IssueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/IssueTestUtils.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/IssueTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/OpenIssueTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/OpenIssueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/ShowLogActionTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/issue/ShowLogActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/ControllerTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/ControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/IssueTableTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/IssueTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryConstants.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryParameterTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryRefreshTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryRefreshTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryTestUtil.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/query/QueryTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/repository/RepositoryControllerTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/repository/RepositoryControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/repository/RepositoryTest.java
+++ b/bugzilla/test/unit/src/org/netbeans/modules/bugzilla/repository/RepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/closure/src/org/netbeans/modules/classfile/closure/Closure.java
+++ b/classfile/closure/src/org/netbeans/modules/classfile/closure/Closure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Access.java
+++ b/classfile/src/org/netbeans/modules/classfile/Access.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Annotation.java
+++ b/classfile/src/org/netbeans/modules/classfile/Annotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/AnnotationComponent.java
+++ b/classfile/src/org/netbeans/modules/classfile/AnnotationComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ArrayElementValue.java
+++ b/classfile/src/org/netbeans/modules/classfile/ArrayElementValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/AttributeMap.java
+++ b/classfile/src/org/netbeans/modules/classfile/AttributeMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/BootstrapMethod.java
+++ b/classfile/src/org/netbeans/modules/classfile/BootstrapMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ByteCodes.java
+++ b/classfile/src/org/netbeans/modules/classfile/ByteCodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPClassInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPDoubleInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPDoubleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPEntry.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPFieldInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPFieldInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPFieldMethodInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPFieldMethodInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPFloatInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPFloatInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPIntegerInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPIntegerInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPInterfaceMethodInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPInterfaceMethodInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPInvokeDynamicInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPInvokeDynamicInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPLongInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPLongInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPMethodHandleInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPMethodHandleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPMethodInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPMethodInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPMethodTypeInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPMethodTypeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPModuleInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPModuleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPName.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPNameAndTypeInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPNameAndTypeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPPackageInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPPackageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPStringInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPStringInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/CPUTF8Info.java
+++ b/classfile/src/org/netbeans/modules/classfile/CPUTF8Info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ClassElementValue.java
+++ b/classfile/src/org/netbeans/modules/classfile/ClassElementValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ClassFile.java
+++ b/classfile/src/org/netbeans/modules/classfile/ClassFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ClassName.java
+++ b/classfile/src/org/netbeans/modules/classfile/ClassName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Code.java
+++ b/classfile/src/org/netbeans/modules/classfile/Code.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ConstantPool.java
+++ b/classfile/src/org/netbeans/modules/classfile/ConstantPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ConstantPoolReader.java
+++ b/classfile/src/org/netbeans/modules/classfile/ConstantPoolReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ElementValue.java
+++ b/classfile/src/org/netbeans/modules/classfile/ElementValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/EnclosingMethod.java
+++ b/classfile/src/org/netbeans/modules/classfile/EnclosingMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/EnumElementValue.java
+++ b/classfile/src/org/netbeans/modules/classfile/EnumElementValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ExceptionTableEntry.java
+++ b/classfile/src/org/netbeans/modules/classfile/ExceptionTableEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Field.java
+++ b/classfile/src/org/netbeans/modules/classfile/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/InnerClass.java
+++ b/classfile/src/org/netbeans/modules/classfile/InnerClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/InvalidClassFileAttributeException.java
+++ b/classfile/src/org/netbeans/modules/classfile/InvalidClassFileAttributeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/InvalidClassFormatException.java
+++ b/classfile/src/org/netbeans/modules/classfile/InvalidClassFormatException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/LegacyClassFile.java
+++ b/classfile/src/org/netbeans/modules/classfile/LegacyClassFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/LocalVariableTableEntry.java
+++ b/classfile/src/org/netbeans/modules/classfile/LocalVariableTableEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/LocalVariableTypeTableEntry.java
+++ b/classfile/src/org/netbeans/modules/classfile/LocalVariableTypeTableEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Method.java
+++ b/classfile/src/org/netbeans/modules/classfile/Method.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Module.java
+++ b/classfile/src/org/netbeans/modules/classfile/Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/ModuleTarget.java
+++ b/classfile/src/org/netbeans/modules/classfile/ModuleTarget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/NestedElementValue.java
+++ b/classfile/src/org/netbeans/modules/classfile/NestedElementValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Parameter.java
+++ b/classfile/src/org/netbeans/modules/classfile/Parameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/PrimitiveElementValue.java
+++ b/classfile/src/org/netbeans/modules/classfile/PrimitiveElementValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/StackMapFrame.java
+++ b/classfile/src/org/netbeans/modules/classfile/StackMapFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/Variable.java
+++ b/classfile/src/org/netbeans/modules/classfile/Variable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/src/org/netbeans/modules/classfile/VerificationTypeInfo.java
+++ b/classfile/src/org/netbeans/modules/classfile/VerificationTypeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/Closure.java
+++ b/classfile/test/Closure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/ElapsedTimer.java
+++ b/classfile/test/ElapsedTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/PrintClass.java
+++ b/classfile/test/PrintClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/PrintClassFile.java
+++ b/classfile/test/PrintClassFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/ScanJar.java
+++ b/classfile/test/ScanJar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/org/netbeans/modules/classfile/AccessTest.java
+++ b/classfile/test/unit/src/org/netbeans/modules/classfile/AccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/org/netbeans/modules/classfile/ClassNameTest.java
+++ b/classfile/test/unit/src/org/netbeans/modules/classfile/ClassNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/org/netbeans/modules/classfile/ConstantPoolTest.java
+++ b/classfile/test/unit/src/org/netbeans/modules/classfile/ConstantPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/org/netbeans/modules/classfile/JDK8ClassFilesTest.java
+++ b/classfile/test/unit/src/org/netbeans/modules/classfile/JDK8ClassFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/org/netbeans/modules/classfile/ModuleTest.java
+++ b/classfile/test/unit/src/org/netbeans/modules/classfile/ModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/org/netbeans/modules/classfile/ParamNameTest.java
+++ b/classfile/test/unit/src/org/netbeans/modules/classfile/ParamNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/regression/Issue219426Test.java
+++ b/classfile/test/unit/src/regression/Issue219426Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/regression/Issue84411Test.java
+++ b/classfile/test/unit/src/regression/Issue84411Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/regression/Issue91098Test.java
+++ b/classfile/test/unit/src/regression/Issue91098Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/classfile/test/unit/src/regression/datafiles/test91098.java
+++ b/classfile/test/unit/src/regression/datafiles/test91098.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/AnalysisProblem.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/AnalysisProblem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/AnalysisResult.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/AnalysisResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/Configuration.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ConfigurationsManager.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ConfigurationsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/DescriptionReader.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/DescriptionReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/RequiredPluginsPanel.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/RequiredPluginsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/RunAnalysis.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/RunAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisAction.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/SPIAccessor.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/Utils.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/api/CodeAnalysis.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/api/CodeAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/spi/AnalysisScopeProvider.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/spi/AnalysisScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/spi/Analyzer.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/spi/Analyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/AbstractErrorAction.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/AbstractErrorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/AnalysisProblemNode.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/AnalysisProblemNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/AnalysisResultTopComponent.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/AnalysisResultTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/ConfigurationsComboModel.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/ConfigurationsComboModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/NextError.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/NextError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/Nodes.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/Nodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/PreviousError.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/PreviousError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/src/org/netbeans/modules/analysis/ui/RequiredPluginsNode.java
+++ b/code.analysis/src/org/netbeans/modules/analysis/ui/RequiredPluginsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/code.analysis/test/unit/src/org/netbeans/modules/analysis/spi/AnalyzerTest.java
+++ b/code.analysis/test/unit/src/org/netbeans/modules/analysis/spi/AnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/BrowserCallback.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/BrowserCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/BrowserFactory.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/BrowserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/BrowserFactoryBeanInfo.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/BrowserFactoryBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/EmbeddedBrowserFactoryImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/EmbeddedBrowserFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/HtmlBrowserImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/HtmlBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/MessageDispatcherImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/MessageDispatcherImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/NoWebBrowserImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/NoWebBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/OldRuntimePanel.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/OldRuntimePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/TransportImplementationWithURLToLoad.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/TransportImplementationWithURLToLoad.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/WebBrowserImplProvider.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/WebBrowserImplProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/ext/ScriptExecutorImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/ext/ScriptExecutorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/ext/WebBrowserEventImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/ext/WebBrowserEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/ext/WebBrowserImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/ext/WebBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/ext/WebKitDebuggingTransport.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/ext/WebKitDebuggingTransport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser.webview/src/org/netbeans/core/browser/webview/ext/ZoomAndResizeImpl.java
+++ b/core.browser.webview/src/org/netbeans/core/browser/webview/ext/ZoomAndResizeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser/src/org/netbeans/core/browser/api/EmbeddedBrowserFactory.java
+++ b/core.browser/src/org/netbeans/core/browser/api/EmbeddedBrowserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser/src/org/netbeans/core/browser/api/WebBrowser.java
+++ b/core.browser/src/org/netbeans/core/browser/api/WebBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser/src/org/netbeans/core/browser/api/WebBrowserEvent.java
+++ b/core.browser/src/org/netbeans/core/browser/api/WebBrowserEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.browser/src/org/netbeans/core/browser/api/WebBrowserListener.java
+++ b/core.browser/src/org/netbeans/core/browser/api/WebBrowserListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/AccController.java
+++ b/core.execution/src/org/netbeans/core/execution/AccController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/DefaultSysProcess.java
+++ b/core.execution/src/org/netbeans/core/execution/DefaultSysProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
+++ b/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/ExecutionEvent.java
+++ b/core.execution/src/org/netbeans/core/execution/ExecutionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/ExecutionListener.java
+++ b/core.execution/src/org/netbeans/core/execution/ExecutionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/ExecutorTaskImpl.java
+++ b/core.execution/src/org/netbeans/core/execution/ExecutorTaskImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/ExitSecurityException.java
+++ b/core.execution/src/org/netbeans/core/execution/ExitSecurityException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/IOPermissionCollection.java
+++ b/core.execution/src/org/netbeans/core/execution/IOPermissionCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/IOTable.java
+++ b/core.execution/src/org/netbeans/core/execution/IOTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/IOThreadIfc.java
+++ b/core.execution/src/org/netbeans/core/execution/IOThreadIfc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/Install.java
+++ b/core.execution/src/org/netbeans/core/execution/Install.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/OutputStreamWriter.java
+++ b/core.execution/src/org/netbeans/core/execution/OutputStreamWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/RunClassThread.java
+++ b/core.execution/src/org/netbeans/core/execution/RunClassThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/SecMan.java
+++ b/core.execution/src/org/netbeans/core/execution/SecMan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/SysIn.java
+++ b/core.execution/src/org/netbeans/core/execution/SysIn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/TaskIO.java
+++ b/core.execution/src/org/netbeans/core/execution/TaskIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/TaskThreadGroup.java
+++ b/core.execution/src/org/netbeans/core/execution/TaskThreadGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/WindowTable.java
+++ b/core.execution/src/org/netbeans/core/execution/WindowTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/WriterPrintStream.java
+++ b/core.execution/src/org/netbeans/core/execution/WriterPrintStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbClassPathCustomEditor.java
+++ b/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbClassPathCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbClassPathEditor.java
+++ b/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbClassPathEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbProcessDescriptorCustomEditor.java
+++ b/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbProcessDescriptorCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbProcessDescriptorEditor.java
+++ b/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbProcessDescriptorEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/beaninfo/editors/package-info.java
+++ b/core.execution/src/org/netbeans/core/execution/beaninfo/editors/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/src/org/netbeans/core/execution/beaninfo/package-info.java
+++ b/core.execution/src/org/netbeans/core/execution/beaninfo/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/test/unit/src/org/netbeans/core/execution/CoreExecutionCompatibilityTest.java
+++ b/core.execution/test/unit/src/org/netbeans/core/execution/CoreExecutionCompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/test/unit/src/org/netbeans/core/execution/PendingTaskTest.java
+++ b/core.execution/test/unit/src/org/netbeans/core/execution/PendingTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.execution/test/unit/src/org/netbeans/core/execution/TaskThreadGroupGCTest.java
+++ b/core.execution/test/unit/src/org/netbeans/core/execution/TaskThreadGroupGCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ide/src/org/netbeans/api/core/ide/ServicesTabNodeRegistration.java
+++ b/core.ide/src/org/netbeans/api/core/ide/ServicesTabNodeRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ide/src/org/netbeans/core/ide/ServiceTabProcessor.java
+++ b/core.ide/src/org/netbeans/core/ide/ServiceTabProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ide/src/org/netbeans/core/ide/ServicesTab.java
+++ b/core.ide/src/org/netbeans/core/ide/ServicesTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ide/test/unit/src/org/netbeans/core/ide/ServiceTabProcessorTest.java
+++ b/core.ide/test/unit/src/org/netbeans/core/ide/ServiceTabProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.io.ui/src/org/netbeans/core/io/ui/IOWindow.java
+++ b/core.io.ui/src/org/netbeans/core/io/ui/IOWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.io.ui/src/org/netbeans/core/io/ui/IOWindowAction.java
+++ b/core.io.ui/src/org/netbeans/core/io/ui/IOWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.io.ui/test/unit/src/org/netbeans/core/io/ui/IOWindowTest.java
+++ b/core.io.ui/test/unit/src/org/netbeans/core/io/ui/IOWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/ErrorManagerTest.java
+++ b/core.kit/test/perf/src/org/openide/ErrorManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/FSTest.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/FSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/PrepareData.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/PrepareData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/ReadOnlyFSTest.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/ReadOnlyFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/Utilities.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/data/JavaSrc.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/data/JavaSrc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/data/SerialData.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/data/SerialData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/localfs/LFSDataDescriptor.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/localfs/LFSDataDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/localfs/LocalFSTest.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/localfs/LocalFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/multifs/MFSDataDescriptor.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/multifs/MFSDataDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/multifs/MultiXMLFSTest.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/multifs/MultiXMLFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/xmlfs/XMLFSTest.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/xmlfs/XMLFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/xmlfs/XMLFSvsParserTest.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/xmlfs/XMLFSvsParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/filesystems/xmlfs/XMLinJarFSTest.java
+++ b/core.kit/test/perf/src/org/openide/filesystems/xmlfs/XMLinJarFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/loaders/Utilities.java
+++ b/core.kit/test/perf/src/org/openide/loaders/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/util/NbBundleTest.java
+++ b/core.kit/test/perf/src/org/openide/util/NbBundleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/util/enum/ArrayEnumTest.java
+++ b/core.kit/test/perf/src/org/openide/util/enum/ArrayEnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/util/enum/EnumBenchmark.java
+++ b/core.kit/test/perf/src/org/openide/util/enum/EnumBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/util/enum/Sequence2EnumTest.java
+++ b/core.kit/test/perf/src/org/openide/util/enum/Sequence2EnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/util/enum/SequenceEnumTest.java
+++ b/core.kit/test/perf/src/org/openide/util/enum/SequenceEnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/util/lookup/ProxyLookupTest.java
+++ b/core.kit/test/perf/src/org/openide/util/lookup/ProxyLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/perf/src/org/openide/utildata/UtilClass.java
+++ b/core.kit/test/perf/src/org/openide/utildata/UtilClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/unit/src/org/openide/awt/ContextManagerIntegrationTest.java
+++ b/core.kit/test/unit/src/org/openide/awt/ContextManagerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/unit/src/org/openide/explorer/ExplorerUtilCreateLookupTest.java
+++ b/core.kit/test/unit/src/org/openide/explorer/ExplorerUtilCreateLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/unit/src/org/openide/explorer/windows/TopComponentGetLookupOverridenTest.java
+++ b/core.kit/test/unit/src/org/openide/explorer/windows/TopComponentGetLookupOverridenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.kit/test/unit/src/org/openide/explorer/windows/TopComponentGetLookupTest.java
+++ b/core.kit/test/unit/src/org/openide/explorer/windows/TopComponentGetLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs.project/src/org/netbeans/core/multitabs/project/ProjectSupportImpl.java
+++ b/core.multitabs.project/src/org/netbeans/core/multitabs/project/ProjectSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/ButtonFactory.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/ButtonFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/Controller.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/Controller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/Settings.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/StackLayout.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/StackLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/TabContainer.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/TabContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/TabDecorator.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/TabDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/TabDisplayer.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/TabDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/TabDisplayerFactory.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/TabDisplayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/TabbedComponentFactoryImpl.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/TabbedComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/TabbedImpl.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/TabbedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/AbstractTabDisplayer.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/AbstractTabDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/ButtonPopupSwitcher.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/ButtonPopupSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/CloseButtonHandler.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/CloseButtonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/ControlsToolbar.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/ControlsToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/FolderNameTabDecorator.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/FolderNameTabDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/MultiRowTabDisplayer.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/MultiRowTabDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectSupport.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/RowPerProjectTabDisplayer.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/RowPerProjectTabDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/ScrollAction.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/ScrollAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/SimpleTabDisplayer.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/SimpleTabDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/SingleRowTabTable.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/SingleRowTabTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/TabListPopupAction.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/TabListPopupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/TabTable.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/TabTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/TabTableModel.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/TabTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/impl/TabTableUI.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/impl/TabTableUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/prefs/InnerTabsPanel.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/prefs/InnerTabsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/prefs/MultiTabsOptionsPanelController.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/prefs/MultiTabsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/prefs/MultiTabsPanel.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/prefs/MultiTabsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multitabs/src/org/netbeans/core/multitabs/prefs/SettingsImpl.java
+++ b/core.multitabs/src/org/netbeans/core/multitabs/prefs/SettingsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/api/multiview/AccessorImpl.java
+++ b/core.multiview/src/org/netbeans/core/api/multiview/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/api/multiview/MultiViewHandler.java
+++ b/core.multiview/src/org/netbeans/core/api/multiview/MultiViewHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/api/multiview/MultiViewPerspective.java
+++ b/core.multiview/src/org/netbeans/core/api/multiview/MultiViewPerspective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/api/multiview/MultiViewPerspectiveComponent.java
+++ b/core.multiview/src/org/netbeans/core/api/multiview/MultiViewPerspectiveComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/api/multiview/MultiViews.java
+++ b/core.multiview/src/org/netbeans/core/api/multiview/MultiViews.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/Accessor.java
+++ b/core.multiview/src/org/netbeans/core/multiview/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/ContextAwareDescription.java
+++ b/core.multiview/src/org/netbeans/core/multiview/ContextAwareDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/EditorsAction.java
+++ b/core.multiview/src/org/netbeans/core/multiview/EditorsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/EmptyViewDescription.java
+++ b/core.multiview/src/org/netbeans/core/multiview/EmptyViewDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/GetLeftEditorAction.java
+++ b/core.multiview/src/org/netbeans/core/multiview/GetLeftEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/GetRightEditorAction.java
+++ b/core.multiview/src/org/netbeans/core/multiview/GetRightEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewActionMap.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewActionMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewCloneableTopComponent.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewCloneableTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewElementCallbackDelegate.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewElementCallbackDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewHandlerDelegate.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewHandlerDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewModel.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewProcessor.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponent.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
+++ b/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/SourceCheckDescription.java
+++ b/core.multiview/src/org/netbeans/core/multiview/SourceCheckDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/SpiAccessor.java
+++ b/core.multiview/src/org/netbeans/core/multiview/SpiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/SplitAction.java
+++ b/core.multiview/src/org/netbeans/core/multiview/SplitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/SplitLayerUI.java
+++ b/core.multiview/src/org/netbeans/core/multiview/SplitLayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/Splitable.java
+++ b/core.multiview/src/org/netbeans/core/multiview/Splitable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/multiview/TabsComponent.java
+++ b/core.multiview/src/org/netbeans/core/multiview/TabsComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/AccessorImpl.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/CloseOperationHandler.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/CloseOperationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/CloseOperationState.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/CloseOperationState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewDescription.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewElement.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewElementCallback.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewElementCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewFactory.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/SourceViewMarker.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/SourceViewMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/text/MultiViewCloneableEditor.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/text/MultiViewCloneableEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/src/org/netbeans/core/spi/multiview/text/MultiViewEditorElement.java
+++ b/core.multiview/src/org/netbeans/core/spi/multiview/text/MultiViewEditorElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/AbstractMultiViewTopComponentTestCase.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/AbstractMultiViewTopComponentTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/CloseOperationHandlerTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/CloseOperationHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MVDesc.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MVDesc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MVElem.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MVElem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MVElemTopComponent.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MVElemTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MVInnerComponentGetLookupTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MVInnerComponentGetLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewActionMapTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewActionMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewCloneableTopComponentTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewCloneableTopComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewElementTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewFactoryTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewHandlerTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewProcessorTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewTopComponentTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewTopComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewsTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/NoMVCLookupTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/NoMVCLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/ToolbarVisibleTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/ToolbarVisibleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/multiview/loaders/DefaultDataObjectHasNodeInMVLookupTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/multiview/loaders/DefaultDataObjectHasNodeInMVLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorCloneTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorCloneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorCreationFinishedTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorCreationFinishedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorDiscardTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorDiscardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorElementTest.java
+++ b/core.multiview/test/unit/src/org/netbeans/core/spi/multiview/text/MultiViewEditorElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.nativeaccess/src/org/netbeans/core/nativeaccess/NativeWindowSystemImpl.java
+++ b/core.nativeaccess/src/org/netbeans/core/nativeaccess/NativeWindowSystemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/src/org/netbeans/core/netigso/Netigso.java
+++ b/core.netigso/src/org/netbeans/core/netigso/Netigso.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/src/org/netbeans/core/netigso/NetigsoActivator.java
+++ b/core.netigso/src/org/netbeans/core/netigso/NetigsoActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/src/org/netbeans/core/netigso/NetigsoArchiveFactory.java
+++ b/core.netigso/src/org/netbeans/core/netigso/NetigsoArchiveFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/src/org/netbeans/core/netigso/NetigsoLoader.java
+++ b/core.netigso/src/org/netbeans/core/netigso/NetigsoLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/src/org/netbeans/core/netigso/NetigsoServices.java
+++ b/core.netigso/src/org/netbeans/core/netigso/NetigsoServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/src/org/netbeans/core/netigso/spi/BundleContent.java
+++ b/core.netigso/src/org/netbeans/core/netigso/spi/BundleContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/src/org/netbeans/core/netigso/spi/NetigsoArchive.java
+++ b/core.netigso/src/org/netbeans/core/netigso/spi/NetigsoArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/data/jars/activate/org/activate/Main.java
+++ b/core.netigso/test/unit/data/jars/activate/org/activate/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/data/jars/activate/org/activate/Query.java
+++ b/core.netigso/test/unit/data/jars/activate/org/activate/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingElse.java
+++ b/core.netigso/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingElse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingReflective.java
+++ b/core.netigso/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingReflective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/data/jars/register/org/register/Main.java
+++ b/core.netigso/test/unit/data/jars/register/org/register/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/data/jars/simple-module/org/foo/Something.java
+++ b/core.netigso/test/unit/data/jars/simple-module/org/foo/Something.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/data/jars/uses-swing/org/barwing/Main.java
+++ b/core.netigso/test/unit/data/jars/uses-swing/org/barwing/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/EnabledAutoloadTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/EnabledAutoloadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/ExportedIfPresentNegTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/ExportedIfPresentNegTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/ExportedIfPresentTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/ExportedIfPresentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/IntegrationTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/IntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationCanAccessLayersTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationCanAccessLayersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationOnExitTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationOnExitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationWithLookupTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoActivationWithLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoDefaultModuleStartLevelTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoDefaultModuleStartLevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoDefaultStartLevelTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoDefaultStartLevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoDuplicatedClassForNameTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoDuplicatedClassForNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoExportPackageTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoExportPackageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoHid.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoHighStartLevelDependsOnAutoloadTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoHighStartLevelDependsOnAutoloadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoLayerDoesNotActivateTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoLayerDoesNotActivateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoLayerTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoLayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoMetaInfServicesTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoMetaInfServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoModuleStartLevelTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoModuleStartLevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiActivationVisibleTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiActivationVisibleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiAutoloadActivationVisibleTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiAutoloadActivationVisibleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiAutoloadWithNeedsTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiAutoloadWithNeedsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanDependTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanDependTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanImportSubpackageTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanImportSubpackageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanProvideTokenTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanProvideTokenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanRequestNoMajorTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanRequestNoMajorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanRequestTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCanRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCannotEnableTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiCannotEnableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiDashTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiDashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiFragmentTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiFragmentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiIsNotFriendTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiIsNotFriendTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoReloadTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoReloadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoSelfQueryTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoSelfQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoServicesTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoStartLevelTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoStartLevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoUsesSwingTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoUsesSwingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoUtil.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
+++ b/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/NetworkProxyReloader.java
+++ b/core.network/src/org/netbeans/core/network/proxy/NetworkProxyReloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/NetworkProxyResolver.java
+++ b/core.network/src/org/netbeans/core/network/proxy/NetworkProxyResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/NetworkProxySettings.java
+++ b/core.network/src/org/netbeans/core/network/proxy/NetworkProxySettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/ProxyAutoConfig.java
+++ b/core.network/src/org/netbeans/core/network/proxy/ProxyAutoConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/fallback/FallbackNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/fallback/FallbackNetworkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/gnome/GconfNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/gnome/GconfNetworkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/gnome/GnomeNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/gnome/GnomeNetworkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/gnome/GsettingsNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/gnome/GsettingsNetworkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/mac/MacCoreFoundationLibrary.java
+++ b/core.network/src/org/netbeans/core/network/proxy/mac/MacCoreFoundationLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxyLibrary.java
+++ b/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxyLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/pac/impl/ClassFilterPacHelpers.java
+++ b/core.network/src/org/netbeans/core/network/proxy/pac/impl/ClassFilterPacHelpers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/pac/impl/HelperScriptFactory.java
+++ b/core.network/src/org/netbeans/core/network/proxy/pac/impl/HelperScriptFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacHelperMethods.java
+++ b/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacHelperMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
+++ b/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluatorFactory.java
+++ b/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/pac/impl/package-info.java
+++ b/core.network/src/org/netbeans/core/network/proxy/pac/impl/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxyLibrary.java
+++ b/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxyLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/HostnameUtils.java
+++ b/core.network/src/org/netbeans/core/network/utils/HostnameUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/IpAddressUtils.java
+++ b/core.network/src/org/netbeans/core/network/utils/IpAddressUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/IpAddressUtilsFilter.java
+++ b/core.network/src/org/netbeans/core/network/utils/IpAddressUtilsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
+++ b/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/NativeException.java
+++ b/core.network/src/org/netbeans/core/network/utils/NativeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/SimpleObjCache.java
+++ b/core.network/src/org/netbeans/core/network/utils/SimpleObjCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/linux/HostnameUtilsLinux.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/linux/HostnameUtilsLinux.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/linux/package-info.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/linux/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/mac/HostnameUtilsMac.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/mac/HostnameUtilsMac.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/mac/package-info.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/mac/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/solaris/HostnameUtilsSolaris.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/solaris/HostnameUtilsSolaris.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/solaris/package-info.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/solaris/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/unix/CLib.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/unix/CLib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/unix/HostnameUtilsUnix.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/unix/HostnameUtilsUnix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/unix/package-info.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/unix/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/win/HostnameUtilsWin.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/win/HostnameUtilsWin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/win/Winsock2Lib.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/win/Winsock2Lib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/hname/win/package-info.java
+++ b/core.network/src/org/netbeans/core/network/utils/hname/win/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/src/org/netbeans/core/network/utils/package-info.java
+++ b/core.network/src/org/netbeans/core/network/utils/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/test/unit/src/org/netbeans/core/network/proxy/DontUseProxyTest.java
+++ b/core.network/test/unit/src/org/netbeans/core/network/proxy/DontUseProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/test/unit/src/org/netbeans/core/network/proxy/NonProxyHostsTest.java
+++ b/core.network/test/unit/src/org/netbeans/core/network/proxy/NonProxyHostsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/test/unit/src/org/netbeans/core/network/proxy/ProxyAutoConfigTest.java
+++ b/core.network/test/unit/src/org/netbeans/core/network/proxy/ProxyAutoConfigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/test/unit/src/org/netbeans/core/network/proxy/pac/impl/PacHelperMethodsImplTest.java
+++ b/core.network/test/unit/src/org/netbeans/core/network/proxy/pac/impl/PacHelperMethodsImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.network/test/unit/src/org/netbeans/core/network/utils/FakeDns.java
+++ b/core.network/test/unit/src/org/netbeans/core/network/utils/FakeDns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/Activator.java
+++ b/core.osgi/src/org/netbeans/core/osgi/Activator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/DependencyQueue.java
+++ b/core.osgi/src/org/netbeans/core/osgi/DependencyQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiClassLoader.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiLifecycleManager.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiMainLookup.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiMainLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiRepository.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/src/org/netbeans/core/osgi/package-info.java
+++ b/core.osgi/src/org/netbeans/core/osgi/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/test/unit/src/org/netbeans/core/osgi/ActivatorTest.java
+++ b/core.osgi/test/unit/src/org/netbeans/core/osgi/ActivatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/test/unit/src/org/netbeans/core/osgi/DependencyQueueTest.java
+++ b/core.osgi/test/unit/src/org/netbeans/core/osgi/DependencyQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiInstalledFileLocatorTest.java
+++ b/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiInstalledFileLocatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiLifecycleManagerTest.java
+++ b/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiLifecycleManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiMainLookupTest.java
+++ b/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiMainLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiProcess.java
+++ b/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiRepositoryTest.java
+++ b/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiRepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/AbstractLines.java
+++ b/core.output2/src/org/netbeans/core/output2/AbstractLines.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/BufferResource.java
+++ b/core.output2/src/org/netbeans/core/output2/BufferResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/Controller.java
+++ b/core.output2/src/org/netbeans/core/output2/Controller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/ErrWriter.java
+++ b/core.output2/src/org/netbeans/core/output2/ErrWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/ExtPlainView.java
+++ b/core.output2/src/org/netbeans/core/output2/ExtPlainView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/FileMapStorage.java
+++ b/core.output2/src/org/netbeans/core/output2/FileMapStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/FindDialogPanel.java
+++ b/core.output2/src/org/netbeans/core/output2/FindDialogPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/FoldingSideBar.java
+++ b/core.output2/src/org/netbeans/core/output2/FoldingSideBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/HeapStorage.java
+++ b/core.output2/src/org/netbeans/core/output2/HeapStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/IOEvent.java
+++ b/core.output2/src/org/netbeans/core/output2/IOEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/IntList.java
+++ b/core.output2/src/org/netbeans/core/output2/IntList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/IntListSimple.java
+++ b/core.output2/src/org/netbeans/core/output2/IntListSimple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/IntMap.java
+++ b/core.output2/src/org/netbeans/core/output2/IntMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/LineInfo.java
+++ b/core.output2/src/org/netbeans/core/output2/LineInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/Lines.java
+++ b/core.output2/src/org/netbeans/core/output2/Lines.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/NbIO.java
+++ b/core.output2/src/org/netbeans/core/output2/NbIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/NbIOProvider.java
+++ b/core.output2/src/org/netbeans/core/output2/NbIOProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/NbWriter.java
+++ b/core.output2/src/org/netbeans/core/output2/NbWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/OutWriter.java
+++ b/core.output2/src/org/netbeans/core/output2/OutWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/OutputDocument.java
+++ b/core.output2/src/org/netbeans/core/output2/OutputDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/OutputEditorKit.java
+++ b/core.output2/src/org/netbeans/core/output2/OutputEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/OutputKind.java
+++ b/core.output2/src/org/netbeans/core/output2/OutputKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/OutputLimits.java
+++ b/core.output2/src/org/netbeans/core/output2/OutputLimits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/OutputPane.java
+++ b/core.output2/src/org/netbeans/core/output2/OutputPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/OutputTab.java
+++ b/core.output2/src/org/netbeans/core/output2/OutputTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/PairMap.java
+++ b/core.output2/src/org/netbeans/core/output2/PairMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/SparseIntList.java
+++ b/core.output2/src/org/netbeans/core/output2/SparseIntList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/Storage.java
+++ b/core.output2/src/org/netbeans/core/output2/Storage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/WrappedTextView.java
+++ b/core.output2/src/org/netbeans/core/output2/WrappedTextView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/options/LinkStyleModel.java
+++ b/core.output2/src/org/netbeans/core/output2/options/LinkStyleModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/options/OutputOptions.java
+++ b/core.output2/src/org/netbeans/core/output2/options/OutputOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/options/OutputSettingsOptionsPanelController.java
+++ b/core.output2/src/org/netbeans/core/output2/options/OutputSettingsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
+++ b/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/options/PreviewIOProvider.java
+++ b/core.output2/src/org/netbeans/core/output2/options/PreviewIOProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
+++ b/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputTab.java
+++ b/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/ui/OutputKeymapManager.java
+++ b/core.output2/src/org/netbeans/core/output2/ui/OutputKeymapManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/src/org/netbeans/core/output2/ui/WeakAction.java
+++ b/core.output2/src/org/netbeans/core/output2/ui/WeakAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/ControllerTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/ControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/IOExtensionsTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/IOExtensionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/IntListTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/IntListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/IntMapTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/IntMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/LifecycleTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/LifecycleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/NbIOFoldTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/NbIOFoldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/NbIOProviderTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/NbIOProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/NbIOTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/NbIOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/OutWriterTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/OutWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/OutputDocumentTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/OutputDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/OutputTabTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/OutputTabTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/PairMapTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/PairMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/SparseIntListTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/SparseIntListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/StorageTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/StorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/TestFrame.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/TestFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.output2/test/unit/src/org/netbeans/core/output2/WrappedTextViewTest.java
+++ b/core.output2/test/unit/src/org/netbeans/core/output2/WrappedTextViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/base/LayerFactory.java
+++ b/core.startup.base/src/org/netbeans/core/startup/base/LayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/layers/LocalFileSystemEx.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/LocalFileSystemEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/layers/ModuleLayeredFileSystem.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/ModuleLayeredFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLMapper.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/layers/SystemFileSystem.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/SystemFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/preferences/NbPreferences.java
+++ b/core.startup.base/src/org/netbeans/core/startup/preferences/NbPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/preferences/NbPreferencesFactory.java
+++ b/core.startup.base/src/org/netbeans/core/startup/preferences/NbPreferencesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/preferences/PropertiesStorage.java
+++ b/core.startup.base/src/org/netbeans/core/startup/preferences/PropertiesStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/src/org/netbeans/core/startup/preferences/Statistics.java
+++ b/core.startup.base/src/org/netbeans/core/startup/preferences/Statistics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/ArchiveURLMapperTest.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/ArchiveURLMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/AttributeChangeIsNotifiedTest.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/AttributeChangeIsNotifiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/LocalFileSystemEx133616Test.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/LocalFileSystemEx133616Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/NbinstURLMapperTest.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/NbinstURLMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesModifiedTest.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesModifiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesTest.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/SystemFileSystemTest.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/SystemFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/Asm.java
+++ b/core.startup/src/org/netbeans/core/startup/Asm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/AutomaticDependencies.java
+++ b/core.startup/src/org/netbeans/core/startup/AutomaticDependencies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/CLICoreBridge.java
+++ b/core.startup/src/org/netbeans/core/startup/CLICoreBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/CLIOptions.java
+++ b/core.startup/src/org/netbeans/core/startup/CLIOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/CLITestModuleReload.java
+++ b/core.startup/src/org/netbeans/core/startup/CLITestModuleReload.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/ConsistencyVerifier.java
+++ b/core.startup/src/org/netbeans/core/startup/ConsistencyVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/CoreBridge.java
+++ b/core.startup/src/org/netbeans/core/startup/CoreBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/InstalledFileLocatorImpl.java
+++ b/core.startup/src/org/netbeans/core/startup/InstalledFileLocatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/JaveleonModuleReloader.java
+++ b/core.startup/src/org/netbeans/core/startup/JaveleonModuleReloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/Main.java
+++ b/core.startup/src/org/netbeans/core/startup/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/MainLookup.java
+++ b/core.startup/src/org/netbeans/core/startup/MainLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/ManifestSection.java
+++ b/core.startup/src/org/netbeans/core/startup/ManifestSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/ModuleHistory.java
+++ b/core.startup/src/org/netbeans/core/startup/ModuleHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/ModuleLifecycleManager.java
+++ b/core.startup/src/org/netbeans/core/startup/ModuleLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/ModuleList.java
+++ b/core.startup/src/org/netbeans/core/startup/ModuleList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/ModuleSystem.java
+++ b/core.startup/src/org/netbeans/core/startup/ModuleSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/NbEvents.java
+++ b/core.startup/src/org/netbeans/core/startup/NbEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/NbInstaller.java
+++ b/core.startup/src/org/netbeans/core/startup/NbInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/NbPlaces.java
+++ b/core.startup/src/org/netbeans/core/startup/NbPlaces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/NbProblemDisplayer.java
+++ b/core.startup/src/org/netbeans/core/startup/NbProblemDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/NbRepository.java
+++ b/core.startup/src/org/netbeans/core/startup/NbRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/NbResourceStreamHandler.java
+++ b/core.startup/src/org/netbeans/core/startup/NbResourceStreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/NbStartStop.java
+++ b/core.startup/src/org/netbeans/core/startup/NbStartStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/ProxyTask.java
+++ b/core.startup/src/org/netbeans/core/startup/ProxyTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/RunLevel.java
+++ b/core.startup/src/org/netbeans/core/startup/RunLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/Splash.java
+++ b/core.startup/src/org/netbeans/core/startup/Splash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/StartLog.java
+++ b/core.startup/src/org/netbeans/core/startup/StartLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/TestModuleDeployer.java
+++ b/core.startup/src/org/netbeans/core/startup/TestModuleDeployer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/TopLogging.java
+++ b/core.startup/src/org/netbeans/core/startup/TopLogging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/TopThreadGroup.java
+++ b/core.startup/src/org/netbeans/core/startup/TopThreadGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/WarmUpSupport.java
+++ b/core.startup/src/org/netbeans/core/startup/WarmUpSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/impl/BinaryLayerFactoryProvider.java
+++ b/core.startup/src/org/netbeans/core/startup/impl/BinaryLayerFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/layers/BinaryCacheManager.java
+++ b/core.startup/src/org/netbeans/core/startup/layers/BinaryCacheManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/layers/BinaryFS.java
+++ b/core.startup/src/org/netbeans/core/startup/layers/BinaryFS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/layers/LayerCacheManager.java
+++ b/core.startup/src/org/netbeans/core/startup/layers/LayerCacheManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/layers/ParsingLayerCacheManager.java
+++ b/core.startup/src/org/netbeans/core/startup/layers/ParsingLayerCacheManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/layers/SessionManager.java
+++ b/core.startup/src/org/netbeans/core/startup/layers/SessionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/logging/DispatchingHandler.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/DispatchingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/logging/NbFormatter.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/NbFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/logging/PrintStreamLogger.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/PrintStreamLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/preferences/PreferencesProviderImpl.java
+++ b/core.startup/src/org/netbeans/core/startup/preferences/PreferencesProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/src/org/netbeans/core/startup/preferences/RelPaths.java
+++ b/core.startup/src/org/netbeans/core/startup/preferences/RelPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/MainCLITest.java
+++ b/core.startup/test/unit/src/org/netbeans/MainCLITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/AsmTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/AsmTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/AutomaticDependenciesCachedTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/AutomaticDependenciesCachedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/AutomaticDependenciesTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/AutomaticDependenciesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/CLILookupExecTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/CLILookupExecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/CLILookupHelpNoDirTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/CLILookupHelpNoDirTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/CLILookupHelpTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/CLILookupHelpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/CLIOptionsTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/CLIOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ConsistencyVerifierTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ConsistencyVerifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/CoreBridgeTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/CoreBridgeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/CountingSecurityManager.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/CountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/InstallTmpModuleTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/InstallTmpModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/InstalledFileLocatorAndCLITest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/InstalledFileLocatorAndCLITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/InstalledFileLocatorImplDirTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/InstalledFileLocatorImplDirTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/InstalledFileLocatorImplTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/InstalledFileLocatorImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/IsDirCntSecurityManager.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/IsDirCntSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/MainLookupTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/MainLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/MockServicesTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/MockServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ModuleFormatSatisfiedTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ModuleFormatSatisfiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ModuleLifecycleManagerEDTTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ModuleLifecycleManagerEDTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ModuleLifecycleManagerTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ModuleLifecycleManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListDontDeleteDisabledModulesTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListDontDeleteDisabledModulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListStartLevelTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListStartLevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbBootDelegationTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbBootDelegationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerCacheTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerHideClasspathPackagesTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerHideClasspathPackagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest2.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest3.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest4.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest5.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest8.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest9.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTest9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTestBase.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbProblemDisplayerTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbProblemDisplayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbProductVersionTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbProductVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbRepositoryClasspathTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbRepositoryClasspathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbRepositoryTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbRepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbStartStopTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbStartStopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryDeadlockTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryWhenSetTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryWhenSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NonGuiHandleCheckOfLicenseTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NonGuiHandleCheckOfLicenseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/NonGuiHandleImportOfUserDirTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/NonGuiHandleImportOfUserDirTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/PlatformDependencySatisfiedTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/PlatformDependencySatisfiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/ProxyTaskTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/ProxyTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/SplashTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/SplashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingAWTTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingLookupTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingNbLoggerConsoleTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingNbLoggerConsoleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingOwnConfigClassTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingOwnConfigClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingOwnConfigTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingOwnConfigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingStartLogTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingStartLogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/TopThreadGroupTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/TopThreadGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/UpdateAllResourcesTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/UpdateAllResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/AttributeChangeOnBinaryFSIsNotifiedTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/AttributeChangeOnBinaryFSIsNotifiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryCacheManagerTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryCacheManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryCacheManagerViaJarTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryCacheManagerViaJarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryFSBehindMultiFSTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryFSBehindMultiFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryFSTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/BinaryFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/CacheManagerTestBaseHid.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/CacheManagerTestBaseHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/CachingPreventsFileTouchesTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/CachingPreventsFileTouchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/ContentProviderTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/ContentProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/CountingSecurityManager.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/CountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/CustomWritableSystemFileSystemTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/CustomWritableSystemFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/DelayFSEventsTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/DelayFSEventsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/DelayFSInstaller.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/DelayFSInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/DynamicSFSFallbackTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/DynamicSFSFallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/NonCacheManagerTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/NonCacheManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/layers/NonCacheManagerViaJarTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/layers/NonCacheManagerViaJarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/logging/DispatchingHandlerTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/logging/DispatchingHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/logging/MessagesHandlerTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/logging/MessagesHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/logging/NbFormatterTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/logging/NbFormatterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/logging/PrintStreamLoggerTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/logging/PrintStreamLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/NbPreferencesTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/NbPreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/PreferencesProviderImplTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/PreferencesProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/RelPathsTest.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/RelPathsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestFileStorage.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestFileStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestNbPreferencesFactory.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestNbPreferencesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestNbPreferencesThreading.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestNbPreferencesThreading.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPreferences.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPropertiesStorage.java
+++ b/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPropertiesStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/notifications/BalloonManager.java
+++ b/core.ui/src/org/netbeans/core/ui/notifications/BalloonManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/notifications/FlashingIcon.java
+++ b/core.ui/src/org/netbeans/core/ui/notifications/FlashingIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/notifications/NotificationDisplayerImpl.java
+++ b/core.ui/src/org/netbeans/core/ui/notifications/NotificationDisplayerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/notifications/NotificationImpl.java
+++ b/core.ui/src/org/netbeans/core/ui/notifications/NotificationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/notifications/PopupList.java
+++ b/core.ui/src/org/netbeans/core/ui/notifications/PopupList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/notifications/StatusLineElement.java
+++ b/core.ui/src/org/netbeans/core/ui/notifications/StatusLineElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/filetypes/FileAssociationsModel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/filetypes/FileAssociationsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/filetypes/FileAssociationsOptionsPanelController.java
+++ b/core.ui/src/org/netbeans/core/ui/options/filetypes/FileAssociationsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/filetypes/FileAssociationsPanel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/filetypes/FileAssociationsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/filetypes/IgnoredFilesPreferences.java
+++ b/core.ui/src/org/netbeans/core/ui/options/filetypes/IgnoredFilesPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/filetypes/NewExtensionPanel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/filetypes/NewExtensionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/filetypes/OpenAsAction.java
+++ b/core.ui/src/org/netbeans/core/ui/options/filetypes/OpenAsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/filetypes/OpenAsPanel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/filetypes/OpenAsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/general/AdvancedProxyPanel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/general/AdvancedProxyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsModel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsPanel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsPanelController.java
+++ b/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/general/WebBrowsersOptionsModel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/general/WebBrowsersOptionsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/options/general/WebBrowsersOptionsPanel.java
+++ b/core.ui/src/org/netbeans/core/ui/options/general/WebBrowsersOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/sampler/SelfSamplerAction.java
+++ b/core.ui/src/org/netbeans/core/ui/sampler/SelfSamplerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
+++ b/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/warmup/ContextMenuWarmUpTask.java
+++ b/core.ui/src/org/netbeans/core/ui/warmup/ContextMenuWarmUpTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/warmup/DiagnosticTask.java
+++ b/core.ui/src/org/netbeans/core/ui/warmup/DiagnosticTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/warmup/DnDWarmUpTask.java
+++ b/core.ui/src/org/netbeans/core/ui/warmup/DnDWarmUpTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/src/org/netbeans/core/ui/warmup/MenuWarmUpTask.java
+++ b/core.ui/src/org/netbeans/core/ui/warmup/MenuWarmUpTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.ui/test/unit/src/org/netbeans/core/ui/notifications/NotificationImplTest.java
+++ b/core.ui/test/unit/src/org/netbeans/core/ui/notifications/NotificationImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/Central.java
+++ b/core.windows/src/org/netbeans/core/windows/Central.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/ConfigFactory.java
+++ b/core.windows/src/org/netbeans/core/windows/ConfigFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/Constants.java
+++ b/core.windows/src/org/netbeans/core/windows/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/Debug.java
+++ b/core.windows/src/org/netbeans/core/windows/Debug.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/EditorOnlyDisplayer.java
+++ b/core.windows/src/org/netbeans/core/windows/EditorOnlyDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/FloatingWindowTransparencyManager.java
+++ b/core.windows/src/org/netbeans/core/windows/FloatingWindowTransparencyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/LazyLoader.java
+++ b/core.windows/src/org/netbeans/core/windows/LazyLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/ModeImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/ModeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/ModeStructureSnapshot.java
+++ b/core.windows/src/org/netbeans/core/windows/ModeStructureSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/PersistenceHandler.java
+++ b/core.windows/src/org/netbeans/core/windows/PersistenceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/RecentViewList.java
+++ b/core.windows/src/org/netbeans/core/windows/RecentViewList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/RegistryImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/RegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
+++ b/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/SplitConstraint.java
+++ b/core.windows/src/org/netbeans/core/windows/SplitConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/Switches.java
+++ b/core.windows/src/org/netbeans/core/windows/Switches.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/TopComponentGroupImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/TopComponentGroupImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/TopComponentTracker.java
+++ b/core.windows/src/org/netbeans/core/windows/TopComponentTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/ViewRequest.java
+++ b/core.windows/src/org/netbeans/core/windows/ViewRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/ViewRequestor.java
+++ b/core.windows/src/org/netbeans/core/windows/ViewRequestor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/WindowManagerImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/WindowManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/WindowSystemEventType.java
+++ b/core.windows/src/org/netbeans/core/windows/WindowSystemEventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/WindowSystemImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/WindowSystemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/WindowSystemSnapshot.java
+++ b/core.windows/src/org/netbeans/core/windows/WindowSystemSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/ActionUtils.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/ActionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/ActionsFactory.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/ActionsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/CloneDocumentAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/CloneDocumentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/CloseAllButThisAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/CloseAllButThisAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/CloseAllDocumentsAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/CloseAllDocumentsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/CloseModeAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/CloseModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/CloseWindowAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/CloseWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/CollapseTabGroupAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/CollapseTabGroupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/DockModeAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/DockModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/DockWindowAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/DockWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/DocumentsAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/DocumentsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/GlobalPropertiesAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/GlobalPropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/MaximizeWindowAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/MaximizeWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/MinimizeModeAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/MinimizeModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/MinimizeWindowAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/MinimizeWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/MoveModeAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/MoveModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/MoveWindowAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/MoveWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/MoveWindowWithinModeAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/MoveWindowWithinModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/NewTabGroupAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/NewTabGroupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/NextTabAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/NextTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/PreviousTabAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/PreviousTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/RecentViewListAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/RecentViewListAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/ResetWindowsAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/ResetWindowsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/ResizeModeAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/ResizeModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/SaveWindowsAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/SaveWindowsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/ShowEditorOnlyAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/ShowEditorOnlyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/SwitchRoleKeepDocumentsAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/SwitchRoleKeepDocumentsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/SwitchToRecentDocumentAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/SwitchToRecentDocumentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/ToggleFullScreenAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/ToggleFullScreenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/ToolbarsListAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/ToolbarsListAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/UndockModeAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/UndockModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/actions/UndockWindowAction.java
+++ b/core.windows/src/org/netbeans/core/windows/actions/UndockWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/design/DesignView.java
+++ b/core.windows/src/org/netbeans/core/windows/design/DesignView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/design/DesignViewComponent.java
+++ b/core.windows/src/org/netbeans/core/windows/design/DesignViewComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/documentgroup/DocumentGroupImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/documentgroup/DocumentGroupImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsManager.java
+++ b/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsMenuAction.java
+++ b/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsMenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/documentgroup/ManageGroupsPanel.java
+++ b/core.windows/src/org/netbeans/core/windows/documentgroup/ManageGroupsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/documentgroup/NewGroupPanel.java
+++ b/core.windows/src/org/netbeans/core/windows/documentgroup/NewGroupPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/documentgroup/PleaseWait.java
+++ b/core.windows/src/org/netbeans/core/windows/documentgroup/PleaseWait.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/DefaultModeModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/DefaultModeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/DefaultModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/DefaultModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/DefaultTopComponentGroupModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/DefaultTopComponentGroupModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/DockingStatus.java
+++ b/core.windows/src/org/netbeans/core/windows/model/DockingStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/EditorSplitSubModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/EditorSplitSubModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/ModeModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/ModeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/Model.java
+++ b/core.windows/src/org/netbeans/core/windows/model/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/ModelElement.java
+++ b/core.windows/src/org/netbeans/core/windows/model/ModelElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/ModelFactory.java
+++ b/core.windows/src/org/netbeans/core/windows/model/ModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/ModesSubModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/ModesSubModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/SplitSubModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/SplitSubModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/TopComponentContextSubModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/TopComponentContextSubModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/TopComponentGroupModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/TopComponentGroupModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/model/TopComponentSubModel.java
+++ b/core.windows/src/org/netbeans/core/windows/model/TopComponentSubModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/nativeaccess/NativeWindowSystem.java
+++ b/core.windows/src/org/netbeans/core/windows/nativeaccess/NativeWindowSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/nativeaccess/NoNativeAccessWindowSystem.java
+++ b/core.windows/src/org/netbeans/core/windows/nativeaccess/NoNativeAccessWindowSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/LafOptionsPanelController.java
+++ b/core.windows/src/org/netbeans/core/windows/options/LafOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/LafPanel.java
+++ b/core.windows/src/org/netbeans/core/windows/options/LafPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/TabsOptionsPanelController.java
+++ b/core.windows/src/org/netbeans/core/windows/options/TabsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/TabsPanel.java
+++ b/core.windows/src/org/netbeans/core/windows/options/TabsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/WinSysOptionsPanelController.java
+++ b/core.windows/src/org/netbeans/core/windows/options/WinSysOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/WinSysPanel.java
+++ b/core.windows/src/org/netbeans/core/windows/options/WinSysPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/WinSysPrefs.java
+++ b/core.windows/src/org/netbeans/core/windows/options/WinSysPrefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/options/package-info.java
+++ b/core.windows/src/org/netbeans/core/windows/options/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/GroupConfig.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/GroupConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/GroupParser.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/GroupParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/InternalConfig.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/InternalConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/ModeConfig.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/ModeConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/ModuleChangeHandler.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/ModuleChangeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/PersistenceObserver.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/PersistenceObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/RoleFileSystem.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/RoleFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/TCGroupConfig.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/TCGroupConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/TCGroupParser.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/TCGroupParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/TCRefConfig.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/TCRefConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/TCRefParser.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/TCRefParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerConfig.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerParser.java
+++ b/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/services/ActionPasteType.java
+++ b/core.windows/src/org/netbeans/core/windows/services/ActionPasteType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/services/FileSelector.java
+++ b/core.windows/src/org/netbeans/core/windows/services/FileSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/services/NbDialog.java
+++ b/core.windows/src/org/netbeans/core/windows/services/NbDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
+++ b/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/services/NodeOperationImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/services/NodeOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/services/PresenterDecorator.java
+++ b/core.windows/src/org/netbeans/core/windows/services/PresenterDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/Controller.java
+++ b/core.windows/src/org/netbeans/core/windows/view/Controller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ControllerHandler.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ControllerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/DefaultView.java
+++ b/core.windows/src/org/netbeans/core/windows/view/DefaultView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/EditorAccessor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/EditorAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/EditorView.java
+++ b/core.windows/src/org/netbeans/core/windows/view/EditorView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ElementAccessor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ElementAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ModeAccessor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ModeAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ModeContainer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ModeContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ModeStructureAccessor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ModeStructureAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ModeStructureAccessorImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ModeStructureAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ModeView.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ModeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/SlidingAccessor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/SlidingAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/SlidingView.java
+++ b/core.windows/src/org/netbeans/core/windows/view/SlidingView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/SplitAccessor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/SplitAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/SplitView.java
+++ b/core.windows/src/org/netbeans/core/windows/view/SplitView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/View.java
+++ b/core.windows/src/org/netbeans/core/windows/view/View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ViewElement.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ViewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ViewEvent.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ViewEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ViewFactory.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ViewHelper.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ViewHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ViewHierarchy.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ViewHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/WindowSystemAccessor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/WindowSystemAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/WindowSystemAccessorImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/view/WindowSystemAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/DragAndDropFeedbackVisualizer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/DragAndDropFeedbackVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/DragWindow.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/DragWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/DropTargetGlassPane.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/DropTargetGlassPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/EnhancedDragPainter.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/EnhancedDragPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/KeyboardDnd.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/KeyboardDnd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDragSupport.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDragSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDraggable.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDraggable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDroppable.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDroppable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/dnd/ZOrderManager.java
+++ b/core.windows/src/org/netbeans/core/windows/view/dnd/ZOrderManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/AbstractModeContainer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/AbstractModeContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/AutoHideStatusText.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/AutoHideStatusText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/DecorationUtils.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/DecorationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/DefaultSeparateContainer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/DefaultSeparateContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/DefaultSplitContainer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/DefaultSplitContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/DefaultTabbedComponentFactory.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/DefaultTabbedComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/DesktopImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/DesktopImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/DocumentsDlg.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/DocumentsDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/EditorAreaFrame.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/EditorAreaFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/MainWindow.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/MainWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/ModeComponent.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/ModeComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/ModeResizer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/ModeResizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitCell.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitDivider.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitDivider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitPane.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/NbSheet.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/NbSheet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/NbTabbedPaneFactory.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/NbTabbedPaneFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/StatusLine.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/StatusLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/TabbedHandler.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/TabbedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/WindowSnapper.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/WindowSnapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Item.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/KeyboardPopupSwitcher.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/KeyboardPopupSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Model.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/PopupSwitcher.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/PopupSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Table.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Table.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/CommandManager.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/CommandManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/DefaultSlidingFx.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/DefaultSlidingFx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/ResizeGestureRecognizer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/ResizeGestureRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/ScaleFx.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/ScaleFx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBar.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBarActionEvent.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBarActionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBarContainer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBarContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBarController.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideBarController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideController.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideGestureRecognizer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideGestureRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideOperation.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideOperationFactory.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideOperationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideOperationImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlideOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlidingFx.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/SlidingFx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/slides/TabbedSlideAdapter.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/slides/TabbedSlideAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/AbstractTabbedImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/AbstractTabbedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/JTabbedPaneAdapter.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/JTabbedPaneAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/TabbedAdapter.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/TabbedAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/Utilities.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/CloseableTabComponent.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/CloseableTabComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/NBTabbedPane.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/NBTabbedPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/NBTabbedPaneController.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/NBTabbedPaneController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ActionsTree.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ActionsTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ConfigureToolbarPanel.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ConfigureToolbarPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/DnDSupport.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/DnDSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ResetToolbarsAction.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ResetToolbarsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConfiguration.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConstraints.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarContainer.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConvertor.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarRow.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/Bug82319Test.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/Bug82319Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/Component00.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/Component00.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/Component01.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/Component01.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/Component02.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/Component02.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/DockingCompatibilityTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/DockingCompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/IDEInitializer.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/IDEInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/ModeActivationTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/ModeActivationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/OpenAtTabPositionTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/OpenAtTabPositionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/PersistenceHandlerTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/PersistenceHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/RoleTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/RoleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/SwitchesTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/SwitchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentCreationTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentCreationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentRegistryImplTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentRegistryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentTrackerTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentTrackerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentTypeTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/TopComponentTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/WindowManagerImplTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/WindowManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/actions/SaveWindowsActionTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/actions/SaveWindowsActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/awt/ValidateLayerMenuTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/awt/ValidateLayerMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/awt/ValidateLayerToolbarTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/awt/ValidateLayerToolbarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/nativeaccess/NativeWindowSystemTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/nativeaccess/NativeWindowSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/nativeaccess/NoNativeAccessWindowSystemTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/nativeaccess/NoNativeAccessWindowSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/persistence/GroupParserTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/persistence/GroupParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/persistence/ModeParserTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/persistence/ModeParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/persistence/TCGroupParserTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/persistence/TCGroupParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/persistence/TCRefParserTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/persistence/TCRefParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/persistence/WindowManagerParserTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/persistence/WindowManagerParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayer128399Test.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayer128399Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayer50960Test.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayer50960Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayerImplTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/services/NbPresenterLeakTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/services/NbPresenterLeakTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/services/NbPresenterTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/services/NbPresenterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/services/NotifyLaterTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/services/NotifyLaterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/services/NotifyLaterWithDialogDescriptorTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/services/NotifyLaterWithDialogDescriptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/CustomMenuBarTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/CustomMenuBarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/DesktopImplTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/DesktopImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/MainWindowTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/MainWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/MultiSplitCellTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/MultiSplitCellTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/MultiSplitPaneTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/MultiSplitPaneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/NbSheetTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/NbSheetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/StatusLineElementProviderTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/StatusLineElementProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/TestViewElement.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/TestViewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/popupswitcher/KeyboardPopupSwitcherTestHid.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/popupswitcher/KeyboardPopupSwitcherTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/toolbars/ConfigureToolbarPanelTest.java
+++ b/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/toolbars/ConfigureToolbarPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/anttask/src/org/netbeans/modules/csl/CslJar.java
+++ b/csl.api/anttask/src/org/netbeans/modules/csl/CslJar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/AbstractCamelCasePosition.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/AbstractCamelCasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/CamelCaseOperations.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/CamelCaseOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionContext.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionHandler.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionHandler2.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionHandler2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionResult.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/CodeCompletionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/ColoringAttributes.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/ColoringAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/CompletionProposal.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/CompletionProposal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/CslActions.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/CslActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/DataLoadersBridge.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/DataLoadersBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/DeclarationFinder.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/DeclarationFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/DeleteToNextCamelCasePosition.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/DeleteToNextCamelCasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/DeleteToPreviousCamelCasePosition.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/DeleteToPreviousCamelCasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/EditHistory.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/EditHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/EditList.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/EditList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/EditRegions.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/EditRegions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/EditorOptions.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/EditorOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/Formatter.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/Formatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/GoToDeclarationAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/GoToDeclarationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/GoToMarkOccurrencesAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/GoToMarkOccurrencesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/GsfLanguage.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/GsfLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/Hint.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/Hint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/HintFix.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/HintFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/HintSeverity.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/HintSeverity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/HintsProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/HintsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/HtmlFormatter.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/HtmlFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/IndexSearcher.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/IndexSearcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/InstantRenameAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/InstantRenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/InstantRenamer.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/InstantRenamer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/KeystrokeHandler.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/KeystrokeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/NextCamelCasePosition.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/NextCamelCasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/OccurrencesFinder.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/OccurrencesFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/OverridingMethods.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/OverridingMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/ParameterInfo.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/ParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/PreviewableFix.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/PreviewableFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/PreviousCamelCasePosition.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/PreviousCamelCasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/Rule.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/RuleContext.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/RuleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/SelectCodeElementAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/SelectCodeElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/SelectNextCamelCasePosition.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/SelectNextCamelCasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/SelectPreviousCamelCasePosition.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/SelectPreviousCamelCasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/SemanticAnalyzer.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/SemanticAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/StructureItem.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/StructureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/StructureScanner.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/StructureScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/ToggleBlockCommentAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/ToggleBlockCommentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/api/UiUtils.java
+++ b/csl.api/src/org/netbeans/modules/csl/api/UiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/AbstractTaskFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/AbstractTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/CancelSupportImplementation.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/CancelSupportImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/CslCamelCaseInterceptor.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/CslCamelCaseInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/CslEditorKit.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/CslEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/EmbeddingIndexerFactoryImpl.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/EmbeddingIndexerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/ErrorFilterQuery.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/ErrorFilterQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfDataLoader.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfDataNode.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfDataObject.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfDocument.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfEditorSettings.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfEditorSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfHtmlFormatter.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfHtmlFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfIndentTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfIndentTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfParserFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfReformatTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfReformatTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfReformatTaskFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfReformatTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/GsfTaskProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfTaskProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/Language.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/Language.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistrationProcessor.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistry.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/PathRecognizerImpl.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/PathRecognizerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/ProjectClassPathProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/ProjectClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/SchedulerTaskCancelSupportImpl.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/SchedulerTaskCancelSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/SpiSupportAccessor.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/SpiSupportAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/TLIndexerFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/TLIndexerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/TasklistStateBackdoor.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/TasklistStateBackdoor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/core/TypeAndSymbolProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/TypeAndSymbolProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/EditRegionsImpl.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/EditRegionsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/FileObjectAccessor.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/FileObjectAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/GsfCodeFoldingSideBar.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/GsfCodeFoldingSideBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/GsfCodeFoldingSideBarFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/GsfCodeFoldingSideBarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/InstantRenamePerformer.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/InstantRenamePerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/SyncDocumentRegion.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/SyncDocumentRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/codetemplates/CslCorePackageAccessor.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/codetemplates/CslCorePackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/codetemplates/GsfCodeTemplateFilter.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/codetemplates/GsfCodeTemplateFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/codetemplates/GsfCodeTemplateProcessor.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/codetemplates/GsfCodeTemplateProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/completion/CompletionCancelSupportImpl.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/completion/CompletionCancelSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionDoc.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionDoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionItem.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/completion/MethodParamsTipPaintComponent.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/completion/MethodParamsTipPaintComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldManager.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldManagerFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldManagerTaskFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldManagerTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldScheduler.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/fold/GsfFoldScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/DeclarationPopup.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/DeclarationPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GoToSupport.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GoToSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GsfHyperlinkProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GsfHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/PopupUtil.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/PopupUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/overridden/AnnotationType.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/overridden/AnnotationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/overridden/AnnotationsHolder.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/overridden/AnnotationsHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/overridden/ComputeAnnotations.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/overridden/ComputeAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenAnnotation.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenAnnotationAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenAnnotationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenPopup.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/overridden/OverrideDescription.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/overridden/OverrideDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/ColoringManager.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/ColoringManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/GsfSemanticLayer.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/GsfSemanticLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/HighlightImpl.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/HighlightImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/HighlightsLayerFactoryImpl.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/HighlightsLayerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighterFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/OccurrencesMarkProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/OccurrencesMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/OccurrencesMarkProviderCreator.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/OccurrencesMarkProviderCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighter.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighterFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/editor/semantic/SequenceElement.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/semantic/SequenceElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/GsfHintsFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/GsfHintsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/GsfHintsProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/GsfHintsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/GsfUpToDateStateProvider.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/GsfUpToDateStateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/GsfUpToDateStateProviderFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/GsfUpToDateStateProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/DisableHintFix.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/DisableHintFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/FixWrapper.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/FixWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/GsfHintsManager.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/GsfHintsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsOptionsPanelController.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanel.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsSettings.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsTaskFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/PreviewHintFix.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/PreviewHintFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SelectionHintsTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SelectionHintsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SelectionHintsTaskFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SelectionHintsTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SuggestionsTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SuggestionsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SuggestionsTaskFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/SuggestionsTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/ide.css
+++ b/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/ide.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/BreadCrumbsTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/BreadCrumbsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/CSLNavigatorScheduler.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/CSLNavigatorScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/CaretListeningFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/CaretListeningFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/CaretListeningTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/CaretListeningTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberFilters.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberFilters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberNavigatorSourceFactory.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberNavigatorSourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberPanel.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberPanelUI.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberPanelUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/ElementNode.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/ElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/ElementScanningTask.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/ElementScanningTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/Icons.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/Icons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/actions/FilterSubmenuAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/actions/FilterSubmenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/actions/OpenAction.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/actions/OpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/actions/SortActionSupport.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/actions/SortActionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/base/FiltersDescription.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/base/FiltersDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/base/FiltersManager.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/base/FiltersManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/base/ModelBusyListener.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/base/ModelBusyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/base/TapPanel.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/base/TapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/base/TooltipHack.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/base/TooltipHack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/navigation/base/TrivialLayout.java
+++ b/csl.api/src/org/netbeans/modules/csl/navigation/base/TrivialLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/CommentHandler.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/CommentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/DefaultCompletionProposal.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/DefaultCompletionProposal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/DefaultCompletionResult.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/DefaultCompletionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/DefaultDataLoadersBridge.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/DefaultDataLoadersBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/DefaultError.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/DefaultError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/DefaultLanguageConfig.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/DefaultLanguageConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/ErrorFilter.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/ErrorFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/LanguageRegistration.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/LanguageRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/support/CancelSupport.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/support/CancelSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/src/org/netbeans/modules/csl/spi/support/ModificationResult.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/support/ModificationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/api/EditHistoryTest.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/api/EditHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/core/GsfDataObjectTest.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/core/GsfDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/core/LanguageRegistryTest.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/core/LanguageRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/editor/semantic/SequenceElementTest.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/editor/semantic/SequenceElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/spi/GsfUtilitiesTest.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/spi/GsfUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/spi/LanguageRegistrationTest.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/spi/LanguageRegistrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.api/test/unit/src/org/netbeans/modules/parsing/impl/indexing/lucene/TestIndexFactoryImpl.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/parsing/impl/indexing/lucene/TestIndexFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/api/Documentation.java
+++ b/csl.types/src/org/netbeans/modules/csl/api/Documentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/api/ElementHandle.java
+++ b/csl.types/src/org/netbeans/modules/csl/api/ElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/api/ElementKind.java
+++ b/csl.types/src/org/netbeans/modules/csl/api/ElementKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/api/Error.java
+++ b/csl.types/src/org/netbeans/modules/csl/api/Error.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/api/Modifier.java
+++ b/csl.types/src/org/netbeans/modules/csl/api/Modifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/api/OffsetRange.java
+++ b/csl.types/src/org/netbeans/modules/csl/api/OffsetRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/api/Severity.java
+++ b/csl.types/src/org/netbeans/modules/csl/api/Severity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/src/org/netbeans/modules/csl/spi/ParserResult.java
+++ b/csl.types/src/org/netbeans/modules/csl/spi/ParserResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/csl.types/test/unit/src/org/netbeans/modules/csl/api/OffsetRangeTest.java
+++ b/csl.types/test/unit/src/org/netbeans/modules/csl/api/OffsetRangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/Css3Utils.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/Css3Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/CssBracesMatcherFactory.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/CssBracesMatcherFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/CssDeclarationContext.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/CssDeclarationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/CssErrorFilterFactory.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/CssErrorFilterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/CssExternalDropHandler.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/CssExternalDropHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/CssHelpResolver.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/CssHelpResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/CssPreferences.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/CssPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/CssProjectSupport.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/CssProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/DefaultErrorsProvider.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/DefaultErrorsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/HtmlTags.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/HtmlTags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/ParsingErrorsFilter.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/ParsingErrorsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/URLRetriever.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/URLRetriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/actions/CopyStyleAction.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/actions/CopyStyleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssAnalyser.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssBracketCompleter.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssBracketCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssCommentHandler.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssCommentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssDeclarationFinder.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssDeclarationFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssElement.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssErrorFactory.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssErrorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssHintsProvider.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssHintsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssInstantRenamer.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssInstantRenamer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssLanguage.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssNodeElement.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssNodeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssOccurrencesFinder.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssOccurrencesFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssPropertyElement.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssPropertyElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssSemanticAnalyzer.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssSemanticAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssStructureScanner.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssStructureScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/csl/CssValueElement.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/csl/CssValueElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/indent/CssIndentTask.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/indent/CssIndentTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/indent/CssIndenter.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/indent/CssIndenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/BrowserSpecificDefinitionParser.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/BrowserSpecificDefinitionParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/CssModuleSupport.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/CssModuleSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/ModulesPropertyDefinitionProvider.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/ModulesPropertyDefinitionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/PropertiesReader.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/PropertiesReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/BackgroundsAndBordersModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/BackgroundsAndBordersModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/BasicUserInterfaceModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/BasicUserInterfaceModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/BrowserSupportModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/BrowserSupportModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/ChromeModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/ChromeModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/ColorsModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/ColorsModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/Constants.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/CssRuleStructureItem.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/CssRuleStructureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/DefaultBrowser.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/DefaultBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/DefaultCssEditorModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/DefaultCssEditorModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/ExtCssEditorModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/ExtCssEditorModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/FirefoxModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/FirefoxModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/InternetExplorerModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/InternetExplorerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/ListsAndCountersModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/ListsAndCountersModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/MediaQueriesModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/MediaQueriesModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespaceCompletionItem.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespaceCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespaceStructureItem.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespaceStructureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespacesModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespacesModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/OperaModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/OperaModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/PagedMediaModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/PagedMediaModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/PropertyCompatibilityHelpResolver.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/PropertyCompatibilityHelpResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/SafariModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/SafariModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/SelectorsModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/SelectorsModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/main/TopLevelStructureItem.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/main/TopLevelStructureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/Browser.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/Browser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/CompletionContext.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/CompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/CssCompletionItem.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/CssCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/CssEditorModule.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/CssEditorModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/EditorFeatureContext.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/EditorFeatureContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/FeatureCancel.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/FeatureCancel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/FeatureContext.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/FeatureContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/FutureParamTask.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/FutureParamTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/HelpResolver.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/HelpResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/PropertySupportResolver.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/PropertySupportResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/SemanticAnalyzer.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/SemanticAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/SemanticAnalyzerResult.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/SemanticAnalyzerResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/module/spi/Utilities.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/module/spi/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/typinghooks/CssDeletedTextInterceptor.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/typinghooks/CssDeletedTextInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/typinghooks/CssTypedBreakInterceptor.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/typinghooks/CssTypedBreakInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/typinghooks/CssTypedTextInterceptor.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/typinghooks/CssTypedTextInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/editor/ui/CssRuleCreateActionDialog.java
+++ b/css.editor/src/org/netbeans/modules/css/editor/ui/CssRuleCreateActionDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/indexing/CssFileModel.java
+++ b/css.editor/src/org/netbeans/modules/css/indexing/CssFileModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/indexing/CssIndexModelSupport.java
+++ b/css.editor/src/org/netbeans/modules/css/indexing/CssIndexModelSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/indexing/CssIndexer.java
+++ b/css.editor/src/org/netbeans/modules/css/indexing/CssIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndex.java
+++ b/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndexModel.java
+++ b/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndexModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndexModelFactory.java
+++ b/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndexModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssActionsImplementationProvider.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssActionsImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssCodeGenerators.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssCodeGenerators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssElementContext.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssElementContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssRefactoringExtraInfo.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssRefactoringExtraInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssRefactoringPluginFactory.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssRefactoringPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssRenameRefactoringPlugin.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssRenameRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssRenameRefactoringUI.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssRenameRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/CssWhereUsedQueryPlugin.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/CssWhereUsedQueryPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/DiffElement.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/DiffElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/RenamePanel.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/RenamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/WhereUsedElement.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/WhereUsedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/WhereUsedPanel.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/WhereUsedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/WhereUsedUI.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/WhereUsedUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/api/CssRefactoring.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/api/CssRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/api/Entry.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/api/Entry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/api/EntryHandle.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/api/EntryHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/src/org/netbeans/modules/css/refactoring/api/RefactoringElementType.java
+++ b/css.editor/src/org/netbeans/modules/css/refactoring/api/RefactoringElementType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/Css3UtilsTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/Css3UtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/CssErrorFiltersTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/CssErrorFiltersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssAnalyserTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssAnalyserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssBracketCompleterTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssBracketCompleterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssCompletionTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssCompletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssStructureScannerTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssStructureScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/TestIssue166592.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/TestIssue166592.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/CssModuleSupportTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/CssModuleSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/AnimationsModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/AnimationsModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/BackgroundsAndBordersModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/BackgroundsAndBordersModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/BasicBoxModelModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/BasicBoxModelModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/BasicUsetInterfaceModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/BasicUsetInterfaceModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ChromeModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ChromeModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ColorsModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ColorsModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/CssModuleTestBase.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/CssModuleTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/DefaultCssModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/DefaultCssModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/FirefoxModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/FirefoxModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/FlexibleBoxLayoutModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/FlexibleBoxLayoutModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/FontsModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/FontsModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/GeneratedAndReplacedContentModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/GeneratedAndReplacedContentModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/GeneratedContentForPagedMediaModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/GeneratedContentForPagedMediaModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ImageValuesModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ImageValuesModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/InternetExplorerModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/InternetExplorerModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/LineModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/LineModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ListsAndCountersModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ListsAndCountersModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/MediaQueriesModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/MediaQueriesModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/MultiColumnLayoutTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/MultiColumnLayoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/NamespacesModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/NamespacesModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/PagedMediaModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/PagedMediaModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/RubyModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/RubyModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/SelectorsModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/SelectorsModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/SpeechModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/SpeechModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolverTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/TextModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/TextModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/Transforms3DTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/Transforms3DTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ValuesAndUnitsModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/ValuesAndUnitsModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/WritingModesModuleTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/WritingModesModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/properties/PropertiesATest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/properties/PropertiesATest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/test/RepositoryImpl.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/test/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/test/TestBase.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/test/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/test/Utils.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/test/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/typinghooks/CssTypingHooksTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/typinghooks/CssTypingHooksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/editor/typinghooks/Typing.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/editor/typinghooks/Typing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/indexing/CssFileModelTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/indexing/CssFileModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.editor/test/unit/src/org/netbeans/modules/css/indexing/api/CssIndexTest.java
+++ b/css.editor/test/unit/src/org/netbeans/modules/css/indexing/api/CssIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/AbstractParseTreeNode.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/AbstractParseTreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/CommonTokenUtil.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/CommonTokenUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/ErrorNode.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/ErrorNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/ErrorsProviderQuery.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/ErrorsProviderQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/ExtCss3Lexer.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/ExtCss3Lexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/ExtCss3Parser.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/ExtCss3Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/NbParseTreeBuilder.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/NbParseTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/RootNode.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/RuleNode.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/RuleNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/TokenNode.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/TokenNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/antlrv4.patch
+++ b/css.lib/src/org/netbeans/modules/css/lib/antlrv4.patch
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/CssColor.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/CssColor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/CssModule.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/CssModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/CssParserFactory.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/CssParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/CssParserResult.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/CssParserResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/CssTokenId.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/CssTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/CssTokenIdCategory.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/CssTokenIdCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/ErrorsProvider.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/ErrorsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/FilterableError.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/FilterableError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/Node.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/NodeType.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/NodeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/NodeUtil.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/NodeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/NodeVisitor.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/NodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/ProblemDescription.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/ProblemDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/TreePath.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/TreePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/FixedTextGrammarElement.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/FixedTextGrammarElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarElement.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarElementVisitor.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarElementVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarParseTreeConvertor.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarParseTreeConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolver.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverListener.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverResult.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GroupGrammarElement.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GroupGrammarElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/GroupNode.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/GroupNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/Node.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/NodeUtil.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/NodeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/NodeVisitor.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/NodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/NodeVisitor2.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/NodeVisitor2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/Properties.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/Properties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/PropertyCategory.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/PropertyCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/PropertyDefinition.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/PropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/PropertyDefinitionProvider.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/PropertyDefinitionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/ResolvedProperty.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/ResolvedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/ResolvedToken.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/ResolvedToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/Token.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/Token.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptor.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenNode.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/Tokenizer.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/Tokenizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/UnitGrammarElement.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/UnitGrammarElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/api/properties/ValueGrammarElement.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/api/properties/ValueGrammarElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/nblexer/CaseInsensitiveNbLexerCHS.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/nblexer/CaseInsensitiveNbLexerCHS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/nblexer/CssLanguageHierarchy.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/nblexer/CssLanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/nblexer/NbCss3Lexer.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/nblexer/NbCss3Lexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/nblexer/NbLexerCharStream.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/nblexer/NbLexerCharStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/nbparser/CssParser.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/nbparser/CssParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParseTreeBuilder.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParseTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParser.java
+++ b/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3LexerTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3LexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3ParserLessTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3ParserLessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3ParserScssTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3ParserScssTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3ParserTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/Css3ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/CssTestBase.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/CssTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/TestUtil.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/W3CSelectorsTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/W3CSelectorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/NodeUtilTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/NodeUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarParserTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverListenerTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/PropertyDefinitionTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/PropertyDefinitionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/PropertyValueTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/PropertyValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/ResolvedPropertyTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/ResolvedPropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptorsTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/TokenizerTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/TokenizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/nblexer/NbCss3LexerTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/nblexer/NbCss3LexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/properties/GrammarParseTreeBuilderTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/properties/GrammarParseTreeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.lib/test/unit/src/org/netbeans/modules/css/lib/properties/GrammarParserTest.java
+++ b/css.lib/test/unit/src/org/netbeans/modules/css/lib/properties/GrammarParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/live/LiveUpdater.java
+++ b/css.model/src/org/netbeans/modules/css/live/LiveUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/ModelAccess.java
+++ b/css.model/src/org/netbeans/modules/css/model/ModelAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/Utils.java
+++ b/css.model/src/org/netbeans/modules/css/model/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/AtRule.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/AtRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/AtRuleId.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/AtRuleId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Body.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Body.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/BodyItem.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/BodyItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/CharSet.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/CharSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/CharSetValue.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/CharSetValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Declaration.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Declaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Declarations.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Declarations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Element.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/ElementFactory.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/ElementFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/ElementHandle.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/ElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/ElementListener.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/ElementListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Expression.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Expression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/FontFace.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/FontFace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/GenericAtRule.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/GenericAtRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/ImportItem.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/ImportItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Imports.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Imports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Media.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Media.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaBody.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaExpression.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaFeature.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaFeatureValue.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaFeatureValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaQuery.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaQueryList.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaQueryList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaQueryOperator.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaQueryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MediaType.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MediaType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Model.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/ModelUtils.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/ModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/ModelVisitor.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/ModelVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MozDocument.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MozDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/MozDocumentFunction.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/MozDocumentFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Namespace.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Namespace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/NamespacePrefixName.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/NamespacePrefixName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Namespaces.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Namespaces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Page.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Page.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/PlainElement.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/PlainElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Prio.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Prio.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Property.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Property.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/PropertyDeclaration.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/PropertyDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/PropertyValue.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/PropertyValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/ResourceIdentifier.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/ResourceIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Rule.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/Selector.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/Selector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/SelectorsGroup.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/SelectorsGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/StyleSheet.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/StyleSheet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/TokenElement.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/TokenElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/VendorAtRule.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/VendorAtRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/WebkitKeyframeSelectors.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/WebkitKeyframeSelectors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/WebkitKeyframes.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/WebkitKeyframes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/api/WebkitKeyframesBlock.java
+++ b/css.model/src/org/netbeans/modules/css/model/api/WebkitKeyframesBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/AtRuleI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/AtRuleI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/AtRuleIdI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/AtRuleIdI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/BodyI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/BodyI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/BodyItemI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/BodyItemI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/CharSetI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/CharSetI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/CharSetValueI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/CharSetValueI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/DeclarationI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/DeclarationI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/DeclarationsI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/DeclarationsI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ElementFactoryImpl.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ElementFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ElementHandleImpl.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ElementHandleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ExpressionI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ExpressionI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/FontFaceI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/FontFaceI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/GenericAtRuleI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/GenericAtRuleI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ImportItemI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ImportItemI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ImportsI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ImportsI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaBodyI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaBodyI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaBodyItem.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaBodyItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaBodyItemI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaBodyItemI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaExpressionI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaExpressionI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaFeatureI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaFeatureI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaFeatureValueI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaFeatureValueI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaQueryI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaQueryI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaQueryListI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaQueryListI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaQueryOperatorI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaQueryOperatorI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MediaTypeI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MediaTypeI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ModelElement.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ModelElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ModelElementListener.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ModelElementListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MozDocumentFunctionI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MozDocumentFunctionI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/MozDocumentI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/MozDocumentI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/NamespaceI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/NamespaceI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/NamespacePrefixNameI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/NamespacePrefixNameI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/NamespacesI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/NamespacesI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/PageI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/PageI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/PlainElementI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/PlainElementI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/PrioI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/PrioI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/PropertyDeclarationI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/PropertyDeclarationI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/PropertyI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/PropertyI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/PropertyValueI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/PropertyValueI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/ResourceIdentifierI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/ResourceIdentifierI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/RuleI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/RuleI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/SelectorI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/SelectorI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/SelectorsGroupI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/SelectorsGroupI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/StyleSheetI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/StyleSheetI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/Utils.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/VendorAtRuleI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/VendorAtRuleI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/WebkitKeyframeSelectorsI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/WebkitKeyframeSelectorsI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/WebkitKeyframesBlockI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/WebkitKeyframesBlockI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/WebkitKeyframesI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/WebkitKeyframesI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/src/org/netbeans/modules/css/model/impl/WsI.java
+++ b/css.model/src/org/netbeans/modules/css/model/impl/WsI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/TestUtils.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/api/ElementListenerTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/api/ElementListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelTestBase.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelUtilsTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelVisitorTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/api/ModelVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/api/StyleSheetTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/api/StyleSheetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/BodyITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/BodyITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/DeclarationITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/DeclarationITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/DeclarationsITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/DeclarationsITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/ElementHandleImplTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/ElementHandleImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/FontFaceITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/FontFaceITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/GenericAtRuleITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/GenericAtRuleITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/MediaITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/MediaITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/MediaQueryITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/MediaQueryITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/ModelElementTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/ModelElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/MozDocumentITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/MozDocumentITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/PropertyDeclarationITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/PropertyDeclarationITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/StyleSheetITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/StyleSheetITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/UtilsTest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/UtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.model/test/unit/src/org/netbeans/modules/css/model/impl/WebkitKeyframesITest.java
+++ b/css.model/test/unit/src/org/netbeans/modules/css/model/impl/WebkitKeyframesITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/CPOnSaveHook.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/CPOnSaveHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/CssPreprocessorType.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/CssPreprocessorType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPCategoryStructureItem.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPCategoryStructureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPCompletionItem.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPCslElementHandle.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPCslElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssEditorModule.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssEditorModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssIndexModel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssIndexModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPLexer.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPSemanticAnalyzer.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPSemanticAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPStructureItem.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPStructureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPTokenId.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPType.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/CPUtils.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/CPUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/EmptyDeclarationFinder.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/EmptyDeclarationFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/EmptyParser.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/EmptyParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/EmptyStructureScanner.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/EmptyStructureScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/MixinCompletionItem.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/MixinCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/VariableCompletionItem.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/VariableCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/less/LessCslLanguage.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/less/LessCslLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/less/LessEmbeddingProvider.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/less/LessEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/less/LessLanguage.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/less/LessLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPElement.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPElementHandle.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPElementType.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPElementType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPModel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/model/CPModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPActionsImplementationProvider.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPActionsImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPRefactoringPluginFactory.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPRefactoringPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPRenameRefactoringPlugin.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPRenameRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPRenameRefactoringUI.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPRenameRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPlugin.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/DiffElement.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/DiffElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/RefactoringElement.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/RefactoringElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/RefactoringElementContext.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/RefactoringElementContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/RenamePanel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/RenamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/WhereUsedElement.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/WhereUsedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/WhereUsedPanel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/WhereUsedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/WhereUsedUI.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/WhereUsedUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/scss/ScssCslLanguage.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/scss/ScssCslLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/scss/ScssEmbeddingProvider.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/scss/ScssEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/editor/scss/ScssLanguage.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/editor/scss/ScssLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/less/LessCssPreprocessor.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/less/LessCssPreprocessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/less/LessExecutable.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/less/LessExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/options/CssPrepOptions.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/options/CssPrepOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/options/CssPrepOptionsValidator.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/options/CssPrepOptionsValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/preferences/BasePreferences.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/preferences/BasePreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/preferences/CssPreprocessorPreferences.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/preferences/CssPreprocessorPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/preferences/CssPreprocessorPreferencesValidator.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/preferences/CssPreprocessorPreferencesValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/preferences/LessPreferences.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/preferences/LessPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/preferences/LessPreferencesValidator.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/preferences/LessPreferencesValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/preferences/SassPreferences.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/preferences/SassPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/preferences/SassPreferencesValidator.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/preferences/SassPreferencesValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/problems/BaseProjectProblemsProvider.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/problems/BaseProjectProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/problems/CustomizerProblemResolver.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/problems/CustomizerProblemResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/problems/Done.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/problems/Done.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/problems/LessProjectProblemsProvider.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/problems/LessProjectProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/problems/OptionsProblemResolver.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/problems/OptionsProblemResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/problems/SassProjectProblemsProvider.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/problems/SassProjectProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/process/BaseProcessor.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/process/BaseProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/process/LessProcessor.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/process/LessProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/process/SassProcessor.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/process/SassProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/sass/LibSassExecutable.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/sass/LibSassExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/sass/SassCli.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/sass/SassCli.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/sass/SassCssPreprocessor.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/sass/SassCssPreprocessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/sass/SassExecutable.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/sass/SassExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/customizer/CustomizerImpl.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/customizer/CustomizerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/customizer/CustomizerOptionsPanel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/customizer/CustomizerOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/customizer/OptionsPanel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/customizer/OptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/less/LessCssPreprocessorUI.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/less/LessCssPreprocessorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/options/LessOptions.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/options/LessOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/options/LessOptionsPanel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/options/LessOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/options/SassOptions.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/options/SassOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/options/SassOptionsPanel.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/options/SassOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/sass/SassCssPreprocessorUI.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/sass/SassCssPreprocessorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/ui/wizard/NewFileWizardIterator.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/ui/wizard/NewFileWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/BaseCssPreprocessor.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/BaseCssPreprocessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/CssPreprocessorUtils.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/CssPreprocessorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/FileUtils.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/InvalidExternalExecutableException.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/InvalidExternalExecutableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/StringUtils.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/UiUtils.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/UiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/VersionOutputProcessorFactory.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/VersionOutputProcessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/src/org/netbeans/modules/css/prep/util/Warnings.java
+++ b/css.prep/src/org/netbeans/modules/css/prep/util/Warnings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/GeneralCSSPrep.java
+++ b/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/GeneralCSSPrep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/cc/LessCompletionTest.java
+++ b/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/cc/LessCompletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/cc/SassCompletionTest.java
+++ b/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/cc/SassCompletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/syntax/LessSyntaxTest.java
+++ b/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/syntax/LessSyntaxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/syntax/SassSyntaxTest.java
+++ b/css.prep/test/qa-functional/src/org/netbeans/modules/css/prep/syntax/SassSyntaxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/CPCssIndexModelTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/CPCssIndexModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/ProjectTestBase.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/ProjectTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/SassParsingTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/SassParsingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/ScssFoldingTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/ScssFoldingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/ScssIndenterTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/ScssIndenterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/less/LessCompletionTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/less/LessCompletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/less/LessCompletionTest2.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/less/LessCompletionTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/less/LessLexerTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/less/LessLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/model/CPModelTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/model/CPModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPluginTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPluginTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/scss/ScssCompletionTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/scss/ScssCompletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/less/LessExecutableTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/less/LessExecutableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/sass/SassExecutableTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/sass/SassExecutableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/util/CssPreprocessorUtilsTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/util/CssPreprocessorUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.prep/test/unit/src/org/netbeans/modules/css/prep/util/WarningsTest.java
+++ b/css.prep/test/unit/src/org/netbeans/modules/css/prep/util/WarningsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/AutocompleteJComboBox.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/AutocompleteJComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/ComboBoxAutoCompleteSupport.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/ComboBoxAutoCompleteSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/CreateRulePanel.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/CreateRulePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/CssCaretAwareSourceTask.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/CssCaretAwareSourceTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/CssStylesListenerSupport.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/CssStylesListenerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/CssStylesPanel.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/CssStylesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/CssStylesTCController.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/CssStylesTCController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/CustomToolbar.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/CustomToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/DocumentNode.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/DocumentNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/DocumentViewModel.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/DocumentViewModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/DocumentViewPanel.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/DocumentViewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/DocumentViewPanelProvider.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/DocumentViewPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/EditRulesPanel.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/EditRulesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/FakeRootNode.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/FakeRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/Filter.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/HtmlEditorSourceTask.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/HtmlEditorSourceTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/HtmlSourceElementHandle.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/HtmlSourceElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/Installer.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/PageInspectorListener.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/PageInspectorListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/PropertyUtils.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/PropertyUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/PropertyValuesEditor.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/PropertyValuesEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/RuleEditorNode.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/RuleEditorNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/RuleEditorPanel.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/RuleEditorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/RuleEditorViews.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/RuleEditorViews.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/RuleNode.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/RuleNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/SelectorsGroupEditor.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/SelectorsGroupEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/StyleSheetNode.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/StyleSheetNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/ViewActionSupport.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/ViewActionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/ViewActions.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/ViewActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/actions/AddPropertyAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/actions/AddPropertyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/actions/DeleteRuleAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/actions/DeleteRuleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/actions/EditCSSRulesEditorAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/actions/EditCSSRulesEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/actions/EditCSSRulesNodeAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/actions/EditCSSRulesNodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/actions/GoToSourceAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/actions/GoToSourceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/actions/OpenLocationAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/actions/OpenLocationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/actions/RemovePropertyAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/actions/RemovePropertyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/api/CssStylesTC.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/api/CssStylesTC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/api/DeclarationInfo.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/api/DeclarationInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/api/EditCSSRulesAction.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/api/EditCSSRulesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/api/RuleEditorController.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/api/RuleEditorController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/api/ViewMode.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/api/ViewMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/spi/CssStylesListener.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/spi/CssStylesListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/spi/CssStylesPanelProvider.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/spi/CssStylesPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/src/org/netbeans/modules/css/visual/spi/RuleHandle.java
+++ b/css.visual/src/org/netbeans/modules/css/visual/spi/RuleHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/data/CSSTestProject/web/css/navigatorTest.css
+++ b/css.visual/test/qa-functional/data/CSSTestProject/web/css/navigatorTest.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/CSSTest.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/CSSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestBackgroundSettings.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestBackgroundSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestBasic.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestBasic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestFontSettings.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestFontSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestIssues.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/TestIssues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/operator/CSSPreviewOperator.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/operator/CSSPreviewOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/operator/StyleBuilderOperator.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/operator/StyleBuilderOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/operator/StyleRuleEditorOperator.java
+++ b/css.visual/test/qa-functional/src/org/netbeans/modules/css/test/operator/StyleRuleEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/css.visual/test/unit/src/org/netbeans/modules/css/visual/CssCaretAwareSourceTaskTest.java
+++ b/css.visual/test/unit/src/org/netbeans/modules/css/visual/CssCaretAwareSourceTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/LogFileLogger.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/LogFileLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecuteCookie.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecuteCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecuteLogger.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecuteLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecuteOptions.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecuteOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecution.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecutionInfo.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecutionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecutor.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLScript.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLScript.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLScriptStatement.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/SQLScriptStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/api/sql/execute/StatementExecutionInfo.java
+++ b/db.core/src/org/netbeans/modules/db/api/sql/execute/StatementExecutionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/core/SQLCoreUILogger.java
+++ b/db.core/src/org/netbeans/modules/db/core/SQLCoreUILogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/core/SQLOptions.java
+++ b/db.core/src/org/netbeans/modules/db/core/SQLOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/ColumnDef.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/ColumnDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/FetchLimitHandler.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/FetchLimitHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/NullValue.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/NullValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecuteHelper.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecuteHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecutionLogger.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecutionLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecutionResult.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecutionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecutionResults.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecutionResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/StatementInfo.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/StatementInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/execute/ui/SQLHistoryPanel.java
+++ b/db.core/src/org/netbeans/modules/db/sql/execute/ui/SQLHistoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/history/SQLHistory.java
+++ b/db.core/src/org/netbeans/modules/db/sql/history/SQLHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryEntry.java
+++ b/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryManager.java
+++ b/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/loader/SQLCloneableEditor.java
+++ b/db.core/src/org/netbeans/modules/db/sql/loader/SQLCloneableEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataLoader.java
+++ b/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataLoaderBeanInfo.java
+++ b/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataObject.java
+++ b/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
+++ b/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/loader/SQLExecutionLoggerImpl.java
+++ b/db.core/src/org/netbeans/modules/db/sql/loader/SQLExecutionLoggerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/src/org/netbeans/modules/db/sql/loader/SQLNode.java
+++ b/db.core/src/org/netbeans/modules/db/sql/loader/SQLNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/api/sql/execute/SQLExecutorTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/api/sql/execute/SQLExecutorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/SQLExecuteHelperTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/SQLExecuteHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/ui/util/DbUtil.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/ui/util/DbUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/ui/util/TestCaseContext.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/ui/util/TestCaseContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/ui/util/TestCaseDataFactory.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/execute/ui/util/TestCaseDataFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/history/SQLHistoryManagerTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/history/SQLHistoryManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/history/SQLHistoryPersistenceManagerTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/history/SQLHistoryPersistenceManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/history/SQLHistoryTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/history/SQLHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLDataLoaderBeanInfoTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLDataLoaderBeanInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLDataObjectTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLEditorSupportConsoleTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLEditorSupportConsoleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLEditorSupportNormalTest.java
+++ b/db.core/test/unit/src/org/netbeans/modules/db/sql/loader/SQLEditorSupportNormalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/api/DataView.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/api/DataView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/api/DataViewPageContext.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/api/DataViewPageContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBColumn.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBConnectionFactory.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBConnectionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBException.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBForeignKey.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBForeignKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBMetaDataFactory.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBMetaDataFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBModel.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBObject.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBPrimaryKey.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBPrimaryKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBTable.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/meta/DBTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/DataView.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/DataView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewActionHandler.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewDBTable.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewDBTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewPageContext.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewPageContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewTableUI.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewTableUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewTableUIModel.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewTableUIModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewUI.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/ErrorPositionExtractor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/ErrorPositionExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/InsertRecordDialog.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/InsertRecordDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/InsertRecordTableUI.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/InsertRecordTableUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLConstant.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLConstant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLExecutionHelper.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLExecutionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLStatementExecutor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLStatementExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLStatementGenerator.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/SQLStatementGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/ShowSQLDialog.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/ShowSQLDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/output/UpdatedRowContext.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/output/UpdatedRowContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/spi/DBConnectionProvider.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/spi/DBConnectionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/CellFocusCustomRenderer.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/CellFocusCustomRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/JXTableDecorator.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/JXTableDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/JXTableRowHeader.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/JXTableRowHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/MultiColPatternFilter.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/MultiColPatternFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetCellRenderer.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetJXTable.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetJXTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetTableCellEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetTableCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetTableModel.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/ResultSetTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/StringFallbackRowSorter.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/StringFallbackRowSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/SuperPatternFilter.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/SuperPatternFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/AlwaysEnable.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/AlwaysEnable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/BlobFieldTableCellEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/BlobFieldTableCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/BooleanTableCellEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/BooleanTableCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/ClobFieldTableCellEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/ClobFieldTableCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/DateTimePickerCellEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/DateTimePickerCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/MonitorableCharacterStreamTransfer.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/MonitorableCharacterStreamTransfer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/MonitorableStreamTransfer.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/MonitorableStreamTransfer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/NumberFieldEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/NumberFieldEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/StringTableCellEditor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/StringTableCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/BinaryToStringConverter.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/BinaryToStringConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/CharsetSelector.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/CharsetSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/ColorHelper.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/ColorHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelper.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/DataViewUtils.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/DataViewUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/DateType.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/DateType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/EncodingHelper.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/EncodingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/FileBackedBlob.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/FileBackedBlob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/FileBackedClob.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/FileBackedClob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/FormatStringValue.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/FormatStringValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/LobHelper.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/LobHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/RandomAccessInputStream.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/RandomAccessInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/RandomAccessOutputStream.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/RandomAccessOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/RelativeColor.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/RelativeColor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/StringValue.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/StringValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/TimeType.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/TimeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/src/org/netbeans/modules/db/dataview/util/TimestampType.java
+++ b/db.dataview/src/org/netbeans/modules/db/dataview/util/TimestampType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/api/ApiSuite.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/api/ApiSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/api/DataViewPageContextTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/api/DataViewPageContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/api/DataViewTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/api/DataViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBColumnTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBColumnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBConnectionFactoryTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBConnectionFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBForeignKeyTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBForeignKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBMetaDataFactoryTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBMetaDataFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBModelTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBPrimaryKeyTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBPrimaryKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBTableTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/DBTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/MetaSuite.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/meta/MetaSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewActionHandlerTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewActionHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewDBTableTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewDBTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewPageContextTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewPageContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTablePanelTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTablePanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTableSorterTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTableSorterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTableUITest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTableUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewUITest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/DataViewUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/InsertRecordTableUITest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/InsertRecordTableUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/OutputSuite.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/OutputSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/SQLExecutionHelperTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/SQLExecutionHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/SQLStatementExecutorTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/SQLStatementExecutorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/SQLStatementGeneratorTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/SQLStatementGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/ShowSQLDialogTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/ShowSQLDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/UpdatedRowContextTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/output/UpdatedRowContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/spi/DBConnectionProviderImpl.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/spi/DBConnectionProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/spi/DBConnectionProviderImplTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/spi/DBConnectionProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/spi/SpiSuite.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/spi/SpiSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/BinaryToStringConverterTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/BinaryToStringConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelperTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DBTestUtil.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DBTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DataViewUtilsTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DataViewUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DateTypeTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DateTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DbUtil.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DbUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/FileBackedBlobTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/FileBackedBlobTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/FileBackedClobTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/FileBackedClobTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TestCaseContext.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TestCaseContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TestCaseDataFactory.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TestCaseDataFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TimeTypeTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TimeTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TimestampTypeTest.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/TimestampTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/UtilSuite.java
+++ b/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/UtilSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/JDBCConnMetadataModel.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/JDBCConnMetadataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/MetadataAccessor.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/MetadataAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/MetadataModelImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/MetadataModelImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/MetadataUtilities.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/MetadataUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Action.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Catalog.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Catalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Column.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Column.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/ForeignKey.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/ForeignKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/ForeignKeyColumn.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/ForeignKeyColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Function.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Function.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Index.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/IndexColumn.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/IndexColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Metadata.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Metadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataElement.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataElementHandle.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataException.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataModel.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataModelException.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataModelException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataModels.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/MetadataModels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Nullable.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Nullable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Ordering.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Ordering.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Parameter.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Parameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/PrimaryKey.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/PrimaryKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Procedure.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Procedure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/SQLType.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/SQLType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Schema.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Schema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Table.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Table.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Tuple.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Tuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Value.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/View.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/api/View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCCatalog.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCColumn.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCForeignKey.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCForeignKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCForeignKeyColumn.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCForeignKeyColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCFunction.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCIndex.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCIndexColumn.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCIndexColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadata.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCParameter.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCPrimaryKey.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCPrimaryKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCProcedure.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCProcedure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCSchema.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCTable.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCUtils.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCValue.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCView.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mssql/MSSQLMetadata.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mssql/MSSQLMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLMetadata.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLProcedure.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLProcedure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLSchema.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/oracle/OracleMetadata.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/oracle/OracleMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/oracle/OracleSchema.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/oracle/OracleSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/CatalogImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/CatalogImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ColumnImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ColumnImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ForeignKeyColumnImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ForeignKeyColumnImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ForeignKeyImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ForeignKeyImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/FunctionImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/FunctionImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/IndexColumnImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/IndexColumnImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/IndexImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/IndexImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/MetadataImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/MetadataImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ParameterImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ParameterImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/PrimaryKeyImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/PrimaryKeyImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ProcedureImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ProcedureImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/SchemaImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/SchemaImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/TableImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/TableImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ValueImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ValueImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ViewImplementation.java
+++ b/db.metadata.model/src/org/netbeans/modules/db/metadata/model/spi/ViewImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/api/MetadataElementHandleTest.java
+++ b/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/api/MetadataElementHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataDerbyTest.java
+++ b/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataDerbyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataMySQLTest.java
+++ b/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataMySQLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataTestBase.java
+++ b/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/test/api/MetadataModelTestUtilities.java
+++ b/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/test/api/MetadataModelTestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/test/api/MetadataTestBase.java
+++ b/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/test/api/MetadataTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/Database.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/Database.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/DatabaseServer.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/DatabaseServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/DatabaseServerManager.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/DatabaseServerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/DatabaseUser.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/DatabaseUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/AdministerAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/AdministerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/ConnectAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/ConnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/ConnectServerAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/ConnectServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/CreateDatabaseAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/CreateDatabaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/DisconnectServerAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/DisconnectServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/PropertiesAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/PropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/RefreshServerAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/RefreshServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/RegisterServerAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/RegisterServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/StartAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/StartAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/actions/StopAction.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/actions/StopAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/BaseSampleProvider.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/BaseSampleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/ConnectManager.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/ConnectManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/ConnectionProcessor.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/ConnectionProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/DbExplorerConnectionListener.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/DbExplorerConnectionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/Installation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/Installation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/InstallationManager.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/InstallationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/MultiInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/MultiInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/MySQLActionProvider.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/MySQLActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/MySQLDatabaseServer.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/MySQLDatabaseServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/MySQLOptions.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/MySQLOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/SampleManager.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/SampleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/SampleProviderHelper.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/SampleProviderHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/ServerNodeProvider.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/ServerNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/StartManager.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/StartManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/impl/StopManager.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/impl/StopManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/BundledInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/BundledInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/LinuxStandaloneInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/LinuxStandaloneInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/LinuxXAMPPInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/LinuxXAMPPInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/MAMPInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/MAMPInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/SXDEWebStackInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/SXDEWebStackInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/WindowsStandaloneInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/WindowsStandaloneInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/WindowsStandaloneMultiInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/WindowsStandaloneMultiInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/WindowsXAMPPInstallation.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/WindowsXAMPPInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/installations/ui/SelectInstallationPanel.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/installations/ui/SelectInstallationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/nodes/DatabaseNode.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/nodes/DatabaseNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/nodes/ServerNode.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/nodes/ServerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/spi/sample/SampleProvider.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/spi/sample/SampleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/ui/AdminPropertiesPanel.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/ui/AdminPropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/ui/BasePropertiesPanel.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/ui/BasePropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/ui/CreateDatabasePanel.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/ui/CreateDatabasePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/ui/PropertiesDialog.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/ui/PropertiesDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/util/DatabaseUtils.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/util/DatabaseUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/util/DriverClassLoader.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/util/DriverClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/util/ExecSupport.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/util/ExecSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/src/org/netbeans/modules/db/mysql/util/Utils.java
+++ b/db.mysql/src/org/netbeans/modules/db/mysql/util/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/test/unit/src/org/netbeans/modules/db/mysql/impl/MySQLDatabaseServerTest.java
+++ b/db.mysql/test/unit/src/org/netbeans/modules/db/mysql/impl/MySQLDatabaseServerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/test/unit/src/org/netbeans/modules/db/mysql/impl/SampleManagerTest.java
+++ b/db.mysql/test/unit/src/org/netbeans/modules/db/mysql/impl/SampleManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.mysql/test/unit/src/org/netbeans/modules/db/mysql/test/TestBase.java
+++ b/db.mysql/test/unit/src/org/netbeans/modules/db/mysql/test/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/CreateStatement.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/CreateStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/CreateStatementAnalyzer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/CreateStatementAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DeleteStatement.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DeleteStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DeleteStatementAnalyzer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DeleteStatementAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DropStatement.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DropStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DropStatementAnalyzer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/DropStatementAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/InsertStatement.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/InsertStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/InsertStatementAnalyzer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/InsertStatementAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/QualIdent.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/QualIdent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SQLStatement.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SQLStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SQLStatementAnalyzer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SQLStatementAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SQLStatementKind.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SQLStatementKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SelectStatement.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SelectStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SelectStatementAnalyzer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/SelectStatementAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/TablesClause.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/TablesClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/UpdateStatement.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/UpdateStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/UpdateStatementAnalyzer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/analyzer/UpdateStatementAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/OptionsUtils.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/OptionsUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLBracesMatcher.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLBracesMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLEditorProviderImpl.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLEditorProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLFileEncodingQueryImpl.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLFileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLTypedTextInterceptor.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLTypedTextInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/StringUtils.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SQLCompletion.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SQLCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SQLCompletionContext.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SQLCompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SQLCompletionResultSet.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SQLCompletionResultSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SubstitutionHandler.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/api/completion/SubstitutionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionEnv.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionItem.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionItems.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionItems.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionProvider.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionQuery.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/completion/SQLCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/ConnectionAction.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/ConnectionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/RunSQLSelectionAction.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/RunSQLSelectionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SQLExecutionBaseAction.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SQLExecutionBaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SQLHistoryAction.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SQLHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SelectConnectionPanel.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SelectConnectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SelectInExplorerAction.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/SelectInExplorerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/ToggleKeepOldResultTabsAction.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/editor/ui/actions/ToggleKeepOldResultTabsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/LexerUtilities.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/LexerUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/SQLLanguageConfig.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/SQLLanguageConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/SQLLexer.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/SQLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/SQLTokenId.java
+++ b/db.sql.editor/src/org/netbeans/modules/db/sql/lexer/SQLTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/CreateStatementAnalyzerTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/CreateStatementAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/DeleteStatementAnalyzerTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/DeleteStatementAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/DropStatementAnalyzerTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/DropStatementAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/InsertStatementAnalyzerTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/InsertStatementAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/QualIdentTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/QualIdentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/SelectStatementAnalyzerTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/SelectStatementAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/UpdateStatementAnalyzerTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/analyzer/UpdateStatementAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/RepositoryImpl.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/SQLTypedTextInterceptorTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/SQLTypedTextInterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/TestBase.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/CompletionQueryTestCase.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/CompletionQueryTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/CreateCompletionQueryTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/CreateCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/DeleteCompletionQueryTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/DeleteCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/InsertCompletionQueryTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/InsertCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/KeywordCompletionQueryTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/KeywordCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/SelectCompletionQueryTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/SelectCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/TestMetadata.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/TestMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/TestMetadataTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/TestMetadataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/UpdateCompletionQueryTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/UpdateCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/ui/actions/SQLExecutionBaseActionTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/ui/actions/SQLExecutionBaseActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/lexer/SQLLexerTest.java
+++ b/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/lexer/SQLLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/Log.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/Log.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/QueryEditorUILogger.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/QueryEditorUILogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/api/VisualSQLEditor.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/api/VisualSQLEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/api/VisualSQLEditorFactory.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/api/VisualSQLEditorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/api/VisualSQLEditorMetaData.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/api/VisualSQLEditorMetaData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/parser/SQLParser.jj
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/parser/SQLParser.jj
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/AddQueryParameterDlg.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/AddQueryParameterDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/AddTableDlg.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/AddTableDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/CondNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/CondNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/InternalVSEMetaDataImpl.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/InternalVSEMetaDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/JoinNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/JoinNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/ParameterizedQueryDialog.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/ParameterizedQueryDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QBGraphScene.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QBGraphScene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QBNodeComponent.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QBNodeComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderGraphFrame.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderGraphFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderInputTable.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderInputTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderInputTableModel.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderInputTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderInternalFrame.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderInternalFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderMetaData.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderMetaData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderPane.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderResultTable.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderResultTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderSqlCompletion.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderSqlCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderSqlTextArea.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderSqlTextArea.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderTable.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderTableModel.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryModel.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/SqlStatement.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/SqlStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/TableNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/TableNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/VisualSQLEditorProviderImpl.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/VisualSQLEditorProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/And.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/And.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/AndNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/AndNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/BooleanExpressionList.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/BooleanExpressionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Column.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Column.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ColumnItem.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ColumnItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ColumnNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ColumnNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ColumnProvider.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ColumnProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Expression.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Expression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ExpressionList.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/ExpressionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/From.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/From.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/FromNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/FromNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/GroupBy.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/GroupBy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/GroupByNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/GroupByNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Having.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Having.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/HavingNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/HavingNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Identifier.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Identifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/JoinRestriction.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/JoinRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/JoinTable.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/JoinTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/JoinTableNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/JoinTableNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Literal.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Literal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Not.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Not.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/NotNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/NotNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Or.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Or.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderBy.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderBy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderByNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderByNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Predicate.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Predicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Query.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryItem.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SQLQueryFactory.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SQLQueryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Select.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Select.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SelectNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SelectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SetFunction.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SetFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SortSpecification.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SortSpecification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Table.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Table.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/TableNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/TableNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/UnaryExpression.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/UnaryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Value.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Where.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/Where.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/WhereNode.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/WhereNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/ui/ConnectionStatusPanel.java
+++ b/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/ui/ConnectionStatusPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/Argument.java
+++ b/db/libsrc/org/netbeans/lib/ddl/Argument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/CheckConstraintDescriptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/CheckConstraintDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/ColumnOperationCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/ColumnOperationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/CommandNotSupportedException.java
+++ b/db/libsrc/org/netbeans/lib/ddl/CommandNotSupportedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/CommentOperationCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/CommentOperationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/CreateProcedureCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/CreateProcedureCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/CreateTableCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/CreateTableCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/CreateTriggerCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/CreateTriggerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/CreateViewCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/CreateViewCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DBConnection.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DBConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DDLCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DDLCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DDLException.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DDLException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DatabaseProductNotFoundException.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DatabaseProductNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DatabaseSpecification.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DatabaseSpecification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DatabaseSpecificationFactory.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DatabaseSpecificationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DriverProductNotFoundException.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DriverProductNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/DriverSpecificationFactory.java
+++ b/db/libsrc/org/netbeans/lib/ddl/DriverSpecificationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/ForeignKeyConstraintDescriptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/ForeignKeyConstraintDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/FunctionDescriptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/FunctionDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/OwnedObjectCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/OwnedObjectCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/ProcedureDescriptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/ProcedureDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/TableColumnDescriptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/TableColumnDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/TableConstraintDescriptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/TableConstraintDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/TriggerDescriptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/TriggerDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/adaptors/DatabaseMetaDataAdaptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/adaptors/DatabaseMetaDataAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/adaptors/DefaultAdaptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/adaptors/DefaultAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/adaptors/DefaultAdaptorBeanInfo.java
+++ b/db/libsrc/org/netbeans/lib/ddl/adaptors/DefaultAdaptorBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/adaptors/OracleAdaptor.java
+++ b/db/libsrc/org/netbeans/lib/ddl/adaptors/OracleAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/AbstractCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/AbstractCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/AbstractTableColumn.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/AbstractTableColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/AddColumn.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/AddColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/ColumnCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/ColumnCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/ColumnListCommand.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/ColumnListCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CommentTable.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CommentTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CommentView.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CommentView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CreateFunction.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CreateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CreateIndex.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CreateIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CreateProcedure.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CreateProcedure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CreateTable.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CreateTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CreateTrigger.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CreateTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/CreateView.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/CreateView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/DriverSpecification.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/DriverSpecification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/DropIndex.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/DropIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/ForeignKeyConstraint.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/ForeignKeyConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/ModifyColumn.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/ModifyColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/PrimaryKeyConstraint.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/PrimaryKeyConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/ProcedureArgument.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/ProcedureArgument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/RemoveColumn.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/RemoveColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/RenameColumn.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/RenameColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/RenameTable.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/RenameTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/RenameView.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/RenameView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/SetDefaultDatabase.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/SetDefaultDatabase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/SetDefaultSchema.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/SetDefaultSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/Specification.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/Specification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/SpecificationFactory.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/SpecificationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/SpecificationParser.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/SpecificationParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/TableColumn.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/TableColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/impl/TriggerEvent.java
+++ b/db/libsrc/org/netbeans/lib/ddl/impl/TriggerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/resources/dbspec.plist
+++ b/db/libsrc/org/netbeans/lib/ddl/resources/dbspec.plist
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/resources/driverspec.plist
+++ b/db/libsrc/org/netbeans/lib/ddl/resources/driverspec.plist
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/util/CommandBuffer.java
+++ b/db/libsrc/org/netbeans/lib/ddl/util/CommandBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/util/CommandFormatter.java
+++ b/db/libsrc/org/netbeans/lib/ddl/util/CommandFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/libsrc/org/netbeans/lib/ddl/util/PListReader.java
+++ b/db/libsrc/org/netbeans/lib/ddl/util/PListReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/ConnectionListener.java
+++ b/db/src/org/netbeans/api/db/explorer/ConnectionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/ConnectionManager.java
+++ b/db/src/org/netbeans/api/db/explorer/ConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/DatabaseConnection.java
+++ b/db/src/org/netbeans/api/db/explorer/DatabaseConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/DatabaseException.java
+++ b/db/src/org/netbeans/api/db/explorer/DatabaseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/DatabaseMetaDataTransfer.java
+++ b/db/src/org/netbeans/api/db/explorer/DatabaseMetaDataTransfer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/JDBCDriver.java
+++ b/db/src/org/netbeans/api/db/explorer/JDBCDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/JDBCDriverListener.java
+++ b/db/src/org/netbeans/api/db/explorer/JDBCDriverListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/JDBCDriverManager.java
+++ b/db/src/org/netbeans/api/db/explorer/JDBCDriverManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/node/BaseNode.java
+++ b/db/src/org/netbeans/api/db/explorer/node/BaseNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/node/ChildNodeFactory.java
+++ b/db/src/org/netbeans/api/db/explorer/node/ChildNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/node/NodeProvider.java
+++ b/db/src/org/netbeans/api/db/explorer/node/NodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/node/NodeProviderFactory.java
+++ b/db/src/org/netbeans/api/db/explorer/node/NodeProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/explorer/support/DatabaseExplorerUIs.java
+++ b/db/src/org/netbeans/api/db/explorer/support/DatabaseExplorerUIs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/api/db/sql/support/SQLIdentifiers.java
+++ b/db/src/org/netbeans/api/db/sql/support/SQLIdentifiers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/DatabaseModule.java
+++ b/db/src/org/netbeans/modules/db/DatabaseModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/ExceptionListener.java
+++ b/db/src/org/netbeans/modules/db/ExceptionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/ConnectionList.java
+++ b/db/src/org/netbeans/modules/db/explorer/ConnectionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseConnection.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseConnectionAccessor.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseConnectionAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertor.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseConnector.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseDriver.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseMetaDataTransferAccessor.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseMetaDataTransferAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseTypePropertyEditor.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseTypePropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DatabaseUILogger.java
+++ b/db/src/org/netbeans/modules/db/explorer/DatabaseUILogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbActionLoader.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbActionLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbActionLoaderSupport.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbActionLoaderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbExtendedDelete.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbExtendedDelete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbMetaDataListener.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbMetaDataListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbMetaDataListenerSupport.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbMetaDataListenerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbMetaDataTransferProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbMetaDataTransferProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbNodeLoader.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbNodeLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbNodeLoaderSupport.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbNodeLoaderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbURLClassLoader.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbURLClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DbUtilities.java
+++ b/db/src/org/netbeans/modules/db/explorer/DbUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DerbyConectionEventListener.java
+++ b/db/src/org/netbeans/modules/db/explorer/DerbyConectionEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/DriverExtendedDeleteImpl.java
+++ b/db/src/org/netbeans/modules/db/explorer/DriverExtendedDeleteImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/OpenConnection.java
+++ b/db/src/org/netbeans/modules/db/explorer/OpenConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/OpenConnectionInterface.java
+++ b/db/src/org/netbeans/modules/db/explorer/OpenConnectionInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/ProgressPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/ProgressPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/TableExtendedDelete.java
+++ b/db/src/org/netbeans/modules/db/explorer/TableExtendedDelete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/AddColumnAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/AddColumnAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/AddConnectionAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/AddConnectionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/AddDriverAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/AddDriverAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/AddIndexAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/AddIndexAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/BaseAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/BaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/ConnectAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/ConnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/ConnectUsingDriverAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/ConnectUsingDriverAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/CreateTableAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/CreateTableAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/CreateViewAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/CreateViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/CustomizeDriverAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/CustomizeDriverAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/DisconnectAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/DisconnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/EditSourceCodeAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/EditSourceCodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/ExecuteCommandAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/ExecuteCommandAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/GrabTableAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/GrabTableAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/GrabTableHelper.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/GrabTableHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/MakeDefaultCatalogAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/MakeDefaultCatalogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/MakeDefaultSchemaAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/MakeDefaultSchemaAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/QueryAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/QueryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/RecreateTableAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/RecreateTableAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/RefreshAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/RefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/ToggleImportantAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/ToggleImportantAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/ViewDataAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/ViewDataAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/action/ViewSourceCodeAction.java
+++ b/db/src/org/netbeans/modules/db/explorer/action/ViewSourceCodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddConnectionWizard.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddConnectionWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddIndexDDL.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddIndexDDL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddIndexDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddIndexDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddTableColumnDDL.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddTableColumnDDL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddTableColumnDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddTableColumnDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddViewDDL.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddViewDDL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/AddViewDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/AddViewDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingConnectionNamePanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingConnectionNamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingDriverPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingDriverPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingDriverUI.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingDriverUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingSchemaPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingSchemaPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ColumnItem.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ColumnItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ConnectPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ConnectPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ConnectProgressDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ConnectProgressDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionDialogMediator.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionDialogMediator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionNamePanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionNamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionProgressListener.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionProgressListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/CreateTableDDL.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/CreateTableDDL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/CreateTableDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/CreateTableDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/DataModel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/DataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/GrabTableProgressPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/GrabTableProgressPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/LabeledTextFieldDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/LabeledTextFieldDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/NewConnectionPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/NewConnectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/SchemaPanel.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/SchemaPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/TypeElement.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/TypeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/dlg/ViewProcedureDialog.java
+++ b/db/src/org/netbeans/modules/db/explorer/dlg/ViewProcedureDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertor.java
+++ b/db/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/driver/JDBCDriverSupport.java
+++ b/db/src/org/netbeans/modules/db/explorer/driver/JDBCDriverSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/metadata/MetadataModelManager.java
+++ b/db/src/org/netbeans/modules/db/explorer/metadata/MetadataModelManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/BaseFilterNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/BaseFilterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/CatalogNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/CatalogNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/CatalogNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/CatalogNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ColumnNameProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ColumnNameProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ColumnNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ColumnNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ColumnNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ColumnNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ConnectedNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ConnectedNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ConnectionNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ConnectionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ConnectionNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ConnectionNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/DDLHelper.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/DDLHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/DriverListNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/DriverListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/DriverListNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/DriverListNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/DriverNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/DriverNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/DriverNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/DriverNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyColumnNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyColumnNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyColumnNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyColumnNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyListNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyListNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyListNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ForeignKeyNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/IndexColumnNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/IndexColumnNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/IndexColumnNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/IndexColumnNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/IndexListNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/IndexListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/IndexListNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/IndexListNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/IndexNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/IndexNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/IndexNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/IndexNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/NodeDataLookup.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/NodeDataLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/NodePropertySupport.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/NodePropertySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/NodeRegistry.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/NodeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ProcedureListNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ProcedureListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ProcedureListNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ProcedureListNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ProcedureNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ProcedureNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ProcedureNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ProcedureNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ProcedureParamNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ProcedureParamNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ProcedureParamNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ProcedureParamNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ReturnValueNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ReturnValueNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/RootNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/SchemaNameProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/SchemaNameProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/SchemaNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/SchemaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/SchemaNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/SchemaNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/TableListNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/TableListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/TableListNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/TableListNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/TableNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/TableNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/TableNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/TableNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ToggleImportantInfo.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ToggleImportantInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ViewListNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ViewListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ViewListNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ViewListNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ViewNode.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ViewNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/node/ViewNodeProvider.java
+++ b/db/src/org/netbeans/modules/db/explorer/node/ViewNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/sql/editor/SQLEditorSupport.java
+++ b/db/src/org/netbeans/modules/db/explorer/sql/editor/SQLEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/explorer/sql/visualeditor/VisualSQLEditorSupport.java
+++ b/db/src/org/netbeans/modules/db/explorer/sql/visualeditor/VisualSQLEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/resources/CreateTableDialog.plist
+++ b/db/src/org/netbeans/modules/db/resources/CreateTableDialog.plist
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/runtime/DatabaseRuntimeManager.java
+++ b/db/src/org/netbeans/modules/db/runtime/DatabaseRuntimeManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/spi/sql/editor/SQLEditorProvider.java
+++ b/db/src/org/netbeans/modules/db/spi/sql/editor/SQLEditorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/spi/sql/visualeditor/VisualSQLEditorProvider.java
+++ b/db/src/org/netbeans/modules/db/spi/sql/visualeditor/VisualSQLEditorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/Base64.java
+++ b/db/src/org/netbeans/modules/db/util/Base64.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/DataComboBoxModel.java
+++ b/db/src/org/netbeans/modules/db/util/DataComboBoxModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/DataComboBoxSupport.java
+++ b/db/src/org/netbeans/modules/db/util/DataComboBoxSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/DatabaseExplorerInternalUIs.java
+++ b/db/src/org/netbeans/modules/db/util/DatabaseExplorerInternalUIs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/DriverListUtil.java
+++ b/db/src/org/netbeans/modules/db/util/DriverListUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/JdbcUrl.java
+++ b/db/src/org/netbeans/modules/db/util/JdbcUrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/PropertiesEditor.java
+++ b/db/src/org/netbeans/modules/db/util/PropertiesEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/modules/db/util/PropertyEditorPanel.java
+++ b/db/src/org/netbeans/modules/db/util/PropertyEditorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/src/org/netbeans/spi/db/explorer/DatabaseRuntime.java
+++ b/db/src/org/netbeans/spi/db/explorer/DatabaseRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/antsrc/org/netbeans/db/antext/StopPointBaseServer.java
+++ b/db/test/antsrc/org/netbeans/db/antext/StopPointBaseServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/data/DummyDriver.java
+++ b/db/test/unit/data/DummyDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/api/db/explorer/DatabaseConnectionTest.java
+++ b/db/test/unit/src/org/netbeans/api/db/explorer/DatabaseConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/api/db/explorer/JDBCDriverManagerTest.java
+++ b/db/test/unit/src/org/netbeans/api/db/explorer/JDBCDriverManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/api/db/explorer/support/DatabaseExplorerUIsTest.java
+++ b/db/test/unit/src/org/netbeans/api/db/explorer/support/DatabaseExplorerUIsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/api/db/sql/support/NonASCIIQuoter.java
+++ b/db/test/unit/src/org/netbeans/api/db/sql/support/NonASCIIQuoter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/api/db/sql/support/NonASCIIQuoterTest.java
+++ b/db/test/unit/src/org/netbeans/api/db/sql/support/NonASCIIQuoterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/api/db/sql/support/QuoterTest.java
+++ b/db/test/unit/src/org/netbeans/api/db/sql/support/QuoterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/DatabaseModuleTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/DatabaseModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/ConnectionListTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/ConnectionListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertor2Test.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertor2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertorTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectorTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/DbDriverManagerTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/DbDriverManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/DbUtilitiesTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/DbUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/action/GrabTableHelperTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/action/GrabTableHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddConnectionWizardTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddConnectionWizardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddIndexDDLTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddIndexDDLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddTableColumnDDLTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddTableColumnDDLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddViewDDLTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/AddViewDDLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/CreateTableDDLTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/dlg/CreateTableDDLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertorTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/node/ColumnNodeTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/node/ColumnNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/node/ConnectionNodeTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/node/ConnectionNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/node/DDLHelperTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/node/DDLHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/node/RootNodeTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/node/RootNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/node/TableNodeTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/node/TableNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/node/ViewNodeTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/node/ViewNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/explorer/test/api/SQLIdentifiersTestUtilities.java
+++ b/db/test/unit/src/org/netbeans/modules/db/explorer/test/api/SQLIdentifiersTestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DBProvider.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DBProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DBTestBase.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DBTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DDLTestBase.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DDLTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DOMCompare.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DOMCompare.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DatabaseMetaDataAdapter.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DatabaseMetaDataAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DefaultDBProvider.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DefaultDBProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DerbyDBProvider.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DerbyDBProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/DriverClassLoader.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/DriverClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/MySQLDBProvider.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/MySQLDBProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/RepositoryImpl.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/ResultSetAdapter.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/ResultSetAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/TestBase.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/test/Util.java
+++ b/db/test/unit/src/org/netbeans/modules/db/test/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/util/Base64Test.java
+++ b/db/test/unit/src/org/netbeans/modules/db/util/Base64Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/util/DataComboBoxSupportTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/util/DataComboBoxSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/util/DatabaseExplorerInternalUIsTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/util/DatabaseExplorerInternalUIsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
+++ b/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/db/api/explorer/ActionProvider.java
+++ b/dbapi/src/org/netbeans/modules/db/api/explorer/ActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/db/api/explorer/MetaDataListener.java
+++ b/dbapi/src/org/netbeans/modules/db/api/explorer/MetaDataListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/db/api/explorer/NodeProvider.java
+++ b/dbapi/src/org/netbeans/modules/db/api/explorer/NodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/db/api/metadata/DBConnMetadataModelManager.java
+++ b/dbapi/src/org/netbeans/modules/db/api/metadata/DBConnMetadataModelManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/db/api/sql/SQLKeywords.java
+++ b/dbapi/src/org/netbeans/modules/db/api/sql/SQLKeywords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/dbapi/DbActionLoaderImpl.java
+++ b/dbapi/src/org/netbeans/modules/dbapi/DbActionLoaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/dbapi/DbMetaDataListenerImpl.java
+++ b/dbapi/src/org/netbeans/modules/dbapi/DbMetaDataListenerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/src/org/netbeans/modules/dbapi/DbNodeLoaderImpl.java
+++ b/dbapi/src/org/netbeans/modules/dbapi/DbNodeLoaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/test/unit/src/org/netbeans/modules/db/api/metadata/DBConnMetadataModelManagerTest.java
+++ b/dbapi/test/unit/src/org/netbeans/modules/db/api/metadata/DBConnMetadataModelManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/test/unit/src/org/netbeans/modules/db/api/sql/SQLKeywordsTest.java
+++ b/dbapi/test/unit/src/org/netbeans/modules/db/api/sql/SQLKeywordsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbapi/test/unit/src/org/netbeans/modules/dbapi/DbMetaDataListenerImplTest.java
+++ b/dbapi/test/unit/src/org/netbeans/modules/dbapi/DbMetaDataListenerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/ColumnElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/ColumnElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/ColumnElementHolder.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/ColumnElementHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/ColumnPairElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/ColumnPairElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/ColumnPairElementHolder.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/ColumnPairElementHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/DBElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/DBElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/DBElementProperties.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/DBElementProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/DBElementProvider.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/DBElementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/DBException.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/DBException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/DBIdentifier.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/DBIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/DBMemberElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/DBMemberElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/ForeignKeyElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/ForeignKeyElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/IndexElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/IndexElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/KeyElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/KeyElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/ReferenceKey.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/ReferenceKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/SchemaElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/SchemaElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/SchemaElementUtil.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/SchemaElementUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/TableElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/TableElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/UniqueKeyElement.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/UniqueKeyElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/CaptureSchemaAction.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/CaptureSchemaAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ColumnElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ColumnElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ColumnPairElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ColumnPairElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ConnectionProvider.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ConnectionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBMemberElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBMemberElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataLoader.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataLoaderBeanInfo.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataObject.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBschemaDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DDLBridge.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DDLBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ForeignKeyElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ForeignKeyElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/IndexElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/IndexElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/KeyElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/KeyElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/MetaDataUtil.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/MetaDataUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/RecaptureSchemaAction.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/RecaptureSchemaAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/UniqueKeyElementImpl.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/UniqueKeyElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ViewDependency.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ViewDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/CaptureSchema.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/CaptureSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/ChooseConnectionPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/ChooseConnectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaConnectionPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaConnectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaConnectionWizardPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaConnectionWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesWizardPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTargetPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTargetPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaWizardData.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaWizardData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaWizardIterator.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/ProgressFrame.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/ProgressFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/ProgressPanel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/ProgressPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/RecaptureSchema.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/RecaptureSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/SortedListModel.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/SortedListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/MapClassName.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/MapClassName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/XMLInputStream.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/XMLInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/XMLOutputStream.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/XMLOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/ArrayListStack.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/ArrayListStack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/BaseSpecificXMLDeserializer.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/BaseSpecificXMLDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/BaseXMLDeserializer.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/BaseXMLDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/NewInstanceHelper.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/NewInstanceHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/SpecificXMLDeserializer.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/SpecificXMLDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/XMLDeserializer.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/XMLDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/XMLGraphDeserializer.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/XMLGraphDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/serializer/XMLGraphSerializer.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/serializer/XMLGraphSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/ColumnElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/ColumnElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/ColumnPairElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/ColumnPairElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/DBElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/DBElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/DBElementNodeFactory.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/DBElementNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/DBMemberElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/DBMemberElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/DefaultDBFactory.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/DefaultDBFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/ForeignKeyElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/ForeignKeyElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/IconStrings.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/IconStrings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/IndexElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/IndexElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaChildren.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaElementFilter.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaElementFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaRootChildren.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/SchemaRootChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/TableChildren.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/TableChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/TableElementFilter.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/TableElementFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/nodes/TableElementNode.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/nodes/TableElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/util/IDEUtil.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/util/IDEUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/util/NameUtil.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/util/NameUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/src/org/netbeans/modules/dbschema/util/SQLTypeUtil.java
+++ b/dbschema/src/org/netbeans/modules/dbschema/util/SQLTypeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/test/unit/src/org/netbeans/modules/dbschema/ColumnElementTest.java
+++ b/dbschema/test/unit/src/org/netbeans/modules/dbschema/ColumnElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/test/unit/src/org/netbeans/modules/dbschema/migration/archiver/serializer/XMLGraphSerializerTest.java
+++ b/dbschema/test/unit/src/org/netbeans/modules/dbschema/migration/archiver/serializer/XMLGraphSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/DbSupport.java
+++ b/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/DbSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/JavaDbSupport.java
+++ b/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/JavaDbSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/MySQLDBSupport.java
+++ b/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/MySQLDBSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/PostgresDbSupport.java
+++ b/dbschema/test/unit/src/org/netbeans/modules/dbschema/test/dbsupport/PostgresDbSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/deadlock.detector/src/org/netbeans/modules/deadlock/detector/Detector.java
+++ b/deadlock.detector/src/org/netbeans/modules/deadlock/detector/Detector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/deadlock.detector/src/org/netbeans/modules/deadlock/detector/Installer.java
+++ b/deadlock.detector/src/org/netbeans/modules/deadlock/detector/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/deadlock.detector/test/unit/src/org/netbeans/modules/deadlock/detector/DetectorTest.java
+++ b/deadlock.detector/test/unit/src/org/netbeans/modules/deadlock/detector/DetectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAAppReloaded.java
+++ b/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAAppReloaded.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAConnect.java
+++ b/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAConnect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAReload.java
+++ b/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAReload.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAStart.java
+++ b/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/ArrayItemValueImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/ArrayItemValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/FieldImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/FieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/FieldValueImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/FieldValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/HeapImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/HeapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/InstanceImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/InstanceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/JavaClassImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/JavaClassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/ObjectArrayInstanceImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/ObjectArrayInstanceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/ObjectFieldValueImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/ObjectFieldValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/PrimitiveArrayInstanceImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/PrimitiveArrayInstanceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/TypeImpl.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/TypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/actions/ClassesCountsViewAction.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/actions/ClassesCountsViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/models/HeapActionsFilter.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/models/HeapActionsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/ClassesCountsView.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/ClassesCountsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/DebuggerHeapFragmentWalker.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/DebuggerHeapFragmentWalker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/InstancesView.java
+++ b/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/InstancesView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/FirstSourceURLProvider.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/FirstSourceURLProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/JSUtils.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/JSUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/StepIntoJSHandler.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/StepIntoJSHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/StepThroughFiltersCheck.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/StepThroughFiltersCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/JSBreakpointsInfoImpl.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/JSBreakpointsInfoImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/JSJavaBreakpointsManager.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/JSJavaBreakpointsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/URLEquality.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/URLEquality.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/io/JSBreakpointReader.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/breakpoints/io/JSBreakpointReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/frames/JSStackFrame.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/frames/JSStackFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/ObservableSet.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/ObservableSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/DebuggerSupport.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/DebuggerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSEvaluator.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSExpression.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSThis.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSThis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSVariable.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/ScopeVariable.java
+++ b/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/ScopeVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/test/unit/src/org/netbeans/modules/debugger/jpda/js/breakpoints/URLEqualityTest.java
+++ b/debugger.jpda.js/test/unit/src/org/netbeans/modules/debugger/jpda/js/breakpoints/URLEqualityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.js/test/unit/src/org/netbeans/modules/debugger/jpda/js/source/SourceTest.java
+++ b/debugger.jpda.js/test/unit/src/org/netbeans/modules/debugger/jpda/js/source/SourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/JSUIUtils.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/JSUIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSActionsProvider.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSFramesInJavaModelFilter.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSFramesInJavaModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSNodeModel.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeExpansionModelFilter.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeExpansionModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeModel.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/JSWatchVar.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/JSWatchVar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/VariablesJSNodeModel.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/VariablesJSNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/VariablesJSTableModel.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/VariablesJSTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/VariablesJSTreeModel.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/models/VariablesJSTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/tooltip/ToolTipAnnotation.java
+++ b/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/vars/tooltip/ToolTipAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/AST2Bytecode.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/AST2Bytecode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ASTOperationCreationDelegate.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ASTOperationCreationDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ClassScanner.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ClassScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ClassToInvoke.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ClassToInvoke.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/CodeCompiler.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/CodeCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/CodeSnippetCompiler.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/CodeSnippetCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ConstantPool.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ConstantPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/EditorContextSupport.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/EditorContextSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ExpressionScanner.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ExpressionScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FieldLNCache.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FieldLNCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FixClassesSupport.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FixClassesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/IntroduceClass.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/IntroduceClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/MethodArgumentsScanner.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/MethodArgumentsScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ParsedData.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ParsedData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/PreferredCCParser.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/PreferredCCParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ScanLocalVars.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/ScanLocalVars.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/WeakHashMapActive.java
+++ b/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/WeakHashMapActive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/test/unit/src/org/netbeans/modules/debugger/jpda/projects/FieldLNCacheTest.java
+++ b/debugger.jpda.projects/test/unit/src/org/netbeans/modules/debugger/jpda/projects/FieldLNCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projects/test/unit/src/org/netbeans/modules/debugger/jpda/projects/WeakHashMapActiveTest.java
+++ b/debugger.jpda.projects/test/unit/src/org/netbeans/modules/debugger/jpda/projects/WeakHashMapActiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/BreakpointAnnotationManager.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/BreakpointAnnotationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/BreakpointAnnotationProvider.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/BreakpointAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/BreakpointsActionsProvider.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/BreakpointsActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerAnnotation.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerBreakpointAnnotation.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerBreakpointAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerStateChangeListener.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerStateChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/EditorContextImpl.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/EditorContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/FixActionProvider.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/FixActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/HighlightsLayerFactoryImpl.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/HighlightsLayerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/LineTranslations.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/LineTranslations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/MainProjectManager.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/MainProjectManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/PinWatchExpandAction.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/PinWatchExpandAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/RunToCursorActionProvider.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/RunToCursorActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesCurrentModel.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesCurrentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesNodeModel.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesRemoteModel.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesRemoteModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesTabs.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesTabs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/StepIntoActionProvider.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/StepIntoActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/ToolTipAnnotation.java
+++ b/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/ToolTipAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/test/unit/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerBreakpointAnnotationTest.java
+++ b/debugger.jpda.projectsui/test/unit/src/org/netbeans/modules/debugger/jpda/projectsui/DebuggerBreakpointAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.projectsui/test/unit/src/org/netbeans/modules/debugger/jpda/projectsui/MainProjectManagerTest.java
+++ b/debugger.jpda.projectsui/test/unit/src/org/netbeans/modules/debugger/jpda/projectsui/MainProjectManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/BreakpointOutput.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/BreakpointOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/ConnectPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/ConnectPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/CurrentThreadAnnotationListener.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/CurrentThreadAnnotationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/EditorContextBridge.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/EditorContextBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/FixedWatchesManager.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/FixedWatchesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/JPDAAttachType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/JPDAAttachType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/JPDACodeEvaluator.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/JPDACodeEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/JavaUtils.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/JavaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/MultilinePanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/MultilinePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SmartSteppingImpl.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SmartSteppingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SourcePath.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SourcePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/WatchPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/WatchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ActionMessageCallbackUIImpl.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ActionMessageCallbackUIImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/CheckDeadlocksAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/CheckDeadlocksAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/EvaluateActionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/EvaluateActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/JPDADebuggerAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/JPDADebuggerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/JPDAMethodChooserFactoryUIImpl.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/JPDAMethodChooserFactoryUIImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/MakeCalleeCurrentActionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/MakeCalleeCurrentActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/MakeCallerCurrentActionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/MakeCallerCurrentActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/MethodChooserSupport.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/MethodChooserSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/NewWatchActionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/NewWatchActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/RunIntoMethodActionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/RunIntoMethodActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/RunToCursorActionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/RunToCursorActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/SetAsCurrentThreadGutterAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/SetAsCurrentThreadGutterAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ToggleBreakpointActionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ToggleBreakpointActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ToggleMethodFieldBreakpointAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ToggleMethodFieldBreakpointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ActionsPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ActionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/BreakpointsExpandableGroup.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/BreakpointsExpandableGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ClassBreakpointPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ClassBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ClassBreakpointType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ClassBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ConditionsPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ConditionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ControllerProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ControllerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ExceptionBreakpointPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ExceptionBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ExceptionBreakpointType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ExceptionBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/FieldBreakpointPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/FieldBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/FieldBreakpointType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/FieldBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/FileMoveBreakpointsHandler.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/FileMoveBreakpointsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/JPDABreakpointCustomizer.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/JPDABreakpointCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/MethodBreakpointPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/MethodBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/MethodBreakpointType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/MethodBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/OutlineComboBox.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/OutlineComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ThreadBreakpointPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ThreadBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ThreadBreakpointType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ThreadBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ClassCompletionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ClassCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ClassSearchScopeType.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ClassSearchScopeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ElementCompletionItem.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ElementCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ExceptionClassNbDebugEditorKit.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ExceptionClassNbDebugEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ExceptionCompletionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/ExceptionCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/FieldsCompletionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/FieldsCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/JavaClassNbDebugEditorKit.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/JavaClassNbDebugEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/JavaFieldNbDebugEditorKit.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/JavaFieldNbDebugEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/JavaMethodNbDebugEditorKit.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/JavaMethodNbDebugEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/MethodsCompletionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/completion/MethodsCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/debugging/DebuggingViewSupportImpl.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/debugging/DebuggingViewSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/debugging/JPDADVThread.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/debugging/JPDADVThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/debugging/JPDADVThreadGroup.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/debugging/JPDADVThreadGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/focus/AWTGrabHandler.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/focus/AWTGrabHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/focus/FocusSuspendController.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/focus/FocusSuspendController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BigStringCustomEditor.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BigStringCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointModelActiveSessionFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointModelActiveSessionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsActionsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsHitCountModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsHitCountModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsNodeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsTreeModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsTreeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackActionsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackNodeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackTableModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackTreeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingActionsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingActionsProviderFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingActionsProviderFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingMonitorModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingMonitorModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingNodeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTableModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeExpansionModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeExpansionModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorNodeModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorNodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorTableModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorTableModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorTreeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorTreeModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorTreeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorVarsTreeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorVarsTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/HiddenCallStackFramesFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/HiddenCallStackFramesFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDAAsynchronousModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDAAsynchronousModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDASessionActionsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDASessionActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDAWatchRefreshModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDAWatchRefreshModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JavaVariablesFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JavaVariablesFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/LabelVarsFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/LabelVarsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/LocalsTreeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/LocalsTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/MonitorModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/MonitorModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/NumericDisplayFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/NumericDisplayFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/PendingActionsFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/PendingActionsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/PinWatchValueProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/PinWatchValueProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ResultsSwitchViewAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ResultsSwitchViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SessionsTableModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SessionsTableModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SourcesModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SourcesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SourcesSessionProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SourcesSessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsActionsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsNodeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTableModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTreeExpansionModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTreeExpansionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTreeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ToolTipSwitchViewAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ToolTipSwitchViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ValuePropertyEditor.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ValuePropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesActionsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesFormatterFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesFormatterFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesNodeModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesPropertyEditorsModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesPropertyEditorsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesSwitchViewAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesSwitchViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTableHTMLModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTableHTMLModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTableModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeExpansionModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeExpansionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeModelFilterSI.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeModelFilterSI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesActionsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesColumnModels.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesColumnModels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesNodeModelFilter.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesNodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesSwitchViewAction.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesSwitchViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/CategoryPanelFormatters.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/CategoryPanelFormatters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/CategoryPanelGeneral.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/CategoryPanelGeneral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/CategoryPanelStepFilters.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/CategoryPanelStepFilters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/DisablingCellRenderer.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/DisablingCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/JavaDebuggerOptionsPanelController.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/JavaDebuggerOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/JavaDebuggerPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/JavaDebuggerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/OptionsInitializer.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/OptionsInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/StorablePanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/StorablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/VariableFormatterEditPanel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/options/VariableFormatterEditPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/views/JPDAEngineComponentsProvider.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/views/JPDAEngineComponentsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/views/SourcesView.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/views/SourcesView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/views/VariablesViewButtons.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/views/VariablesViewButtons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/examples/advanced/MemoryView.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/examples/advanced/MemoryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/tests/FixAndContinue.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/tests/FixAndContinue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/tests/ThrowException.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/tests/ThrowException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/tests/ThrowMultipleExceptions.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProject/src/tests/ThrowMultipleExceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/ApplyCodeChangesTest.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/ApplyCodeChangesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/DetectDeadlockTest.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/DetectDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/ThreadSuspendingTest.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/ThreadSuspendingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/VariablesTest.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/advanced/VariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/memoryView/MemoryView.java
+++ b/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/src/memoryView/MemoryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/jpda/ui/operators/AttachJDialogOperator.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/jpda/ui/operators/AttachJDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ActionsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/AntSanityTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/AntSanityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ApplyCodeChangesTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ApplyCodeChangesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ClassBreakpointsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ClassBreakpointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/CloseSessionsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/CloseSessionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/DebuggerTestCase.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/DebuggerTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/DebuggingActionsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/DebuggingActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/DebuggingBreakpointsActionsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/DebuggingBreakpointsActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ExceptionBreakpointsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ExceptionBreakpointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/FieldBreakpointsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/FieldBreakpointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/LineBreakpointsHitCountTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/LineBreakpointsHitCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/LineBreakpointsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/LineBreakpointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/LocalVariablesTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/LocalVariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/MethodBreakpointsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/MethodBreakpointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/SanitySuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/SanitySuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/StartDebuggerTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/StartDebuggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/StepsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/StepsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ThreadBreakpointsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ThreadBreakpointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/Utilities.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ViewsTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ViewsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/WatchesTest.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/WatchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/ActionsTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/ActionsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_ClassTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_ClassTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_ExceptionTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_ExceptionTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_FieldTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_FieldTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_LineTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_LineTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_MethodTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_MethodTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_ThreadTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/Breakpoints_ThreadTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/DebuggingActionsTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/DebuggingActionsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/DebuggingBreakpointsActionsTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/DebuggingBreakpointsActionsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/LineBreakpointsHitCountTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/LineBreakpointsHitCountTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/LocalVariablesTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/LocalVariablesTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/StartDebuggerTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/StartDebuggerTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/StepsTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/StepsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/ViewsTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/ViewsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/WatchesTestSuite.java
+++ b/debugger.jpda.ui/test/qa-functional/src/org/netbeans/modules/debugger/jpda/ui/ts/WatchesTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteAWTHierarchyListener.java
+++ b/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteAWTHierarchyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteAWTService.java
+++ b/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteAWTService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteAWTServiceListener.java
+++ b/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteAWTServiceListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteFXService.java
+++ b/debugger.jpda.visual/remotesrc/org/netbeans/modules/debugger/jpda/visual/remote/RemoteFXService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ComponentsFieldFinder.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ComponentsFieldFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/JavaComponentInfo.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/JavaComponentInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteAWTScreenshot.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteAWTScreenshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteFXScreenshot.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteFXScreenshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteServices.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RetrievalException.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RetrievalException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/VisualDebuggerListener.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/VisualDebuggerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/ComponentBreakpointActionProvider.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/ComponentBreakpointActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/CreateFixedWatchAction.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/CreateFixedWatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GestureSubmitter.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GestureSubmitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GoToAddIntoHierarchyAction.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GoToAddIntoHierarchyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GoToFieldDeclarationAction.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GoToFieldDeclarationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GoToSourceAction.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GoToSourceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/ShowListenersAction.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/ShowListenersAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/TakeScreenshotActionProvider.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/TakeScreenshotActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/ToggleComponentBreakpointAction.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/ToggleComponentBreakpointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/AWTComponentBreakpoint.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/AWTComponentBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/AWTComponentBreakpointImpl.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/AWTComponentBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/BaseComponentBreakpointImpl.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/BaseComponentBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/BreakpointsEngineListener.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/BreakpointsEngineListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpoint.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointBeanInfo.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointCustomizer.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointImpl.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointPanel.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointType.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/FXComponentBreakpoint.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/FXComponentBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/FXComponentBreakpointImpl.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/FXComponentBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/ComponentBreakpointsActionsProvider.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/ComponentBreakpointsActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/ComponentBreakpointsNodeModel.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/ComponentBreakpointsNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/EventTypesColumnModel.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/EventTypesColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/EventsColumnModel.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/EventsColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/EventsModel.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/EventsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/SelectEventsPanel.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/models/SelectEventsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/options/CategoryPanelVisual.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/options/CategoryPanelVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/options/Options.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/options/Options.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/options/VisualOptionsProvider.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/options/VisualOptionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/spi/ComponentInfo.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/spi/ComponentInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/spi/RemoteScreenshot.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/spi/RemoteScreenshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/spi/ScreenshotUIManager.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/spi/ScreenshotUIManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ComponentHierarchy.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ComponentHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ComponentHierarchyNavigatorHint.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ComponentHierarchyNavigatorHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ComponentNode.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ComponentNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ScreenshotComponent.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/ui/ScreenshotComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/views/VariablesViewButtons.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/views/VariablesViewButtons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/views/View.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/views/View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/views/VisualDebuggerComponentsProvider.java
+++ b/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/views/VisualDebuggerComponentsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/gensrc/org/netbeans/modules/debugger/jpda/jdi/Generate.java
+++ b/debugger.jpda/gensrc/org/netbeans/modules/debugger/jpda/jdi/Generate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/AttachingSessionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/AttachingSessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ClassTypeList.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ClassTypeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DeadlockDetectorImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DeadlockDetectorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DebuggerConsoleIO.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DebuggerConsoleIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/EditorContextBridge.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/EditorContextBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ExpressionPool.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ExpressionPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JDIExceptionReporter.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JDIExceptionReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDAStepImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDAStepImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JSR45DebuggerEngineProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JSR45DebuggerEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JavaEngineProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JavaEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JavaEvaluator.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JavaEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/LaunchingSessionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/LaunchingSessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ListeningSessionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ListeningSessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/SingleThreadWatcher.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/SingleThreadWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/SourcePath.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/SourcePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ThreadsCollectorImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ThreadsCollectorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionErrorMessageCallback.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionErrorMessageCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionMessageCallback.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionMessageCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionStatusDisplayCallback.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionStatusDisplayCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionsSynchronizer.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ActionsSynchronizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/CompoundSmartSteppingListener.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/CompoundSmartSteppingListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ContinueActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/ContinueActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDADebuggerActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDADebuggerActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDAMethodChooserFactory.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDAMethodChooserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDAMethodChooserUtils.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDAMethodChooserUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/KillActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/KillActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/PauseActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/PauseActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/PopToHereActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/PopToHereActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/RunIntoMethodActionSupport.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/RunIntoMethodActionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/SmartSteppingFilterImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/SmartSteppingFilterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StartActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StartActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepIntoActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepIntoActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepIntoNextMethod.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepIntoNextMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepIntoNextMethodActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepIntoNextMethodActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepOperationActionProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepOperationActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/SuspendController.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/SuspendController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsEngineListener.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsEngineListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsFromGroup.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsFromGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ClassBasedBreakpoint.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ClassBasedBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ClassBreakpointImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ClassBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ExceptionBreakpointImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ExceptionBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/FieldBreakpointImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/FieldBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/JPDABreakpointsActivation.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/JPDABreakpointsActivation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/LineBreakpointImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/LineBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/PersistenceManager.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/PersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/RequestNotSupportedException.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/RequestNotSupportedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/SourceRootsCache.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/SourceRootsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ThreadBreakpointImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ThreadBreakpointImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/console/DebuggerOutput.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/console/DebuggerOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/console/IOManager.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/console/IOManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/Assert.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/Assert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/CanInterpretVisitor.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/CanInterpretVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/CompilationInfoHolder.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/CompilationInfoHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluationContext.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluationException.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorExpression.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/InvocationExceptionTranslated.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/InvocationExceptionTranslated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/JDIVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/JDIVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/JavaExpression.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/JavaExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/TreeEvaluator.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/TreeEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/VMCache.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/VMCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/Formatters.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/Formatters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/FormattersLoopControl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/FormattersLoopControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/VariablesFormatter.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/VariablesFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ArrayReferenceWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ArrayReferenceWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ArrayTypeWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ArrayTypeWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/BooleanValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/BooleanValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ByteValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ByteValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/CharValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/CharValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ClassNotPreparedExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ClassNotPreparedExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ClassObjectReferenceWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ClassObjectReferenceWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ClassTypeWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ClassTypeWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/DoubleValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/DoubleValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/FieldWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/FieldWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/FloatValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/FloatValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/IllegalArgumentExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/IllegalArgumentExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/IllegalThreadStateExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/IllegalThreadStateExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/IntegerValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/IntegerValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InterfaceTypeWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InterfaceTypeWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InternalExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InternalExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InvalidRequestStateExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InvalidRequestStateExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InvalidStackFrameExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/InvalidStackFrameExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LocalVariableWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LocalVariableWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LocatableWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LocatableWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LocationWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LocationWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LongValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/LongValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/MethodWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/MethodWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/MirrorWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/MirrorWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/MonitorInfoWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/MonitorInfoWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/NativeMethodExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/NativeMethodExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ObjectCollectedExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ObjectCollectedExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ObjectReferenceWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ObjectReferenceWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/PrimitiveValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/PrimitiveValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ReferenceTypeWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ReferenceTypeWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ShortValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ShortValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/StackFrameWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/StackFrameWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/StringReferenceWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/StringReferenceWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ThreadGroupReferenceWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ThreadGroupReferenceWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ThreadReferenceWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ThreadReferenceWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/TypeComponentWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/TypeComponentWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/TypeWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/TypeWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/UnsupportedOperationExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/UnsupportedOperationExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VMDisconnectedExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VMDisconnectedExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VMOutOfMemoryExceptionWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VMOutOfMemoryExceptionWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ValueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/ValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VirtualMachineManagerWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VirtualMachineManagerWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VirtualMachineWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/VirtualMachineWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ClassPrepareEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ClassPrepareEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ClassUnloadEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ClassUnloadEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventIteratorWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventIteratorWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventQueueWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventQueueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventSetWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventSetWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/EventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ExceptionEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ExceptionEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/LocatableEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/LocatableEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MethodEntryEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MethodEntryEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MethodExitEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MethodExitEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ModificationWatchpointEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ModificationWatchpointEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorContendedEnterEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorContendedEnterEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorContendedEnteredEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorContendedEnteredEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorWaitEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorWaitEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorWaitedEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/MonitorWaitedEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ThreadDeathEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ThreadDeathEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ThreadStartEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/ThreadStartEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/VMStartEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/VMStartEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/WatchpointEventWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/event/WatchpointEventWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/BreakpointRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/BreakpointRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ClassPrepareRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ClassPrepareRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ClassUnloadRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ClassUnloadRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/EventRequestManagerWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/EventRequestManagerWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/EventRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/EventRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ExceptionRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ExceptionRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MethodEntryRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MethodEntryRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MethodExitRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MethodExitRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorContendedEnterRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorContendedEnterRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorContendedEnteredRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorContendedEnteredRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorWaitRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorWaitRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorWaitedRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/MonitorWaitedRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/StepRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/StepRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ThreadDeathRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ThreadDeathRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ThreadStartRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/ThreadStartRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/WatchpointRequestWrapper.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/jdi/request/WatchpointRequestWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/AbstractObjectVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/AbstractObjectVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/AbstractVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/AbstractVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ArgumentObjectVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ArgumentObjectVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ArgumentVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ArgumentVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ArrayFieldVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ArrayFieldVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/CallStackFrameImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/CallStackFrameImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ClassFieldVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ClassFieldVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ClassVariableImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ClassVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ExceptionVariableImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ExceptionVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/FieldReadVariableImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/FieldReadVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/FieldToBeVariableImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/FieldToBeVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/FieldVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/FieldVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAArrayTypeImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAArrayTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAClassTypeImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAClassTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAObjectWatchImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAObjectWatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadGroupImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadGroupImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAWatchFactory.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAWatchFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAWatchImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAWatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/Local.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/Local.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/MonitorInfoImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/MonitorInfoImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectArrayFieldVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectArrayFieldVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectFieldVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectFieldVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectLocalVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectLocalVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectTranslation.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ObjectTranslation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ReturnVariableImpl.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ReturnVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ShortenedStrings.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ShortenedStrings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/SuperVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/SuperVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThisVariable.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThisVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/VariableMirrorTranslator.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/VariableMirrorTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/remote/RemoteClass.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/remote/RemoteClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/remote/RemoteServices.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/remote/RemoteServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/spi/StrataProvider.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/spi/StrataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/ConditionedExecutor.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/ConditionedExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/Executor.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/Executor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/JPDAUtils.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/JPDAUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/Operator.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/Operator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/WeakCacheMap.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/WeakCacheMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/WeakHashMapActive.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/util/WeakHashMapActive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/AsynchStepTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/AsynchStepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointResumeTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointResumeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointsClassFilterTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointsClassFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointsDeactivationTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointsDeactivationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/CallStackTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/CallStackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ClassBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ClassBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ConcurrencyTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ConnectorsTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ConnectorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/DummyTests.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/DummyTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluationTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluatorTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ExceptionBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ExceptionBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ExpressionStepTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ExpressionStepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/FieldBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/FieldBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/HeapWalkingTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/HeapWalkingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JDICallException.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JDICallException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JDIWrappersTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JDIWrappersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDAClassTypeTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDAClassTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDAStepTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDAStepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDASupport.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDASupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JspLineBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JspLineBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/LineBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/LineBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/LocalVariablesTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/LocalVariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MethodBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MethodBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MethodInvocationTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MethodInvocationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MirrorValuesTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MirrorValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MonitorAndDeadlockTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/MonitorAndDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/StepTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/StepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ThreadBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ThreadBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/Utils.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/AsynchStepApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/AsynchStepApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/BreakpointsClassFilterApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/BreakpointsClassFilterApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/BreakpointsClassFilterApp2.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/BreakpointsClassFilterApp2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/CallStackApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/CallStackApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ClassBreakpointApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ClassBreakpointApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ClassBreakpointTest1.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ClassBreakpointTest1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ConcurrencyApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ConcurrencyApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EmptyApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EmptyApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvalApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvalApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvaluatorApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvaluatorApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ExceptionBreakpointApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ExceptionBreakpointApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ExceptionTestException.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ExceptionTestException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ExpressionStepApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ExpressionStepApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/FieldBreakpointApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/FieldBreakpointApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/HeapWalkApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/HeapWalkApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/JPDAClassTypeTestApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/JPDAClassTypeTestApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/JspLineBreakpointApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/JspLineBreakpointApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/LineBreakpointApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/LineBreakpointApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/LocalVariablesApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/LocalVariablesApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/MethodBreakpointApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/MethodBreakpointApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/MirrorValuesApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/MirrorValuesApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/MonitorAndDeadlockApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/MonitorAndDeadlockApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/StepApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/StepApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ThreadBreakpointApp.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/ThreadBreakpointApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/privat/PackagePrivateClass.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/privat/PackagePrivateClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/debugger.jpda/test/unit/src/org/netbeans/modules/debugger/jpda/breakpoints/ClassBasedBreakpointTest.java
+++ b/debugger.jpda/test/unit/src/org/netbeans/modules/debugger/jpda/breakpoints/ClassBasedBreakpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/ConnectDatabaseAction.java
+++ b/derby/src/org/netbeans/modules/derby/ConnectDatabaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/CreateDatabaseAction.java
+++ b/derby/src/org/netbeans/modules/derby/CreateDatabaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/CreateSampleDBAction.java
+++ b/derby/src/org/netbeans/modules/derby/CreateSampleDBAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DbURLClassLoader.java
+++ b/derby/src/org/netbeans/modules/derby/DbURLClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyActivator.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyDatabaseNode.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyDatabaseNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyDatabasesImpl.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyDatabasesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyNodeProvider.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyNodeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyOptions.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyOptionsBeanInfo.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyOptionsBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyPropertiesAction.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyPropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyRegistration.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/DerbyServerNode.java
+++ b/derby/src/org/netbeans/modules/derby/DerbyServerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/ExecSupport.java
+++ b/derby/src/org/netbeans/modules/derby/ExecSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/JDKDerbyHelper.java
+++ b/derby/src/org/netbeans/modules/derby/JDKDerbyHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/RegisterDerby.java
+++ b/derby/src/org/netbeans/modules/derby/RegisterDerby.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/SearchUtil.java
+++ b/derby/src/org/netbeans/modules/derby/SearchUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/StartAction.java
+++ b/derby/src/org/netbeans/modules/derby/StartAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/StopAction.java
+++ b/derby/src/org/netbeans/modules/derby/StopAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/Util.java
+++ b/derby/src/org/netbeans/modules/derby/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/api/DerbyDatabases.java
+++ b/derby/src/org/netbeans/modules/derby/api/DerbyDatabases.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/spi/support/DerbySupport.java
+++ b/derby/src/org/netbeans/modules/derby/spi/support/DerbySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/ui/CreateDatabasePanel.java
+++ b/derby/src/org/netbeans/modules/derby/ui/CreateDatabasePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/ui/CreateSampleDatabasePanel.java
+++ b/derby/src/org/netbeans/modules/derby/ui/CreateSampleDatabasePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/ui/DerbyPropertiesPanel.java
+++ b/derby/src/org/netbeans/modules/derby/ui/DerbyPropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/src/org/netbeans/modules/derby/ui/SecurityManagerBugPanel.java
+++ b/derby/src/org/netbeans/modules/derby/ui/SecurityManagerBugPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/qa-functional/src/org/netbeans/test/db/derby/CreateDatabaseTest.java
+++ b/derby/test/qa-functional/src/org/netbeans/test/db/derby/CreateDatabaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/qa-functional/src/org/netbeans/test/db/derby/DbJellyTestCase.java
+++ b/derby/test/qa-functional/src/org/netbeans/test/db/derby/DbJellyTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/qa-functional/src/org/netbeans/test/db/derby/DerbyDatabaseTest.java
+++ b/derby/test/qa-functional/src/org/netbeans/test/db/derby/DerbyDatabaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/qa-functional/src/org/netbeans/test/db/util/DbUtil.java
+++ b/derby/test/qa-functional/src/org/netbeans/test/db/util/DbUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/unit/src/org/netbeans/modules/derby/DerbyOptionsTest.java
+++ b/derby/test/unit/src/org/netbeans/modules/derby/DerbyOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/unit/src/org/netbeans/modules/derby/DerbyOptionsTest2.java
+++ b/derby/test/unit/src/org/netbeans/modules/derby/DerbyOptionsTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/unit/src/org/netbeans/modules/derby/RegisterDerbyTest.java
+++ b/derby/test/unit/src/org/netbeans/modules/derby/RegisterDerbyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/unit/src/org/netbeans/modules/derby/SearchUtilTest.java
+++ b/derby/test/unit/src/org/netbeans/modules/derby/SearchUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/unit/src/org/netbeans/modules/derby/api/DerbyDatabasesTest.java
+++ b/derby/test/unit/src/org/netbeans/modules/derby/api/DerbyDatabasesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/unit/src/org/netbeans/modules/derby/spi/support/DerbySupportTest.java
+++ b/derby/test/unit/src/org/netbeans/modules/derby/spi/support/DerbySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/derby/test/unit/src/org/netbeans/modules/derby/test/TestBase.java
+++ b/derby/test/unit/src/org/netbeans/modules/derby/test/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/api/diff/Diff.java
+++ b/diff/src/org/netbeans/api/diff/Diff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/api/diff/DiffController.java
+++ b/diff/src/org/netbeans/api/diff/DiffController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/api/diff/DiffView.java
+++ b/diff/src/org/netbeans/api/diff/DiffView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/api/diff/Difference.java
+++ b/diff/src/org/netbeans/api/diff/Difference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/api/diff/PatchUtils.java
+++ b/diff/src/org/netbeans/api/diff/PatchUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/api/diff/StreamSource.java
+++ b/diff/src/org/netbeans/api/diff/StreamSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/DiffAction.java
+++ b/diff/src/org/netbeans/modules/diff/DiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/DiffFileEncodingQueryImplementation.java
+++ b/diff/src/org/netbeans/modules/diff/DiffFileEncodingQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/DiffModuleConfig.java
+++ b/diff/src/org/netbeans/modules/diff/DiffModuleConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/EditorBufferSelectorPanel.java
+++ b/diff/src/org/netbeans/modules/diff/EditorBufferSelectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/EncodedReaderFactory.java
+++ b/diff/src/org/netbeans/modules/diff/EncodedReaderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/PatchAction.java
+++ b/diff/src/org/netbeans/modules/diff/PatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/Utils.java
+++ b/diff/src/org/netbeans/modules/diff/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/XMLEncodingHelper.java
+++ b/diff/src/org/netbeans/modules/diff/XMLEncodingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/Base64.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/Base64.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/ContextualPatch.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/ContextualPatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/DefaultDiff.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/DefaultDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/DefaultDiffBeanInfo.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/DefaultDiffBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/DefaultDiffControllerProvider.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/DefaultDiffControllerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/DiffPresenter.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/DiffPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/ExportPatch.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/ExportPatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/Hunk.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/Hunk.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/Patch.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/Patch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/PatchException.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/PatchException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/SingleDiffPanel.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/SingleDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/provider/BuiltInDiffProvider.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/provider/BuiltInDiffProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/provider/HuntDiff.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/provider/HuntDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/DEditorPane.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/DEditorPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/DiffComponent.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/DiffComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/DiffPanel.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/DiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/DiffViewImpl.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/DiffViewImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/GraphicalDiffVisualizer.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/GraphicalDiffVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/GraphicalDiffVisualizerBeanInfo.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/GraphicalDiffVisualizerBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/LinesComponent.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/LinesComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/SourceTranslatorAction.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/SourceTranslatorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/TextDiffEditorSupport.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/TextDiffEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/TextDiffVisualizer.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/TextDiffVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/TextDiffVisualizerBeanInfo.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/TextDiffVisualizerBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/UnifiedDiff.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/UnifiedDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DecoratedEditorPane.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DecoratedEditorPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffContentPanel.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffContentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffHighlightsLayerFactory.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffHighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffMark.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffMarkProviderCreator.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffMarkProviderCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffSplitPaneDivider.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffSplitPaneDivider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffViewManager.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffViewManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/EditableDiffView.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/EditableDiffView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/EditableDiffVisualizer.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/EditableDiffVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/HotSpot.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/HotSpot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/LineNumbersActionsBar.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/LineNumbersActionsBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/NoContentPanel.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/NoContentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/cmdline/CmdlineDiffProvider.java
+++ b/diff/src/org/netbeans/modules/diff/cmdline/CmdlineDiffProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/cmdline/CmdlineDiffProviderBeanInfo.java
+++ b/diff/src/org/netbeans/modules/diff/cmdline/CmdlineDiffProviderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/options/AccessibleJFileChooser.java
+++ b/diff/src/org/netbeans/modules/diff/options/AccessibleJFileChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/options/CategoryRenderer.java
+++ b/diff/src/org/netbeans/modules/diff/options/CategoryRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/options/DiffColorsPanel.java
+++ b/diff/src/org/netbeans/modules/diff/options/DiffColorsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/options/DiffOptionsController.java
+++ b/diff/src/org/netbeans/modules/diff/options/DiffOptionsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/diff/options/DiffOptionsPanel.java
+++ b/diff/src/org/netbeans/modules/diff/options/DiffOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/CloseMergeViewAction.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/CloseMergeViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/GraphicalMergeVisualizer.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/GraphicalMergeVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/GraphicalMergeVisualizerBeanInfo.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/GraphicalMergeVisualizerBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeControl.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeDialogComponent.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeDialogComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeHighlightsLayerFactory.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeHighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePane.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePanel.java
+++ b/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/spi/diff/DiffControllerImpl.java
+++ b/diff/src/org/netbeans/spi/diff/DiffControllerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/spi/diff/DiffControllerProvider.java
+++ b/diff/src/org/netbeans/spi/diff/DiffControllerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/spi/diff/DiffProvider.java
+++ b/diff/src/org/netbeans/spi/diff/DiffProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/spi/diff/DiffVisualizer.java
+++ b/diff/src/org/netbeans/spi/diff/DiffVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/src/org/netbeans/spi/diff/MergeVisualizer.java
+++ b/diff/src/org/netbeans/spi/diff/MergeVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/api/diff/PatchUtilsTest.java
+++ b/diff/test/unit/src/org/netbeans/api/diff/PatchUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/modules/diff/DefaultDiffViewTest.java
+++ b/diff/test/unit/src/org/netbeans/modules/diff/DefaultDiffViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/modules/diff/DiffControllerTest.java
+++ b/diff/test/unit/src/org/netbeans/modules/diff/DiffControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/modules/diff/DiffViewAbstract.java
+++ b/diff/test/unit/src/org/netbeans/modules/diff/DiffViewAbstract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/modules/diff/FallbackDiffViewTest.java
+++ b/diff/test/unit/src/org/netbeans/modules/diff/FallbackDiffViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/modules/diff/builtin/DefaultDiffControllerProviderTest.java
+++ b/diff/test/unit/src/org/netbeans/modules/diff/builtin/DefaultDiffControllerProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/BuiltInDiffProviderTest.java
+++ b/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/BuiltInDiffProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/diff/test/unit/src/org/netbeans/modules/diff/builtin/visualizer/UnifiedDiffTest.java
+++ b/diff/test/unit/src/org/netbeans/modules/diff/builtin/visualizer/UnifiedDiffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/api/ui/util/NativeExecutionUIUtils.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/api/ui/util/NativeExecutionUIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/api/ui/util/ValidatablePanelListener.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/api/ui/util/ValidatablePanelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/api/ui/util/ValidateablePanel.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/api/ui/util/ValidateablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/impl/JSchAuthenticationSelectionImplementation.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/impl/JSchAuthenticationSelectionImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/impl/NativeExecutionUserNotificationImpl.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/impl/NativeExecutionUserNotificationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/spi/ui/HostPropertiesPanelProvider.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/spi/ui/HostPropertiesPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/HostConfigurationPanel.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/HostConfigurationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/HostPropertiesPanelProviderImpl.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/HostPropertiesPanelProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/ui/api/AutocompletionProvider.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/ui/api/AutocompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/ui/api/FileNamesCompletionProvider.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/ui/api/FileNamesCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/ui/api/FileSelectorField.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/support/ui/api/FileSelectorField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/AuthTypeSelectorDlg.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/AuthTypeSelectorDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/AuthenticationSettingsPanel.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/AuthenticationSettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/CertPassphraseDlg.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/CertPassphraseDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/CertPassphraseDlgFactory.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/CertPassphraseDlgFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/Completable.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/Completable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/CompletionPopup.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/CompletionPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/GrantPrivilegesDialog.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/GrantPrivilegesDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/GrantPrivilegesDialogFactory.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/GrantPrivilegesDialogFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/PasswordDlg.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/PasswordDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/PasswordDlgFactory.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/PasswordDlgFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/PromptPasswordDialog.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/PromptPasswordDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileChooser.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileCompletionProvider.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileFilter.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeysPanel.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeysPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/ShellValidationStatusPanel.java
+++ b/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/ShellValidationStatusPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/AbstractNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/AbstractNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ConnectionManagerAccessor.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ConnectionManagerAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExProcessInfoProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExProcessInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExecutionEnvironmentFactoryServiceImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExecutionEnvironmentFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExecutionEnvironmentImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExecutionEnvironmentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExternalTerminalAccessor.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ExternalTerminalAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/JschSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/JschSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NativeProcessBuilderAccessor.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NativeProcessBuilderAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NativeProcessInfo.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NativeProcessInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NbLocalNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NbLocalNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NbNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NbNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NbRemoteNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NbRemoteNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ProcessStatusAccessor.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/ProcessStatusAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/PtyNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/PtyNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/RemoteNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/RemoteNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/TerminalLocalNativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/TerminalLocalNativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ExecutionEnvironment.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ExecutionEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ExecutionEnvironmentFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ExecutionEnvironmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ExecutionListener.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ExecutionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/HostInfo.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/HostInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcessBuilder.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcessBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcessChangeEvent.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcessChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcessExecutionService.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/NativeProcessExecutionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ProcessInfo.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ProcessInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ProcessInfoProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ProcessInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ProcessStatusEx.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/ProcessStatusEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/IOTabsController.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/IOTabsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/NativeExecutionDescriptor.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/NativeExecutionDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/NativeExecutionService.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/NativeExecutionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/PostMessageDisplayer.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/PostMessageDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/PostMessageDisplayer2.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/execution/PostMessageDisplayer2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/pty/Pty.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/pty/Pty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/pty/PtySupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/pty/PtySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/pty/package-info.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/pty/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/AsynchronousAction.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/AsynchronousAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Authentication.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Authentication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/AuthenticationUtils.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/AuthenticationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/CommonTasksSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/CommonTasksSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ConnectionListener.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ConnectionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ConnectionManager.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/EnvUtils.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/EnvUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ExternalTerminal.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ExternalTerminal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ExternalTerminalProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ExternalTerminalProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HelperLibraryUtility.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HelperLibraryUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HelperUtility.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HelperUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HostInfoCache.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HostInfoCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HostInfoUtils.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HostInfoUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HostPropertyValidator.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/HostPropertyValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/LinkSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/LinkSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/MacroExpanderFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/MacroExpanderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/MacroMap.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/MacroMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Md5checker.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Md5checker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/PasswordManager.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/PasswordManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Path.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Path.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/PathUtils.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/PathUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ProcessUtils.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ProcessUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/RemoteMeasurements.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/RemoteMeasurements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/RemoteStatistics.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/RemoteStatistics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SftpSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SftpSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Shell.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Shell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ShellScriptRunner.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ShellScriptRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ShellValidationSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/ShellValidationSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Signal.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Signal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SlowListenerDetector.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SlowListenerDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupportProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/UnbufferSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/UnbufferSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/WindowsRegistryIterator.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/WindowsRegistryIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/WindowsSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/WindowsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/ConnectingProgressHandle.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/ConnectingProgressHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/JSchChannelsSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/JSchChannelsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/JSchConnectionTask.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/JSchConnectionTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/MeasurableSocketFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/MeasurableSocketFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/PortForwarding.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/jsch/PortForwarding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/IOConnector.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/IOConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/NbStartUtility.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/NbStartUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyAllocator.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyAllocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyOpenUtility.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyOpenUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyProcessStartUtility.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyProcessStartUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyUtility.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/PtyUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/SttySupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/pty/SttySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/SignalSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/SignalSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/SignalSupportImplementation.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/SignalSupportImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/impl/NbKillAllSignalSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/impl/NbKillAllSignalSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/impl/SignalSupportImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/signals/impl/SignalSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/ExecutionEnvironmentServiceProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/ExecutionEnvironmentServiceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/JSchAuthenticationSelection.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/JSchAuthenticationSelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/ProcessInfoProviderFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/ProcessInfoProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/GrantPrivilegesProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/GrantPrivilegesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/GrantPrivilegesProviderFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/GrantPrivilegesProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/JSchAccess.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/JSchAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/JSchAccessor.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/JSchAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/NativeExecutionUserNotification.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/NativeExecutionUserNotification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/PasswordProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/PasswordProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/PasswordProviderFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/spi/support/PasswordProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/FetchPrivilegesTask.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/FetchPrivilegesTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/RequestPrivilegesAction.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/RequestPrivilegesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/RequestPrivilegesTask.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/RequestPrivilegesTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/SPSCommonImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/SPSCommonImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/SPSLocalImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/SPSLocalImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/SPSRemoteImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/sps/impl/SPSRemoteImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Computable.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Computable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Encrypter.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Encrypter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/EnvReader.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/EnvReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/EnvWriter.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/EnvWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/InputRedirectorFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/InputRedirectorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/InstalledFileLocatorProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/InstalledFileLocatorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Logger.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Logger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/MiscUtils.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/MiscUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/NativeTaskExecutorService.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/NativeTaskExecutorService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ObservableAction.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ObservableAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ObservableActionListener.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ObservableActionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/RemoteUserInfo.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/RemoteUserInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ShellSession.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ShellSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/TasksCachedProcessor.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/TasksCachedProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/TerminalProfile.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/TerminalProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Win32APISupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Win32APISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/FileSearchParams.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/FileSearchParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/FileSearchSupport.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/FileSearchSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/FileSearcher.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/FileSearcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/impl/LocalFileSearcherImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/impl/LocalFileSearcherImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/impl/RemoteFileSearcherImpl.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/filesearch/impl/RemoteFileSearcherImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/FetchHostInfoTask.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/FetchHostInfoTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/HostInfoProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/HostInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/impl/HostInfoFactory.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/impl/HostInfoFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/impl/UnixHostInfoProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/impl/UnixHostInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/impl/WindowsHostInfoProvider.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/hostinfo/impl/WindowsHostInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/windows/PathConverter.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/windows/PathConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/windows/SimpleConverter.java
+++ b/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/windows/SimpleConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/ConcurrentTasksSupport.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/ConcurrentTasksSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/CopyTaskTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/CopyTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/EnvironmentTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/EnvironmentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/HostInfoTestCase.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/HostInfoTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/IZ182478.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/IZ182478.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/NativeProcessTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/NativeProcessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/NativeTaskTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/NativeTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/NbStartLocalTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/NbStartLocalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/ObservableActionTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/ObservableActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/RedirectErrorTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/RedirectErrorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/RegressionTests.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/RegressionTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/RemoveTaskTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/RemoveTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/ExecutionEnvironmentFactoryTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/ExecutionEnvironmentFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/NativeProcessBuilderTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/NativeProcessBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/ConnectionManagerTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/ConnectionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/FileInfoProviderTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/FileInfoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/HostInfoUtilsTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/HostInfoUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/Md5checkerTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/Md5checkerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/ParallelSftpTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/ParallelSftpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/SlowHostInfoProvider.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/SlowHostInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/StreamsHangup.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/StreamsHangup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/StreamsHangupTestCase.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/StreamsHangupTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/UploadWithMd5CheckTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/UploadWithMd5CheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/WindowsSupportTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/WindowsSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/support/MacroHashMapTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/support/MacroHashMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/support/ShellSessionTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/support/ShellSessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/support/TerminalConfigurationProviderTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/support/TerminalConfigurationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/ClassForAllEnvironments.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/ClassForAllEnvironments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/DummyKeyringProvider.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/DummyKeyringProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/ForAllEnvironments.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/ForAllEnvironments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/If.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/If.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/Ifdef.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/Ifdef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionBaseTestCase.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionBaseTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionBaseTestSuite.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionBaseTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionTestFrameworkTestCase.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionTestFrameworkTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionTestSupport.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NativeExecutionTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NbClustersInfoProvider.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/NbClustersInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/RcFile.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/test/RcFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/util/EncrypterTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/util/EncrypterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/util/MacroExpanderFactoryTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/util/MacroExpanderFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/util/SolarisPrivilegesSupportTest.java
+++ b/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/util/SolarisPrivilegesSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/error.c
+++ b/dlight.nativeexecution/tools/killall/src/error.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/error.h
+++ b/dlight.nativeexecution/tools/killall/src/error.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/killall.c
+++ b/dlight.nativeexecution/tools/killall/src/killall.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/killall.h
+++ b/dlight.nativeexecution/tools/killall/src/killall.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/linux/pfind.c
+++ b/dlight.nativeexecution/tools/killall/src/linux/pfind.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/macosx/pfind.c
+++ b/dlight.nativeexecution/tools/killall/src/macosx/pfind.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/options.c
+++ b/dlight.nativeexecution/tools/killall/src/options.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/options.h
+++ b/dlight.nativeexecution/tools/killall/src/options.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/pfind.h
+++ b/dlight.nativeexecution/tools/killall/src/pfind.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/killall/src/solaris/pfind.c
+++ b/dlight.nativeexecution/tools/killall/src/solaris/pfind.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/privp.c
+++ b/dlight.nativeexecution/tools/privp.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/process_start.c
+++ b/dlight.nativeexecution/tools/process_start.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/env.c
+++ b/dlight.nativeexecution/tools/pty/src/env.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/env.h
+++ b/dlight.nativeexecution/tools/pty/src/env.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/error.c
+++ b/dlight.nativeexecution/tools/pty/src/error.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/error.h
+++ b/dlight.nativeexecution/tools/pty/src/error.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/loop.c
+++ b/dlight.nativeexecution/tools/pty/src/loop.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/loop.h
+++ b/dlight.nativeexecution/tools/pty/src/loop.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/options.c
+++ b/dlight.nativeexecution/tools/pty/src/options.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/options.h
+++ b/dlight.nativeexecution/tools/pty/src/options.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/pty.c
+++ b/dlight.nativeexecution/tools/pty/src/pty.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/pty.h
+++ b/dlight.nativeexecution/tools/pty/src/pty.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/pty_fork.c
+++ b/dlight.nativeexecution/tools/pty/src/pty_fork.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/pty_fork.h
+++ b/dlight.nativeexecution/tools/pty/src/pty_fork.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/util.c
+++ b/dlight.nativeexecution/tools/pty/src/util.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty/src/util.h
+++ b/dlight.nativeexecution/tools/pty/src/util.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/pty_open.c
+++ b/dlight.nativeexecution/tools/pty_open.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/sigqueue.c
+++ b/dlight.nativeexecution/tools/sigqueue.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/stat.c
+++ b/dlight.nativeexecution/tools/stat.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.nativeexecution/tools/unbuffer/src/unbuffer.c
+++ b/dlight.nativeexecution/tools/unbuffer/src/unbuffer.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/api/terminal/TerminalSupport.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/api/terminal/TerminalSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/LocalTerminalAction.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/LocalTerminalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/OpenInEditorActionProvider.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/OpenInEditorActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/OpenInTerminalAction.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/OpenInTerminalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/RemoteTerminalAction.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/RemoteTerminalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/ShowTerminalAction.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/ShowTerminalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalAction.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSettingsAction.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSettingsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/ui/RemoteInfoDialog.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/ui/RemoteInfoDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/dlight.terminal/src/org/netbeans/modules/dlight/terminal/ui/TerminalContainerTopComponent.java
+++ b/dlight.terminal/src/org/netbeans/modules/dlight/terminal/ui/TerminalContainerTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/ChunkedInputStream.java
+++ b/docker.api/src/org/netbeans/modules/docker/ChunkedInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/ChunkedOutputStream.java
+++ b/docker.api/src/org/netbeans/modules/docker/ChunkedOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/ConnectionListener.java
+++ b/docker.api/src/org/netbeans/modules/docker/ConnectionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/Demuxer.java
+++ b/docker.api/src/org/netbeans/modules/docker/Demuxer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/DirectStreamResult.java
+++ b/docker.api/src/org/netbeans/modules/docker/DirectStreamResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/DockerActionAccessor.java
+++ b/docker.api/src/org/netbeans/modules/docker/DockerActionAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/DockerConfig.java
+++ b/docker.api/src/org/netbeans/modules/docker/DockerConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/DockerEventBus.java
+++ b/docker.api/src/org/netbeans/modules/docker/DockerEventBus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/DockerRemoteException.java
+++ b/docker.api/src/org/netbeans/modules/docker/DockerRemoteException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/DockerUtils.java
+++ b/docker.api/src/org/netbeans/modules/docker/DockerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/Endpoint.java
+++ b/docker.api/src/org/netbeans/modules/docker/Endpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/FolderUploader.java
+++ b/docker.api/src/org/netbeans/modules/docker/FolderUploader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/HttpUtils.java
+++ b/docker.api/src/org/netbeans/modules/docker/HttpUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/IgnoreFileFilter.java
+++ b/docker.api/src/org/netbeans/modules/docker/IgnoreFileFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/IgnorePattern.java
+++ b/docker.api/src/org/netbeans/modules/docker/IgnorePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/MuxedStreamResult.java
+++ b/docker.api/src/org/netbeans/modules/docker/MuxedStreamResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/StreamItem.java
+++ b/docker.api/src/org/netbeans/modules/docker/StreamItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/StreamResult.java
+++ b/docker.api/src/org/netbeans/modules/docker/StreamResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/ActionChunkedResult.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/ActionChunkedResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/ActionStreamResult.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/ActionStreamResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/BuildEvent.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/BuildEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/Credentials.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/Credentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/CredentialsManager.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/CredentialsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerAuthenticationException.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerAuthenticationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerConflictException.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerConflictException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerContainer.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerContainerDetail.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerContainerDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerEntity.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerEvent.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerException.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerImage.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerImage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerImageDetail.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerImageDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerInstance.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerName.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerRegistryImage.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerRegistryImage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerSupport.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerTag.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/DockerfileDetail.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/DockerfileDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/ExposedPort.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/ExposedPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/PortMapping.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/PortMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/api/StatusEvent.java
+++ b/docker.api/src/org/netbeans/modules/docker/api/StatusEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/tls/Asn1Object.java
+++ b/docker.api/src/org/netbeans/modules/docker/tls/Asn1Object.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/tls/ContextProvider.java
+++ b/docker.api/src/org/netbeans/modules/docker/tls/ContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/tls/DerParser.java
+++ b/docker.api/src/org/netbeans/modules/docker/tls/DerParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/src/org/netbeans/modules/docker/tls/PrivateKeyParser.java
+++ b/docker.api/src/org/netbeans/modules/docker/tls/PrivateKeyParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/test/unit/src/org/netbeans/modules/docker/ChunkedInputStreamTest.java
+++ b/docker.api/test/unit/src/org/netbeans/modules/docker/ChunkedInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.api/test/unit/src/org/netbeans/modules/docker/IgnorePatternTest.java
+++ b/docker.api/test/unit/src/org/netbeans/modules/docker/IgnorePatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileLanguage.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileResolver.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/completion/DockerfileCompletion.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/completion/DockerfileCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/indent/DockerfileTypedBreakInterceptor.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/indent/DockerfileTypedBreakInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/lexer/DockerfileLexer.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/lexer/DockerfileLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/lexer/DockerfileTokenId.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/lexer/DockerfileTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/parser/Command.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/parser/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/parser/DockerfileParser.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/parser/DockerfileParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/parser/DockerfileResult.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/parser/DockerfileResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.editor/src/org/netbeans/modules/docker/editor/util/DocDownloader.java
+++ b/docker.editor/src/org/netbeans/modules/docker/editor/util/DocDownloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/UiUtils.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/UiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/Validations.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/Validations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildActionListener.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildActionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildContextPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildContextPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildContextVisual.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildContextVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildImageAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildImageAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildImageWizard.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildImageWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildInstancePanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildInstancePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildInstanceVisual.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildInstanceVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildOptionsPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildOptionsVisual.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildOptionsVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildTask.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/BuildTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/build2/InputOutputCache.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/build2/InputOutputCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/commit/CommitContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/commit/CommitContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/commit/CommitPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/commit/CommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsListPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsListPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsUtils.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/credentials/CredentialsUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/AbstractContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/AbstractContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/AttachContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/AttachContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/CopyIdAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/CopyIdAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerChildFactory.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerChildFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerContainerNode.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerContainerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerContainersChildFactory.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerContainersChildFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerContainersNode.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerContainersNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerImagesChildFactory.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerImagesChildFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerImagesNode.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerImagesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerInstanceChildFactory.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerInstanceChildFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerInstanceNode.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerInstanceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerNode.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerTagNode.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/DockerTagNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/GetPortMappingsAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/GetPortMappingsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/NodeClosingFactory.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/NodeClosingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/PauseContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/PauseContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/PushTagAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/PushTagAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/RefreshAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/RefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/Refreshable.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/Refreshable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/RemoveContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/RemoveContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/RemoveInstanceAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/RemoveInstanceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/RemoveTagAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/RemoveTagAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/ShowLogAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/ShowLogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/StartContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/StartContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/StatefulDockerContainer.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/StatefulDockerContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/StatefulDockerInstance.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/StatefulDockerInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/StopContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/StopContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/UnpauseContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/UnpauseContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/node/ViewPortBindingsPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/node/ViewPortBindingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/output/ChunkedResultOutputTask.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/output/ChunkedResultOutputTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/output/ExceptionHandler.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/output/ExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/output/OutputUtils.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/output/OutputUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/output/StatusOutputListener.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/output/StatusOutputListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/output/TerminalInputStream.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/output/TerminalInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/output/TerminalOptionsAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/output/TerminalOptionsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/output/TerminalResizeListener.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/output/TerminalResizeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/pull/DockerHubImageItem.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/pull/DockerHubImageItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/pull/DockerHubSearchPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/pull/DockerHubSearchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/pull/PullImageAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/pull/PullImageAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/rename/RenameContainerAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/rename/RenameContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/rename/RenamePanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/rename/RenamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/run/RunContainerPropertiesPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/run/RunContainerPropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/run/RunContainerPropertiesVisual.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/run/RunContainerPropertiesVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/run/RunPortBindingsPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/run/RunPortBindingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/run/RunPortBindingsVisual.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/run/RunPortBindingsVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/run/RunTagAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/run/RunTagAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/run/RunTagWizard.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/run/RunTagWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/tag/TagPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/tag/TagPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/tag/TagTagAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/tag/TagTagAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/wizard/AddDockerInstanceAction.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/wizard/AddDockerInstanceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/wizard/AddDockerInstanceWizard.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/wizard/AddDockerInstanceWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/wizard/Configuration.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/wizard/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/wizard/ConfigurationLinuxPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/wizard/ConfigurationLinuxPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/wizard/ConfigurationPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/wizard/ConfigurationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/wizard/DockerConnectionPanel.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/wizard/DockerConnectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/src/org/netbeans/modules/docker/ui/wizard/DockerConnectionVisual.java
+++ b/docker.ui/src/org/netbeans/modules/docker/ui/wizard/DockerConnectionVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/docker.ui/test/unit/src/org/netbeans/modules/docker/ui/ValidationsTest.java
+++ b/docker.ui/test/unit/src/org/netbeans/modules/docker/ui/ValidationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/AddCaretAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/AddCaretAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/CamelCaseActions.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/CamelCaseActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/GotoAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/GotoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/MoveCodeElementAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/MoveCodeElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/PasteLinesAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/PasteLinesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/RemoveLastCaretAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/RemoveLastCaretAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/ShowLinesAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/ShowLinesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/ToggleAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/ToggleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/ToggleTypingModeAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/ToggleTypingModeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/TransposeLettersAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/TransposeLettersAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.actions/src/org/netbeans/modules/editor/actions/ZoomTextAction.java
+++ b/editor.actions/src/org/netbeans/modules/editor/actions/ZoomTextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/ClearDocumentBookmarksAction.java
+++ b/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/ClearDocumentBookmarksAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/GotoBookmarkAction.java
+++ b/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/GotoBookmarkAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/ToggleBookmarkAction.java
+++ b/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/ToggleBookmarkAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/api/Bookmark.java
+++ b/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/api/Bookmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/api/BookmarkList.java
+++ b/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/api/BookmarkList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkAPIAccessor.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkAPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkChange.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkHistory.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkInfo.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkManager.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkManagerEvent.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkManagerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkManagerListener.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkUtils.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarkUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarksPersistence.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/BookmarksPersistence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/EditorBookmarksModule.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/EditorBookmarksModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/FileBookmarks.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/FileBookmarks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/FileBookmarksChange.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/FileBookmarksChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ProjectBookmarks.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ProjectBookmarks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ProjectBookmarksChange.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ProjectBookmarksChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/WrapperBookmarkAction.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/WrapperBookmarkAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkHistoryPopup.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkHistoryPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkHistoryPopupAction.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkHistoryPopupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkKeyChooser.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkKeyChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkNode.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkNodeRenderer.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarkNodeRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksNodeTree.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksNodeTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksTable.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksTableModel.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksView.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/GotoLineOrBookmarkPanel.java
+++ b/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/GotoLineOrBookmarkPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testBookmarkMerge.java
+++ b/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testBookmarkMerge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testBookmarkMove.java
+++ b/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testBookmarkMove.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testNextBookmark.java
+++ b/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testNextBookmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testPersistence.java
+++ b/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testPersistence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testPreviousBookmark.java
+++ b/editor.bookmarks/test/qa-functional/data/projects/editor_bookmarks_test/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest/testPreviousBookmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest.java
+++ b/editor.bookmarks/test/qa-functional/src/org/netbeans/test/bookmarks/BookmarksPersistenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/src/org/netbeans/test/bookmarks/EditorBookmarksTestCase.java
+++ b/editor.bookmarks/test/qa-functional/src/org/netbeans/test/bookmarks/EditorBookmarksTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/qa-functional/src/org/netbeans/test/bookmarks/EditorTestCase.java
+++ b/editor.bookmarks/test/qa-functional/src/org/netbeans/test/bookmarks/EditorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bookmarks/test/unit/src/org/netbeans/lib/editor/bookmarks/api/BookmarkTest.java
+++ b/editor.bookmarks/test/unit/src/org/netbeans/lib/editor/bookmarks/api/BookmarkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BraceMatchingSidebarComponent.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BraceMatchingSidebarComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BraceMatchingSidebarFactory.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BraceMatchingSidebarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BraceToolTip.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BraceToolTip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BracesMatchAction.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BracesMatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BracesMatchHighlighting.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/BracesMatchHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/ControlPanel.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/ControlPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/ControlPanelAction.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/ControlPanelAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/LegacyEssMatcher.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/LegacyEssMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MasterMatcher.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MasterMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MatchEvent.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MatchEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MatchListener.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MatchListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/SkipLinesViewFactory.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/SkipLinesViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/SpiAccessor.java
+++ b/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/SpiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BraceContext.java
+++ b/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BraceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BracesMatcher.java
+++ b/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BracesMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BracesMatcherFactory.java
+++ b/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BracesMatcherFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/MatcherContext.java
+++ b/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/MatcherContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/support/BracesMatcherSupport.java
+++ b/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/support/BracesMatcherSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/support/CharacterMatcher.java
+++ b/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/support/CharacterMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/test/unit/src/org/netbeans/modules/editor/bracesmatching/MasterMatcherTest.java
+++ b/editor.bracesmatching/test/unit/src/org/netbeans/modules/editor/bracesmatching/MasterMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.bracesmatching/test/unit/src/org/netbeans/modules/editor/bracesmatching/api/BracesMatchingTestUtils.java
+++ b/editor.bracesmatching/test/unit/src/org/netbeans/modules/editor/bracesmatching/api/BracesMatchingTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbsNodeImpl.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbsNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/HolderImpl.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/HolderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/MenuAction.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/MenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/SideBarFactoryImpl.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/SideBarFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/spi/BreadcrumbsController.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/spi/BreadcrumbsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/spi/BreadcrumbsElement.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/spi/BreadcrumbsElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/support/BreadCrumbsScheduler.java
+++ b/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/support/BreadCrumbsScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/AbbrevDetection.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/AbbrevDetection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateApiPackageAccessor.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateApiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateComparator.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateCompletionItem.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateCompletionProvider.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandler.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateManagerOperation.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateManagerOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImpl.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateSpiPackageAccessor.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateSpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplatesModule.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplatesModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/ParametrizedTextParser.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/ParametrizedTextParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/SurroundWithFix.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/SurroundWithFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/SyncDocumentRegion.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/SyncDocumentRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/api/CodeTemplate.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/api/CodeTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/api/CodeTemplateManager.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/api/CodeTemplateManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateFilter.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateInsertRequest.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateInsertRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateParameter.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateProcessor.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateProcessorFactory.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateProcessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplateSettingsImpl.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplateSettingsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplatesStorage.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplatesStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/SettingsProvider.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/SettingsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesPanel.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesPanelController.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegion.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManager.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerEvent.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerListener.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextSync.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextSync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextSyncGroup.java
+++ b/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextSyncGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CTManagerOperationBridge.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CTManagerOperationBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CTProcessor.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CTProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandlerTest.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplatesTest.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/spi/ParameterParsingTest.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/spi/ParameterParsingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplateSettingsImplTest.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplateSettingsImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplatesLocatorTest.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/storage/CodeTemplatesLocatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerTest.java
+++ b/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/api/editor/completion/Completion.java
+++ b/editor.completion/src/org/netbeans/api/editor/completion/Completion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionActionsMainMenu.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionActionsMainMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionImpl.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionImplProfile.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionImplProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionItemComparator.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionItemComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionLayout.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionLayoutPopup.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionLayoutPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionModule.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionResultSetImpl.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionResultSetImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionScrollPane.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionScrollPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionSettings.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/CompletionSpiPackageAccessor.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/CompletionSpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/DocumentationScrollPane.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/DocumentationScrollPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/HTMLDocView.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/HTMLDocView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/LazyListModel.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/LazyListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/MulticaretHandler.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/MulticaretHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/modules/editor/completion/PatchedHtmlRenderer.java
+++ b/editor.completion/src/org/netbeans/modules/editor/completion/PatchedHtmlRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/CompletionDocumentation.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/CompletionDocumentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/CompletionProvider.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/CompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/CompletionResultSet.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/CompletionResultSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/CompletionTask.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/CompletionTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/CompositeCompletionItem.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/CompositeCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/LazyCompletionItem.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/LazyCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/support/AsyncCompletionQuery.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/support/AsyncCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/support/AsyncCompletionTask.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/support/AsyncCompletionTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.completion/src/org/netbeans/spi/editor/completion/support/CompletionUtilities.java
+++ b/editor.completion/src/org/netbeans/spi/editor/completion/support/CompletionUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/Formatter.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/Formatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/AbstractFormatLayer.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/AbstractFormatLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatSupport.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatLayer.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatSupport.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPosition.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatWriter.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/FormatterIndentEngine.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/FormatterIndentEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/FormatterIndentEngineBeanInfo.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/FormatterIndentEngineBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/IndentEngineFormatter.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/IndentEngineFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/SimpleIndentEngine.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/SimpleIndentEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/SimpleIndentEngineBeanInfo.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/SimpleIndentEngineBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/deprecated/pre65formatting/ComplexValueSettingsFactory.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/deprecated/pre65formatting/ComplexValueSettingsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/deprecated/pre65formatting/LegacyFormattersProvider.java
+++ b/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/deprecated/pre65formatting/LegacyFormattersProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/AtomicLockDocument.java
+++ b/editor.document/src/org/netbeans/api/editor/document/AtomicLockDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/AtomicLockEvent.java
+++ b/editor.document/src/org/netbeans/api/editor/document/AtomicLockEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/AtomicLockListener.java
+++ b/editor.document/src/org/netbeans/api/editor/document/AtomicLockListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/ComplexPositions.java
+++ b/editor.document/src/org/netbeans/api/editor/document/ComplexPositions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/CustomUndoDocument.java
+++ b/editor.document/src/org/netbeans/api/editor/document/CustomUndoDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/DocumentLockState.java
+++ b/editor.document/src/org/netbeans/api/editor/document/DocumentLockState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/EditorDocumentUtils.java
+++ b/editor.document/src/org/netbeans/api/editor/document/EditorDocumentUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/EditorMimeTypes.java
+++ b/editor.document/src/org/netbeans/api/editor/document/EditorMimeTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/LineDocument.java
+++ b/editor.document/src/org/netbeans/api/editor/document/LineDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/api/editor/document/LineDocumentUtils.java
+++ b/editor.document/src/org/netbeans/api/editor/document/LineDocumentUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/document/DocumentServices.java
+++ b/editor.document/src/org/netbeans/modules/editor/document/DocumentServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/document/StubImpl.java
+++ b/editor.document/src/org/netbeans/modules/editor/document/StubImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/document/TextSearchUtils.java
+++ b/editor.document/src/org/netbeans/modules/editor/document/TextSearchUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/document/implspi/CharClassifier.java
+++ b/editor.document/src/org/netbeans/modules/editor/document/implspi/CharClassifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/document/implspi/DocumentServiceFactory.java
+++ b/editor.document/src/org/netbeans/modules/editor/document/implspi/DocumentServiceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib/WcwdithUtil.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib/WcwdithUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/Acceptor.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/Acceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/AcceptorFactory.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/AcceptorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/DocumentPreferencesDefaults.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/DocumentPreferencesDefaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/DocumentPreferencesKeys.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/DocumentPreferencesKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/AbstractPositionElement.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/AbstractPositionElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/AbstractRootElement.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/AbstractRootElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/CharContent.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/CharContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/ComplexPos.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/ComplexPos.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/ContentEdit.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/ContentEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/DefaultDocumentCharacterAcceptor.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/DefaultDocumentCharacterAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/DefaultEditorCharacterServices.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/DefaultEditorCharacterServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/DocumentCharacterAcceptor.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/DocumentCharacterAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/DocumentInternalUtils.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/DocumentInternalUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorCharacterServices.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorCharacterServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorDocumentContent.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorDocumentContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorDocumentHandler.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorDocumentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorDocumentServices.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorDocumentServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorPosition.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/EditorPosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/LineElement.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/LineElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/LineRootElement.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/LineRootElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/ListUndoableEdit.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/ListUndoableEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/Mark.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/Mark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/MarkVector.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/MarkVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/ModElement.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/ModElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/ModRootElement.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/ModRootElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/ReadWriteBuffer.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/ReadWriteBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/ReadWriteUtils.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/ReadWriteUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/modules/editor/lib2/document/StableCompoundEdit.java
+++ b/editor.document/src/org/netbeans/modules/editor/lib2/document/StableCompoundEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/spi/editor/document/DocumentFactory.java
+++ b/editor.document/src/org/netbeans/spi/editor/document/DocumentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/spi/editor/document/EditorMimeTypesImplementation.java
+++ b/editor.document/src/org/netbeans/spi/editor/document/EditorMimeTypesImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/src/org/netbeans/spi/editor/document/UndoableEditWrapper.java
+++ b/editor.document/src/org/netbeans/spi/editor/document/UndoableEditWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/api/editor/document/ComplexPositionsTest.java
+++ b/editor.document/test/unit/src/org/netbeans/api/editor/document/ComplexPositionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/document/TextSearchUtilsTest.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/document/TextSearchUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/DocumentContentTesting.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/DocumentContentTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/EditorDocumentContentTest.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/EditorDocumentContentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/ExpectedDocument.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/ExpectedDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/ExpectedDocumentContent.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/ExpectedDocumentContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/PositionSyncList.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/PositionSyncList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/ReadWriteUtilsTest.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/ReadWriteUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/StableCompoundEditTest.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/StableCompoundEditTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/TestEditorDocument.java
+++ b/editor.document/test/unit/src/org/netbeans/modules/editor/lib2/document/TestEditorDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe.api/src/org/netbeans/modules/editor/errorstripe/apimodule/SPIAccessor.java
+++ b/editor.errorstripe.api/src/org/netbeans/modules/editor/errorstripe/apimodule/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/SPIAccessorImpl.java
+++ b/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/SPIAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/UpToDateStatus.java
+++ b/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/UpToDateStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/UpToDateStatusProvider.java
+++ b/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/UpToDateStatusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/UpToDateStatusProviderFactory.java
+++ b/editor.errorstripe.api/src/org/netbeans/spi/editor/errorstripe/UpToDateStatusProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationMark.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationView.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewData.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImpl.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewFactory.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/caret/CaretMark.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/caret/CaretMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/caret/CaretMarkProvider.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/caret/CaretMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/caret/CaretMarkProviderCreator.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/caret/CaretMarkProviderCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/Mark.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/Mark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/MarkProvider.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/MarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/MarkProviderCreator.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/MarkProviderCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/Status.java
+++ b/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/privatespi/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationTestUtilities.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationTestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImplTest.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationViewTest.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/TestMark.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/TestMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/TestMarkProvider.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/TestMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/TestMarkProviderCreator.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/TestMarkProviderCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/UnitUtilities.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/UnitUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/spi/StatusTest.java
+++ b/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/spi/StatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/api/editor/fold/ui/FoldingUISupport.java
+++ b/editor.fold.nbui/src/org/netbeans/api/editor/fold/ui/FoldingUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/ActionFactory.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/ActionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CaretFoldExpanderImpl.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CaretFoldExpanderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CodeFoldingSideBar.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CodeFoldingSideBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CustomizerWithDefaults.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CustomizerWithDefaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/DefaultFoldingOptions.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/DefaultFoldingOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldContentReaders.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldContentReaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsController.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsPanel.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldToolTip.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldToolTip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldUtilitiesImpl.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldUtilitiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldView.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldViewFactory.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldingEditorSupport.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldingEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/InheritedPreferences.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/InheritedPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/VerticalFlowLayout.java
+++ b/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/VerticalFlowLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold.nbui/test/unit/src/org/netbeans/modules/editor/fold/ui/BaseCaretTest.java
+++ b/editor.fold.nbui/test/unit/src/org/netbeans/modules/editor/fold/ui/BaseCaretTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/Fold.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/Fold.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldHierarchy.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldHierarchyEvent.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldHierarchyEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldHierarchyListener.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldHierarchyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldStateChange.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldStateChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldTemplate.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldType.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldUtilities.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/api/editor/fold/FoldingSupport.java
+++ b/editor.fold/src/org/netbeans/api/editor/fold/FoldingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/ApiPackageAccessor.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/ApiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/CustomFoldManager.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/CustomFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/CustomProvider.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/CustomProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/DefaultFoldProvider.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/DefaultFoldProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/FoldChildren.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/FoldChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/FoldHierarchyExecution.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/FoldHierarchyExecution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/FoldHierarchyTransactionImpl.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/FoldHierarchyTransactionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/FoldManagerFactoryProvider.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/FoldManagerFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/FoldOperationImpl.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/FoldOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/FoldRegistry.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/FoldRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/FoldUtilitiesImpl.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/FoldUtilitiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/GapObjectArray.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/GapObjectArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/HierarchyErrorException.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/HierarchyErrorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/JavadocReader.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/JavadocReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/LayerProvider.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/LayerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/LegacySettingsSync.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/LegacySettingsSync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/modules/editor/fold/SpiPackageAccessor.java
+++ b/editor.fold/src/org/netbeans/modules/editor/fold/SpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/ContentReader.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/ContentReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/FoldHierarchyMonitor.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/FoldHierarchyMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/FoldHierarchyTransaction.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/FoldHierarchyTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/FoldInfo.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/FoldInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/FoldManager.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/FoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/FoldManagerFactory.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/FoldManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/FoldOperation.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/FoldOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/src/org/netbeans/spi/editor/fold/FoldTypeProvider.java
+++ b/editor.fold/src/org/netbeans/spi/editor/fold/FoldTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/AbstractFoldManager.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/AbstractFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/DoubleFoldManagerTest.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/DoubleFoldManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldContentReaderTest.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldContentReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldGuardTest.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldGuardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldHierarchyTestEnv.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldHierarchyTestEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldManagerTesting.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldManagerTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldOperationTest.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldOperationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/NestedFoldManagerTest.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/NestedFoldManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/RandomFoldManagerTest.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/RandomFoldManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/SimpleFoldManagerTest.java
+++ b/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/SimpleFoldManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.global.format/src/org/netbeans/modules/editor/global/format/ConfirmationPanel.java
+++ b/editor.global.format/src/org/netbeans/modules/editor/global/format/ConfirmationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.global.format/src/org/netbeans/modules/editor/global/format/GlobalFormatAction.java
+++ b/editor.global.format/src/org/netbeans/modules/editor/global/format/GlobalFormatAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/api/editor/guards/DocumentGuards.java
+++ b/editor.guards/src/org/netbeans/api/editor/guards/DocumentGuards.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/api/editor/guards/GuardedSection.java
+++ b/editor.guards/src/org/netbeans/api/editor/guards/GuardedSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/api/editor/guards/GuardedSectionManager.java
+++ b/editor.guards/src/org/netbeans/api/editor/guards/GuardedSectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/api/editor/guards/InteriorSection.java
+++ b/editor.guards/src/org/netbeans/api/editor/guards/InteriorSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/api/editor/guards/SimpleSection.java
+++ b/editor.guards/src/org/netbeans/api/editor/guards/SimpleSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/GuardedPositionComparator.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/GuardedPositionComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/GuardedReader.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/GuardedReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/GuardedSectionImpl.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/GuardedSectionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/GuardedSectionsImpl.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/GuardedSectionsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/GuardedWriter.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/GuardedWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/GuardsAccessor.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/GuardsAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/GuardsSupportAccessor.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/GuardsSupportAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/InteriorSectionImpl.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/InteriorSectionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/NewLine.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/NewLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/OffsetPosition.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/OffsetPosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/PositionBounds.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/PositionBounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/modules/editor/guards/SimpleSectionImpl.java
+++ b/editor.guards/src/org/netbeans/modules/editor/guards/SimpleSectionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/spi/editor/guards/GuardedEditorSupport.java
+++ b/editor.guards/src/org/netbeans/spi/editor/guards/GuardedEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/spi/editor/guards/GuardedRegionMarker.java
+++ b/editor.guards/src/org/netbeans/spi/editor/guards/GuardedRegionMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/spi/editor/guards/GuardedSectionsFactory.java
+++ b/editor.guards/src/org/netbeans/spi/editor/guards/GuardedSectionsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/spi/editor/guards/GuardedSectionsProvider.java
+++ b/editor.guards/src/org/netbeans/spi/editor/guards/GuardedSectionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/src/org/netbeans/spi/editor/guards/support/AbstractGuardedSectionsProvider.java
+++ b/editor.guards/src/org/netbeans/spi/editor/guards/support/AbstractGuardedSectionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/test/unit/src/org/netbeans/api/editor/guards/Editor.java
+++ b/editor.guards/test/unit/src/org/netbeans/api/editor/guards/Editor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/test/unit/src/org/netbeans/api/editor/guards/GuardUtils.java
+++ b/editor.guards/test/unit/src/org/netbeans/api/editor/guards/GuardUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/test/unit/src/org/netbeans/api/editor/guards/GuardedSectionManagerTest.java
+++ b/editor.guards/test/unit/src/org/netbeans/api/editor/guards/GuardedSectionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.guards/test/unit/src/org/netbeans/modules/editor/guards/PositionBoundsTest.java
+++ b/editor.guards/test/unit/src/org/netbeans/modules/editor/guards/PositionBoundsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent.project/src/org/netbeans/modules/editor/indent/project/FormattingCustomizerPanel.java
+++ b/editor.indent.project/src/org/netbeans/modules/editor/indent/project/FormattingCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent.project/src/org/netbeans/modules/editor/indent/project/ProjectAwareCodeStylePreferences.java
+++ b/editor.indent.project/src/org/netbeans/modules/editor/indent/project/ProjectAwareCodeStylePreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent.project/src/org/netbeans/modules/editor/indent/project/ProxyPreferences.java
+++ b/editor.indent.project/src/org/netbeans/modules/editor/indent/project/ProxyPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent.project/src/org/netbeans/modules/editor/indent/project/api/Customizers.java
+++ b/editor.indent.project/src/org/netbeans/modules/editor/indent/project/api/Customizers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent.project/test/unit/src/org/netbeans/modules/editor/indent/project/ProxyPreferencesTest.java
+++ b/editor.indent.project/test/unit/src/org/netbeans/modules/editor/indent/project/ProxyPreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent.support/src/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.java
+++ b/editor.indent.support/src/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/FormatterWriterImpl.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/FormatterWriterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/IndentImpl.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/IndentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/IndentScriptEngineHack.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/IndentScriptEngineHack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/IndentSpiPackageAccessor.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/IndentSpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/TaskHandler.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/TaskHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/api/Indent.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/api/Indent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/api/IndentUtils.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/api/IndentUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/api/Reformat.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/api/Reformat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/spi/CodeStylePreferences.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/spi/CodeStylePreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/spi/Context.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/spi/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/spi/ExtraLock.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/spi/ExtraLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/spi/IndentTask.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/spi/IndentTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/src/org/netbeans/modules/editor/indent/spi/ReformatTask.java
+++ b/editor.indent/src/org/netbeans/modules/editor/indent/spi/ReformatTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/IndentActionsTest.java
+++ b/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/IndentActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/api/EmbeddedIndentTest.java
+++ b/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/api/EmbeddedIndentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/api/IndentTest.java
+++ b/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/api/IndentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/api/IndentUtilsTest.java
+++ b/editor.indent/test/unit/src/org/netbeans/modules/editor/indent/api/IndentUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/BasicSearchAndReplaceTest.java
+++ b/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/BasicSearchAndReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/BasicSearchTest.java
+++ b/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/BasicSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/SearchResultsOperator.java
+++ b/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/SearchResultsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/Utilities.java
+++ b/editor.kit/test/qa-functional/src/org/netbeans/test/modules/search/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Abbrev.java
+++ b/editor.lib/src/org/netbeans/editor/Abbrev.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Acceptor.java
+++ b/editor.lib/src/org/netbeans/editor/Acceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AcceptorFactory.java
+++ b/editor.lib/src/org/netbeans/editor/AcceptorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ActionFactory.java
+++ b/editor.lib/src/org/netbeans/editor/ActionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AdjustFinder.java
+++ b/editor.lib/src/org/netbeans/editor/AdjustFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Analyzer.java
+++ b/editor.lib/src/org/netbeans/editor/Analyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AnnotationDesc.java
+++ b/editor.lib/src/org/netbeans/editor/AnnotationDesc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AnnotationType.java
+++ b/editor.lib/src/org/netbeans/editor/AnnotationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AnnotationTypes.java
+++ b/editor.lib/src/org/netbeans/editor/AnnotationTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Annotations.java
+++ b/editor.lib/src/org/netbeans/editor/Annotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AtomicLockDocument.java
+++ b/editor.lib/src/org/netbeans/editor/AtomicLockDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AtomicLockEvent.java
+++ b/editor.lib/src/org/netbeans/editor/AtomicLockEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/AtomicLockListener.java
+++ b/editor.lib/src/org/netbeans/editor/AtomicLockListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseAction.java
+++ b/editor.lib/src/org/netbeans/editor/BaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseCaret.java
+++ b/editor.lib/src/org/netbeans/editor/BaseCaret.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseDocument.java
+++ b/editor.lib/src/org/netbeans/editor/BaseDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseDocumentEvent.java
+++ b/editor.lib/src/org/netbeans/editor/BaseDocumentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseElement.java
+++ b/editor.lib/src/org/netbeans/editor/BaseElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseImageTokenID.java
+++ b/editor.lib/src/org/netbeans/editor/BaseImageTokenID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseKit.java
+++ b/editor.lib/src/org/netbeans/editor/BaseKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseTextUI.java
+++ b/editor.lib/src/org/netbeans/editor/BaseTextUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseTokenCategory.java
+++ b/editor.lib/src/org/netbeans/editor/BaseTokenCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseTokenID.java
+++ b/editor.lib/src/org/netbeans/editor/BaseTokenID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/BaseView.java
+++ b/editor.lib/src/org/netbeans/editor/BaseView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/CharSeq.java
+++ b/editor.lib/src/org/netbeans/editor/CharSeq.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/CodeFoldingSideBar.java
+++ b/editor.lib/src/org/netbeans/editor/CodeFoldingSideBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Coloring.java
+++ b/editor.lib/src/org/netbeans/editor/Coloring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/CustomFoldManager.java
+++ b/editor.lib/src/org/netbeans/editor/CustomFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/DelegateAction.java
+++ b/editor.lib/src/org/netbeans/editor/DelegateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/DialogSupport.java
+++ b/editor.lib/src/org/netbeans/editor/DialogSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/DocumentContent.java
+++ b/editor.lib/src/org/netbeans/editor/DocumentContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/DocumentUtilities.java
+++ b/editor.lib/src/org/netbeans/editor/DocumentUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/EditorDebug.java
+++ b/editor.lib/src/org/netbeans/editor/EditorDebug.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/EditorState.java
+++ b/editor.lib/src/org/netbeans/editor/EditorState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/EditorUI.java
+++ b/editor.lib/src/org/netbeans/editor/EditorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Finder.java
+++ b/editor.lib/src/org/netbeans/editor/Finder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/FinderFactory.java
+++ b/editor.lib/src/org/netbeans/editor/FinderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/FixLineSyntaxState.java
+++ b/editor.lib/src/org/netbeans/editor/FixLineSyntaxState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/FoldingToolTip.java
+++ b/editor.lib/src/org/netbeans/editor/FoldingToolTip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/FontMetricsCache.java
+++ b/editor.lib/src/org/netbeans/editor/FontMetricsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/GapObjectArray.java
+++ b/editor.lib/src/org/netbeans/editor/GapObjectArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/GapStart.java
+++ b/editor.lib/src/org/netbeans/editor/GapStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/GlyphGutter.java
+++ b/editor.lib/src/org/netbeans/editor/GlyphGutter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/GuardedDocument.java
+++ b/editor.lib/src/org/netbeans/editor/GuardedDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/GuardedDocumentEvent.java
+++ b/editor.lib/src/org/netbeans/editor/GuardedDocumentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/GuardedException.java
+++ b/editor.lib/src/org/netbeans/editor/GuardedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ImageTokenID.java
+++ b/editor.lib/src/org/netbeans/editor/ImageTokenID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ImplementationProvider.java
+++ b/editor.lib/src/org/netbeans/editor/ImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/InvalidMarkException.java
+++ b/editor.lib/src/org/netbeans/editor/InvalidMarkException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/JumpList.java
+++ b/editor.lib/src/org/netbeans/editor/JumpList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/KeySequenceInputPanel.java
+++ b/editor.lib/src/org/netbeans/editor/KeySequenceInputPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/LeafElement.java
+++ b/editor.lib/src/org/netbeans/editor/LeafElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/LeafView.java
+++ b/editor.lib/src/org/netbeans/editor/LeafView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/LineElement.java
+++ b/editor.lib/src/org/netbeans/editor/LineElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/LineRootElement.java
+++ b/editor.lib/src/org/netbeans/editor/LineRootElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/LineSeparatorConversion.java
+++ b/editor.lib/src/org/netbeans/editor/LineSeparatorConversion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/LocalBaseAction.java
+++ b/editor.lib/src/org/netbeans/editor/LocalBaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/LocaleSupport.java
+++ b/editor.lib/src/org/netbeans/editor/LocaleSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MacroDialogSupport.java
+++ b/editor.lib/src/org/netbeans/editor/MacroDialogSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MacroSavePanel.java
+++ b/editor.lib/src/org/netbeans/editor/MacroSavePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Mark.java
+++ b/editor.lib/src/org/netbeans/editor/Mark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MarkBlock.java
+++ b/editor.lib/src/org/netbeans/editor/MarkBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MarkBlockChain.java
+++ b/editor.lib/src/org/netbeans/editor/MarkBlockChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MarkFactory.java
+++ b/editor.lib/src/org/netbeans/editor/MarkFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MimeTypeInitializer.java
+++ b/editor.lib/src/org/netbeans/editor/MimeTypeInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MultiKeyBinding.java
+++ b/editor.lib/src/org/netbeans/editor/MultiKeyBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/MultiKeymap.java
+++ b/editor.lib/src/org/netbeans/editor/MultiKeymap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ObjectArray.java
+++ b/editor.lib/src/org/netbeans/editor/ObjectArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ObjectArrayUtilities.java
+++ b/editor.lib/src/org/netbeans/editor/ObjectArrayUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/PopupManager.java
+++ b/editor.lib/src/org/netbeans/editor/PopupManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/PrintContainer.java
+++ b/editor.lib/src/org/netbeans/editor/PrintContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Registry.java
+++ b/editor.lib/src/org/netbeans/editor/Registry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/SegmentCache.java
+++ b/editor.lib/src/org/netbeans/editor/SegmentCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/SideBarFactory.java
+++ b/editor.lib/src/org/netbeans/editor/SideBarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/StatusBar.java
+++ b/editor.lib/src/org/netbeans/editor/StatusBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/StringMap.java
+++ b/editor.lib/src/org/netbeans/editor/StringMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Syntax.java
+++ b/editor.lib/src/org/netbeans/editor/Syntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/SyntaxDebug.java
+++ b/editor.lib/src/org/netbeans/editor/SyntaxDebug.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/SyntaxSeg.java
+++ b/editor.lib/src/org/netbeans/editor/SyntaxSeg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/SyntaxSupport.java
+++ b/editor.lib/src/org/netbeans/editor/SyntaxSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/SyntaxUpdateTokens.java
+++ b/editor.lib/src/org/netbeans/editor/SyntaxUpdateTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/TextBatchProcessor.java
+++ b/editor.lib/src/org/netbeans/editor/TextBatchProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/TokenCategory.java
+++ b/editor.lib/src/org/netbeans/editor/TokenCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/TokenContext.java
+++ b/editor.lib/src/org/netbeans/editor/TokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/TokenContextPath.java
+++ b/editor.lib/src/org/netbeans/editor/TokenContextPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/TokenID.java
+++ b/editor.lib/src/org/netbeans/editor/TokenID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/TokenItem.java
+++ b/editor.lib/src/org/netbeans/editor/TokenItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/TokenProcessor.java
+++ b/editor.lib/src/org/netbeans/editor/TokenProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/Utilities.java
+++ b/editor.lib/src/org/netbeans/editor/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/WeakEventListenerList.java
+++ b/editor.lib/src/org/netbeans/editor/WeakEventListenerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/WeakPropertyChangeSupport.java
+++ b/editor.lib/src/org/netbeans/editor/WeakPropertyChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/WeakTimerListener.java
+++ b/editor.lib/src/org/netbeans/editor/WeakTimerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/WordMatch.java
+++ b/editor.lib/src/org/netbeans/editor/WordMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/CharacterArrayIterator.java
+++ b/editor.lib/src/org/netbeans/editor/ext/CharacterArrayIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/DataAccessor.java
+++ b/editor.lib/src/org/netbeans/editor/ext/DataAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/ExtCaret.java
+++ b/editor.lib/src/org/netbeans/editor/ext/ExtCaret.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/ExtFinderFactory.java
+++ b/editor.lib/src/org/netbeans/editor/ext/ExtFinderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
+++ b/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/ExtSyntaxSupport.java
+++ b/editor.lib/src/org/netbeans/editor/ext/ExtSyntaxSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/FileAccessor.java
+++ b/editor.lib/src/org/netbeans/editor/ext/FileAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/FileStorage.java
+++ b/editor.lib/src/org/netbeans/editor/ext/FileStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/GotoDialogPanel.java
+++ b/editor.lib/src/org/netbeans/editor/ext/GotoDialogPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/GotoDialogSupport.java
+++ b/editor.lib/src/org/netbeans/editor/ext/GotoDialogSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/KeyEventBlocker.java
+++ b/editor.lib/src/org/netbeans/editor/ext/KeyEventBlocker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/KeywordMatchGenerator.java
+++ b/editor.lib/src/org/netbeans/editor/ext/KeywordMatchGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/MultiSyntax.java
+++ b/editor.lib/src/org/netbeans/editor/ext/MultiSyntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/StringCache.java
+++ b/editor.lib/src/org/netbeans/editor/ext/StringCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/ext/ToolTipSupport.java
+++ b/editor.lib/src/org/netbeans/editor/ext/ToolTipSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/EstimatedSpanView.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/EstimatedSpanView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/FlyView.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/FlyView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/LockView.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/LockView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/RenderingContextView.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/RenderingContextView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/ViewFragment.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/ViewFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/ViewHierarchyMutex.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/ViewHierarchyMutex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/ViewInsets.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/ViewInsets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/ViewLayoutQueue.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/ViewLayoutQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/ViewLayoutState.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/ViewLayoutState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/ViewRenderingContext.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/ViewRenderingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/editor/view/spi/ViewUtilities.java
+++ b/editor.lib/src/org/netbeans/editor/view/spi/ViewUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/hyperlink/HyperlinkOperation.java
+++ b/editor.lib/src/org/netbeans/lib/editor/hyperlink/HyperlinkOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/hyperlink/spi/HyperlinkProvider.java
+++ b/editor.lib/src/org/netbeans/lib/editor/hyperlink/spi/HyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/hyperlink/spi/HyperlinkProviderExt.java
+++ b/editor.lib/src/org/netbeans/lib/editor/hyperlink/spi/HyperlinkProviderExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/hyperlink/spi/HyperlinkType.java
+++ b/editor.lib/src/org/netbeans/lib/editor/hyperlink/spi/HyperlinkType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/DefaultViewLayoutState.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/DefaultViewLayoutState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapBoxView.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapBoxView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapBoxViewChildren.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapBoxViewChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapDocumentView.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapDocumentView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapDocumentViewChildren.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapDocumentViewChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapLineView.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapLineView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapLineViewChildren.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapLineViewChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapMultiLineView.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapMultiLineView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/GapObjectArray.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/GapObjectArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/SimpleViewLayoutState.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/SimpleViewLayoutState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/lib/editor/view/ViewUtilitiesImpl.java
+++ b/editor.lib/src/org/netbeans/lib/editor/view/ViewUtilitiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/BaseDocument_PropertyHandler.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/BaseDocument_PropertyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/BeforeSaveTasks.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/BeforeSaveTasks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/ColoringMap.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/ColoringMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/DocumentGuardsImpl.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/DocumentGuardsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/DocumentServices.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/DocumentServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/EditorExtPackageAccessor.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/EditorExtPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/EditorPackageAccessor.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/EditorPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/KitsTracker.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/KitsTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/SettingsConversions.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/SettingsConversions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/TrailingWhitespaceRemove.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/TrailingWhitespaceRemove.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/ChainDrawMark.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/ChainDrawMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/CollapsedView.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/CollapsedView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/ColoringAccessor.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/ColoringAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawContext.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngine.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngineDocView.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngineDocView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngineFakeDocView.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngineFakeDocView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngineLineView.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawEngineLineView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawGraphics.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawGraphics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawLayer.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawLayerList.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawLayerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawMark.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/EditorUiAccessor.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/EditorUiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/FoldMultiLineView.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/FoldMultiLineView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/LayerChain.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/LayerChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/drawing/MarkChain.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/drawing/MarkChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/impl/BasePosition.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/impl/BasePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/impl/MarkVector.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/impl/MarkVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/src/org/netbeans/modules/editor/lib/impl/MultiMark.java
+++ b/editor.lib/src/org/netbeans/modules/editor/lib/impl/MultiMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/editor/BaseDocumentTest.java
+++ b/editor.lib/test/unit/src/org/netbeans/editor/BaseDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/editor/DrawEngineTest.java
+++ b/editor.lib/test/unit/src/org/netbeans/editor/DrawEngineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/editor/TestingUndoableEditWrapper.java
+++ b/editor.lib/test/unit/src/org/netbeans/editor/TestingUndoableEditWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/editor/TestingUndoableEditWrapper2.java
+++ b/editor.lib/test/unit/src/org/netbeans/editor/TestingUndoableEditWrapper2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/editor/UndoableEditWrapperTest.java
+++ b/editor.lib/test/unit/src/org/netbeans/editor/UndoableEditWrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/modules/editor/lib/BeforeSaveTasksTest.java
+++ b/editor.lib/test/unit/src/org/netbeans/modules/editor/lib/BeforeSaveTasksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/modules/editor/lib/DummyTest.java
+++ b/editor.lib/test/unit/src/org/netbeans/modules/editor/lib/DummyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib/test/unit/src/org/netbeans/modules/editor/lib/TrailingWhitespaceRemoveTest.java
+++ b/editor.lib/test/unit/src/org/netbeans/modules/editor/lib/TrailingWhitespaceRemoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/DialogBinding.java
+++ b/editor.lib2/src/org/netbeans/api/editor/DialogBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/EditorActionNames.java
+++ b/editor.lib2/src/org/netbeans/api/editor/EditorActionNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/EditorActionRegistration.java
+++ b/editor.lib2/src/org/netbeans/api/editor/EditorActionRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/EditorActionRegistrations.java
+++ b/editor.lib2/src/org/netbeans/api/editor/EditorActionRegistrations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/EditorRegistry.java
+++ b/editor.lib2/src/org/netbeans/api/editor/EditorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/EditorUtilities.java
+++ b/editor.lib2/src/org/netbeans/api/editor/EditorUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/NavigationHistory.java
+++ b/editor.lib2/src/org/netbeans/api/editor/NavigationHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/StickyWindowSupport.java
+++ b/editor.lib2/src/org/netbeans/api/editor/StickyWindowSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/CaretInfo.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/CaretInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/CaretItem.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/CaretItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/CaretMoveContext.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/CaretMoveContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/CaretTransaction.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/CaretTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaretEvent.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaretEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaretListener.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaretListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/FilterBypassImpl.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/FilterBypassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/api/editor/caret/MoveCaretsOrigin.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/MoveCaretsOrigin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/CaretUndo.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/CaretUndo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/CaretUndoEdit.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/CaretUndoEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/ComponentUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/ComponentUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/DialogBindingTokenId.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/DialogBindingTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/DialogFactory.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/DialogFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/DialogSupport.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/DialogSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/DocUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/DocUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorApiPackageAccessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorApiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorCaretTransferHandler.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorCaretTransferHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorImplementation.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorImplementationProvider.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesDefaults.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesDefaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesKeys.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/KeyEventBlocker.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/KeyEventBlocker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/RectangularSelectionCaretAccessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/RectangularSelectionCaretAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/RectangularSelectionUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/RectangularSelectionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/URLMapper.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/URLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/WeakPositions.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/WeakPositions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/WeakReferenceStableList.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/WeakReferenceStableList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorActionUtilities.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorActionUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorActionsProvider.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorRegistryWatcher.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorRegistryWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/KeyBindingsUpdater.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/KeyBindingsUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/MacroRecording.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/MacroRecording.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterEditorAction.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterUpdater.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/SearchableEditorKit.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/SearchableEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/SearchableEditorKitImpl.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/SearchableEditorKitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/WrapperEditorAction.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/WrapperEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/caret/CaretFoldExpander.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/caret/CaretFoldExpander.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/document/DocumentPostModificationUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/document/DocumentPostModificationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/document/DocumentSpiPackageAccessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/document/DocumentSpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/document/TrailingWhitespaceRemoveProcessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/document/TrailingWhitespaceRemoveProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/document/UndoRedoDocumentEventResolver.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/document/UndoRedoDocumentEventResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/AbstractOffsetGapList.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/AbstractOffsetGapList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/BlockHighlighting.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/BlockHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CaretBasedBlockHighlighting.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CaretBasedBlockHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CaretOverwriteModeHighlighting.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CaretOverwriteModeHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CheckedHighlightsSequence.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CheckedHighlightsSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CompoundAttributes.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CompoundAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CompoundHighlightsContainer.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CompoundHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CoveringHighlightsSequence.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/CoveringHighlightsSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/DirectMergeContainer.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/DirectMergeContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/Factory.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/Factory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightItem.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingManager.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingSpiPackageAccessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingSpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsLayerAccessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsLayerAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsLayerFilter.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsLayerFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsList.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsReader.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsSequenceEx.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsSequenceEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/MultiLayerContainer.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/MultiLayerContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/OffsetGapList.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/OffsetGapList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/ProxyHighlightsContainer.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/ProxyHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/ReadOnlyFilesHighlighting.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/ReadOnlyFilesHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/SplitOffsetHighlightItem.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/SplitOffsetHighlightItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/SyntaxHighlighting.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/SyntaxHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/VisualMark.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/VisualMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/VisualMarkVector.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/VisualMarkVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/WhitespaceHighlighting.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/WhitespaceHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/search/TextStorageSet.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/search/TextStorageSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/search/WordMatch.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/search/WordMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/CamelCaseInterceptorsManager.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/CamelCaseInterceptorsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/DeletedTextInterceptorsManager.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/DeletedTextInterceptorsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/TypedBreakInterceptorsManager.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/TypedBreakInterceptorsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/TypedTextInterceptorsManager.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/TypedTextInterceptorsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/TypingHooksSpiAccessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/typinghooks/TypingHooksSpiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/AttributedCharSequence.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/AttributedCharSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DebugRepaintManager.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DebugRepaintManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentView.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewChildren.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorTabExpander.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorTabExpander.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorView.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactory.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactoryChange.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactoryChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactoryEvent.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactoryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactoryListener.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/EditorViewFactoryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/FontInfo.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/FontInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsView.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewFactory.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewPart.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewPart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/LineWrapType.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/LineWrapType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/LockedViewHierarchy.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/LockedViewHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/NewlineView.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/NewlineView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/OffsetRegion.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/OffsetRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/PaintState.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/PaintState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ParagraphView.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ParagraphView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ParagraphViewChildren.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ParagraphViewChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ParagraphViewDescriptor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ParagraphViewDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/PrintUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/PrintUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TabView.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TabView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TextLayoutBreakInfo.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TextLayoutBreakInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TextLayoutCache.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TextLayoutCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TextLayoutUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/TextLayoutUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewApiPackageAccessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewApiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewBuilder.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewChildren.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewFactoryImpl.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewGapStorage.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewGapStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchy.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyChange.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyEvent.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyImpl.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyListener.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewPaintHighlights.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewPaintHighlights.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewPart.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewPart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewRenderContext.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewRenderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewReplace.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewReplace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewStats.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewStats.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewUpdates.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewUpdates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewUtils.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfo.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfoUpdater.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfoUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapLine.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/AbstractEditorAction.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/AbstractEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/SideBarFactory.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/SideBarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/caret/CaretMoveHandler.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/caret/CaretMoveHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/caret/CascadingNavigationFilter.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/caret/CascadingNavigationFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/caret/NavigationFilterBypass.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/caret/NavigationFilterBypass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/codegen/CodeGenerator.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/codegen/CodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/codegen/CodeGeneratorContextProvider.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/codegen/CodeGeneratorContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/document/OnSaveTask.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/document/OnSaveTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightAttributeValue.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightAttributeValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsChangeEvent.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsChangeListener.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsContainer.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsLayer.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsLayerFactory.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsSequence.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/HighlightsSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/ReleasableHighlightsContainer.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/ReleasableHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/SplitOffsetHighlightsSequence.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/SplitOffsetHighlightsSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/ZOrder.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/ZOrder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/AbstractHighlightsContainer.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/AbstractHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/OffsetsBag.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/OffsetsBag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/PositionsBag.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/PositionsBag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/typinghooks/CamelCaseInterceptor.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/typinghooks/CamelCaseInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/typinghooks/DeletedTextInterceptor.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/typinghooks/DeletedTextInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/typinghooks/TypedBreakInterceptor.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/typinghooks/TypedBreakInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/src/org/netbeans/spi/editor/typinghooks/TypedTextInterceptor.java
+++ b/editor.lib2/src/org/netbeans/spi/editor/typinghooks/TypedTextInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/api/editor/EditorRegistryTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/api/editor/EditorRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/api/editor/EditorUtilitiesTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/api/editor/EditorUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/api/editor/PlainDocumentTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/api/editor/PlainDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/WeakReferenceStableListTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/WeakReferenceStableListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/actions/MacroRecordingTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/actions/MacroRecordingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/CompoundHighlightsContainerTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/CompoundHighlightsContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/DirectMergeContainerTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/DirectMergeContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingManagerTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsListTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsMergeTesting.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsMergeTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/MemoryMimeDataProvider.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/MemoryMimeDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/OffsetGapListTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/OffsetGapListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/ProxyHighlightsContainerTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/ProxyHighlightsContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/SyntaxHighlightingTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/SyntaxHighlightingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/WhitespaceHighlightingTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/WhitespaceHighlightingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/search/WordMatchTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/search/WordMatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/testactionsregistration/EditorActionRegistrationTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/testactionsregistration/EditorActionRegistrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/AttributedCharSequenceTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/AttributedCharSequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/OffsetRegionTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/OffsetRegionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/RootViewRandomTesting.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/RootViewRandomTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestHighlight.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestHighlight.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestHighlightsView.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestHighlightsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestHighlightsViewFactory.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestHighlightsViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestOffsetsHighlightsContainer.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/TestOffsetsHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyRandomTesting.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyRandomTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewHierarchyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewPaintHighlightsTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewPaintHighlightsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewUpdatesExtraFactoryTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewUpdatesExtraFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewUpdatesTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewUpdatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewUpdatesTesting.java
+++ b/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/ViewUpdatesTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/AbstractEditorActionTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/AbstractEditorActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/ZOrderTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/ZOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/PositionsBagFindHighlightTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/PositionsBagFindHighlightTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/PositionsBagMemoryTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/PositionsBagMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/SimplePosition.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/SimplePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/SyntaxHighlightingTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/performance/SyntaxHighlightingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/MergingOffsetsBagTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/MergingOffsetsBagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/MergingPositionsBagTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/MergingPositionsBagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/OffsetsBagTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/OffsetsBagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/PositionsBagRandomTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/PositionsBagRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/PositionsBagTest.java
+++ b/editor.lib2/test/unit/src/org/netbeans/spi/editor/highlighting/support/PositionsBagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/MacroDialogSupport.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/MacroDialogSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/MacroShortcutsInjector.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/MacroShortcutsInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/MacrosKeymapManager.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/MacrosKeymapManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/storage/MacroDescription.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/storage/MacroDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/storage/MacrosStorage.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/storage/MacrosStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosModel.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosNamePanel.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosNamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosPanel.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosPanelController.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
+++ b/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.macros/test/unit/src/org/netbeans/modules/editor/macros/storage/ui/MacrosModelTest.java
+++ b/editor.macros/test/unit/src/org/netbeans/modules/editor/macros/storage/ui/MacrosModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/CompoundFolderChildren.java
+++ b/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/CompoundFolderChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/DefaultMimeDataProvider.java
+++ b/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/DefaultMimeDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookup.java
+++ b/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/InstanceProviderLookup.java
+++ b/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/InstanceProviderLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/SwitchLookup.java
+++ b/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/SwitchLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/CompoundFolderChildrenTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/CompoundFolderChildrenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DefaultMimeDataProviderTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DefaultMimeDataProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupInheritanceTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupInheritanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupPerformanceTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupPopupItemsChangeTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupPopupItemsChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/Depr_MimeLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummyInstanceProvider.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummyInstanceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummyMimeDataProvider.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummyMimeDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummyMimeLookupInitializer.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummyMimeLookupInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummySetting.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummySetting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummySettingImpl.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummySettingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummySettingWithPath.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DummySettingWithPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/EditorTestLookup.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/EditorTestLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookupTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/IssuesTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/IssuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupInheritanceTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupInheritanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupPerformanceTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupPopupItemsChangeTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupPopupItemsChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/MimeLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/PopupActions.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/PopupActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/SwitchLookupTest.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/SwitchLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestLookupObject.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestLookupObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestLookupObjectInstantiation.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestLookupObjectInstantiation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestLookupObjectTwo.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestLookupObjectTwo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestUtilities.java
+++ b/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimeLookup.java
+++ b/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimeLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimePath.java
+++ b/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimeRegistration.java
+++ b/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimeRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimeRegistrations.java
+++ b/editor.mimelookup/src/org/netbeans/api/editor/mimelookup/MimeRegistrations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/APIAccessor.java
+++ b/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/APIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/CreateRegistrationProcessor.java
+++ b/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/CreateRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/MimeLookupCacheSPI.java
+++ b/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/MimeLookupCacheSPI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/MimePathLookup.java
+++ b/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/MimePathLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/SharedMimeLookupCache.java
+++ b/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/SharedMimeLookupCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/Class2LayerFolder.java
+++ b/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/Class2LayerFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/InstanceProvider.java
+++ b/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/InstanceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeDataProvider.java
+++ b/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeLocation.java
+++ b/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeLookupInitializer.java
+++ b/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeLookupInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimeLookupMemoryGCTest.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimeLookupMemoryGCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimeLookupMemoryTest.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimeLookupMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimePathMemoryTest.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimePathMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimePathTest.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/MimePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/test/MockMimeLookup.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/test/MockMimeLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/test/MockMimeLookupTest.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/api/editor/mimelookup/test/MockMimeLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/CreateRegistrationProcessorTest.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/CreateRegistrationProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/DummyMimeDataProvider.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/DummyMimeDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/DummyMimeLookupInitializer.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/DummyMimeLookupInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/EditorTestLookup.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/EditorTestLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/MimePathLookupTest.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/MimePathLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/TestUtilities.java
+++ b/editor.mimelookup/test/unit/src/org/netbeans/modules/editor/mimelookup/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainSyntax.java
+++ b/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainSyntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainTokenContext.java
+++ b/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainTokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.plain/src/org/netbeans/modules/editor/plain/PlainKit.java
+++ b/editor.plain/src/org/netbeans/modules/editor/plain/PlainKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/DocumentFinder.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/DocumentFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/EditorFindSupport.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/EditorFindSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/ListFocusTraversalPolicy.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/ListFocusTraversalPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/ReplaceBar.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/ReplaceBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/SearchBar.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/SearchBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/SearchButton.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/SearchButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/SearchComboBox.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/SearchComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/SearchNbEditorKit.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/SearchNbEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/SearchPropertiesSupport.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/SearchPropertiesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/TextSearchHighlighting.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/TextSearchHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/actions/AddCaretSelectAllAction.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/actions/AddCaretSelectAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/actions/AddCaretSelectNextAction.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/actions/AddCaretSelectNextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/actions/FindNextAction.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/actions/FindNextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/actions/FindPreviousAction.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/actions/FindPreviousAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/actions/ReplaceAction.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/actions/ReplaceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/actions/SearchAction.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/actions/SearchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/actions/ToggleHighlightSearchAction.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/actions/ToggleHighlightSearchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/src/org/netbeans/modules/editor/search/completion/SearchCompletion.java
+++ b/editor.search/src/org/netbeans/modules/editor/search/completion/SearchCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/test/unit/src/org/netbeans/modules/editor/search/DocumentFinderTest.java
+++ b/editor.search/test/unit/src/org/netbeans/modules/editor/search/DocumentFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/test/unit/src/org/netbeans/modules/editor/search/EditorFindSupportTest.java
+++ b/editor.search/test/unit/src/org/netbeans/modules/editor/search/EditorFindSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.search/test/unit/src/org/netbeans/modules/editor/search/SearchPropertiesSupportTest.java
+++ b/editor.search/test/unit/src/org/netbeans/modules/editor/search/SearchPropertiesSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/ApiAccessor.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/ApiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/SettingsType.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/SettingsType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/SpiPackageAccessor.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/SpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/Utils.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/api/EditorSettingsStorage.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/api/EditorSettingsStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/api/MemoryPreferences.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/api/MemoryPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/api/OverridePreferences.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/api/OverridePreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/InheritedPreferences.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/InheritedPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesImpl.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesStorage.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/ProxyPreferencesImpl.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/ProxyPreferencesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageDescription.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageFilter.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageReader.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageWriter.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/StorageWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/TypedValue.java
+++ b/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/spi/TypedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/EditorSettingsStorageTest.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/EditorSettingsStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/EditorTestLookup.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/EditorTestLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/LocatorTest.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/LocatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/SettingsProviderTest.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/SettingsProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/StorageFilterTest.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/StorageFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/TestUtilities.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesStorageTest.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesTest.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/ProxyPreferencesImplTest.java
+++ b/editor.settings.lib/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/ProxyPreferencesImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/EditorLocatorFactory.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/EditorLocatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/EditorSettingsImpl.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/EditorSettingsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/MimeTypesTracker.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/MimeTypesTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/NbUtils.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/NbUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/ProfilesTracker.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/ProfilesTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/SettingsProvider.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/SettingsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/EditorSettings.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/EditorSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/FontColorSettingsFactory.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/FontColorSettingsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/KeyBindingSettingsFactory.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/KeyBindingSettingsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/fontscolors/ColoringStorage.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/fontscolors/ColoringStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/fontscolors/CompositeFCS.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/fontscolors/CompositeFCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/keybindings/KeyMapsStorage.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/keybindings/KeyMapsStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/spi/support/StorageSupport.java
+++ b/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/spi/support/StorageSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/EditorTestLookup.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/EditorTestLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/FontColorSettingsImplTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/FontColorSettingsImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/MimeTypesTrackerTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/MimeTypesTrackerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/ProfilesTrackerTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/ProfilesTrackerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/TestUtilities.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/compatibility/p1/Pre90403Phase1CompatibilityTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/compatibility/p1/Pre90403Phase1CompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/fontscolors/ColoringStorageTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/fontscolors/ColoringStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/fontscolors/CompositeFCSTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/fontscolors/CompositeFCSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/keybindings/KeybindingStorageTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/keybindings/KeybindingStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesStorageTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/ProxyPreferencesImplTest.java
+++ b/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/preferences/ProxyPreferencesImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/AttributesUtilities.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/AttributesUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateDescription.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateSettings.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/EditorStyleConstants.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/EditorStyleConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/FontColorNames.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/FontColorNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/FontColorSettings.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/FontColorSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/KeyBindingSettings.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/KeyBindingSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/MultiKeyBinding.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/MultiKeyBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/api/editor/settings/SimpleValueNames.java
+++ b/editor.settings/src/org/netbeans/api/editor/settings/SimpleValueNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/modules/editor/settings/AttrSet.java
+++ b/editor.settings/src/org/netbeans/modules/editor/settings/AttrSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/src/org/netbeans/modules/editor/settings/SimpleWeakSet.java
+++ b/editor.settings/src/org/netbeans/modules/editor/settings/SimpleWeakSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/AttrSetTest.java
+++ b/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/AttrSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/AttrSetTesting.java
+++ b/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/AttrSetTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/EditorSettingsTest.java
+++ b/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/EditorSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/SimpleWeakSetTest.java
+++ b/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/SimpleWeakSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/SimpleWeakSetTesting.java
+++ b/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/SimpleWeakSetTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/DocumentModelProviderFactory.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/DocumentModelProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentElement.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentElementEvent.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentElementEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentElementListener.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentElementListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModel.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelException.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelListener.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelStateListener.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelStateListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelUtils.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/formatting/JoinedTokenSequence.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/formatting/JoinedTokenSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TagBasedFormatter.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TagBasedFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TagBasedLexerFormatter.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TagBasedLexerFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TextBounds.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TextBounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TransferData.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TransferData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/src/org/netbeans/modules/editor/structure/spi/DocumentModelProvider.java
+++ b/editor.structure/src/org/netbeans/modules/editor/structure/spi/DocumentModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.structure/test/unit/src/org/netbeans/modules/editor/structure/api/DocumentModelTest.java
+++ b/editor.structure/test/unit/src/org/netbeans/modules/editor/structure/api/DocumentModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.tools.storage/src/org/netbeans/modules/editor/tools/storage/api/ToolPreferences.java
+++ b/editor.tools.storage/src/org/netbeans/modules/editor/tools/storage/api/ToolPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.tools.storage/src/org/netbeans/modules/editor/tools/storage/api/XMLHintPreferences.java
+++ b/editor.tools.storage/src/org/netbeans/modules/editor/tools/storage/api/XMLHintPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.tools.storage/test/unit/src/org/netbeans/modules/editor/tools/storage/api/ToolPreferencesTest.java
+++ b/editor.tools.storage/test/unit/src/org/netbeans/modules/editor/tools/storage/api/ToolPreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/AbstractCharSequence.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/AbstractCharSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/ArrayUtilities.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/ArrayUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/CharSequenceUtilities.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/CharSequenceUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/CharSubSequence.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/CharSubSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/CharacterConversions.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/CharacterConversions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/CompactMap.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/CompactMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/FlyOffsetGapList.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/FlyOffsetGapList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/GapList.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/GapList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/ListenerList.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/ListenerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/OffsetGapList.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/OffsetGapList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/PriorityListenerList.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/PriorityListenerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/PriorityMutex.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/PriorityMutex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/StringEscapeUtils.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/StringEscapeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/BlockCompare.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/BlockCompare.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentListenerPriority.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentListenerPriority.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/ElementUtilities.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/ElementUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/GapBranchElement.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/GapBranchElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/MutablePositionRegion.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/MutablePositionRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/PositionComparator.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/PositionComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/PositionRegion.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/PositionRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/PriorityDocumentListenerList.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/PriorityDocumentListenerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/ArrayUtilitiesTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/ArrayUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/CharSequenceTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/CharSequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/CharSequenceUtilitiesTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/CharSequenceUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/CompactMapTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/CompactMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/FlyOffsetGapListTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/FlyOffsetGapListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/GapListRandomTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/GapListRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/ListenerListTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/ListenerListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/PriorityListenerListTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/PriorityListenerListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/StringEscapeUtilsTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/StringEscapeUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/DocumentTesting.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/DocumentTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/EditorPaneTesting.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/EditorPaneTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/PropertyProvider.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/PropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/RandomTestContainer.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/RandomTestContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/RandomText.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/RandomText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/TestDocument.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/random/TestDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/swing/BlockCompareTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/swing/BlockCompareTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/swing/DocumentUtilitiesTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/swing/DocumentUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor.util/test/unit/src/org/netbeans/lib/editor/util/swing/PriorityDocumentListenerListTest.java
+++ b/editor.util/test/unit/src/org/netbeans/lib/editor/util/swing/PriorityDocumentListenerListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/demosrc/base/org/netbeans/editor/example/Editor.java
+++ b/editor/demosrc/base/org/netbeans/editor/example/Editor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/demosrc/base/org/netbeans/editor/example/HTMLKit.java
+++ b/editor/demosrc/base/org/netbeans/editor/example/HTMLKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/demosrc/base/org/netbeans/editor/example/JavaKit.java
+++ b/editor/demosrc/base/org/netbeans/editor/example/JavaKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/demosrc/base/org/netbeans/editor/example/PlainKit.java
+++ b/editor/demosrc/base/org/netbeans/editor/example/PlainKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/demosrc/base/org/netbeans/editor/example/SAReaderProvider.java
+++ b/editor/demosrc/base/org/netbeans/editor/example/SAReaderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/demosrc/properties-addon/org/netbeans/editor/example/PropertiesKit.java
+++ b/editor/demosrc/properties-addon/org/netbeans/editor/example/PropertiesKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/demosrc/properties-addon/org/netbeans/editor/example/PropertiesSettingsInitializer.java
+++ b/editor/demosrc/properties-addon/org/netbeans/editor/example/PropertiesSettingsInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/lib/src/org/netbeans/modules/editor/lib/EditorRenderingHints.java
+++ b/editor/lib/src/org/netbeans/modules/editor/lib/EditorRenderingHints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/lib/src/org/netbeans/modules/editor/lib/SettingsConversions.java
+++ b/editor/lib/src/org/netbeans/modules/editor/lib/SettingsConversions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/EditorModule.java
+++ b/editor/src/org/netbeans/modules/editor/EditorModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/EditorWarmUpTask.java
+++ b/editor/src/org/netbeans/modules/editor/EditorWarmUpTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/ExportHtmlAction.java
+++ b/editor/src/org/netbeans/modules/editor/ExportHtmlAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/HtmlPrintContainer.java
+++ b/editor/src/org/netbeans/modules/editor/HtmlPrintContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/MainMenuAction.java
+++ b/editor/src/org/netbeans/modules/editor/MainMenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbCodeFoldingAction.java
+++ b/editor/src/org/netbeans/modules/editor/NbCodeFoldingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbDialogSupport.java
+++ b/editor/src/org/netbeans/modules/editor/NbDialogSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbEditorDocument.java
+++ b/editor/src/org/netbeans/modules/editor/NbEditorDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbEditorKit.java
+++ b/editor/src/org/netbeans/modules/editor/NbEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbEditorToolBar.java
+++ b/editor/src/org/netbeans/modules/editor/NbEditorToolBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbEditorUI.java
+++ b/editor/src/org/netbeans/modules/editor/NbEditorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbEditorUtilities.java
+++ b/editor/src/org/netbeans/modules/editor/NbEditorUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbImplementationProvider.java
+++ b/editor/src/org/netbeans/modules/editor/NbImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbLocalizer.java
+++ b/editor/src/org/netbeans/modules/editor/NbLocalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/NbToolTip.java
+++ b/editor/src/org/netbeans/modules/editor/NbToolTip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/codegen/GenerateCodePanel.java
+++ b/editor/src/org/netbeans/modules/editor/codegen/GenerateCodePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/codegen/NbGenerateCodeAction.java
+++ b/editor/src/org/netbeans/modules/editor/codegen/NbGenerateCodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/codegen/PopupUtil.java
+++ b/editor/src/org/netbeans/modules/editor/codegen/PopupUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/ActionsList.java
+++ b/editor/src/org/netbeans/modules/editor/impl/ActionsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/ComplexValueSettingsFactory.java
+++ b/editor/src/org/netbeans/modules/editor/impl/ComplexValueSettingsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/CustomizableSideBar.java
+++ b/editor/src/org/netbeans/modules/editor/impl/CustomizableSideBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/DefaultIndentEngine.java
+++ b/editor/src/org/netbeans/modules/editor/impl/DefaultIndentEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/DocumentFactoryImpl.java
+++ b/editor/src/org/netbeans/modules/editor/impl/DocumentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/EditorActionsProvider.java
+++ b/editor/src/org/netbeans/modules/editor/impl/EditorActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/GlyphGutterActionsProvider.java
+++ b/editor/src/org/netbeans/modules/editor/impl/GlyphGutterActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/KitsTrackerImpl.java
+++ b/editor/src/org/netbeans/modules/editor/impl/KitsTrackerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/NbDialogFactory.java
+++ b/editor/src/org/netbeans/modules/editor/impl/NbDialogFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/NbEditorImplementationProvider.java
+++ b/editor/src/org/netbeans/modules/editor/impl/NbEditorImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/NbGuardedMarker.java
+++ b/editor/src/org/netbeans/modules/editor/impl/NbGuardedMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/NbURLMapper.java
+++ b/editor/src/org/netbeans/modules/editor/impl/NbURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/PopupMenuActionsProvider.java
+++ b/editor/src/org/netbeans/modules/editor/impl/PopupMenuActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/ReformatBeforeSaveTask.java
+++ b/editor/src/org/netbeans/modules/editor/impl/ReformatBeforeSaveTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/SideBarFactoriesProvider.java
+++ b/editor/src/org/netbeans/modules/editor/impl/SideBarFactoriesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/StatusBarImpl.java
+++ b/editor/src/org/netbeans/modules/editor/impl/StatusBarImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/StatusLineComponent.java
+++ b/editor/src/org/netbeans/modules/editor/impl/StatusLineComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/StatusLineFactories.java
+++ b/editor/src/org/netbeans/modules/editor/impl/StatusLineFactories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/ToolbarActionsProvider.java
+++ b/editor/src/org/netbeans/modules/editor/impl/ToolbarActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/ClipboardHistoryAction.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/ClipboardHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/LineActionsMainMenu.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/LineActionsMainMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/NavigationHistoryBackAction.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/NavigationHistoryBackAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/NavigationHistoryForwardAction.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/NavigationHistoryForwardAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/NavigationHistoryLastEditAction.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/NavigationHistoryLastEditAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ClipboardHistory.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ClipboardHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ClipboardHistoryElement.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ClipboardHistoryElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/CompletionLayoutPopup.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/CompletionLayoutPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/DocumentationScrollPane.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/DocumentationScrollPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ListCompletionView.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ListCompletionView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ScrollCompletionPane.java
+++ b/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ScrollCompletionPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/highlighting/AnnotationsHighlighting.java
+++ b/editor/src/org/netbeans/modules/editor/impl/highlighting/AnnotationsHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/highlighting/ComposedTextHighlighting.java
+++ b/editor/src/org/netbeans/modules/editor/impl/highlighting/ComposedTextHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/highlighting/GuardedBlocksHighlighting.java
+++ b/editor/src/org/netbeans/modules/editor/impl/highlighting/GuardedBlocksHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/highlighting/HLFactory.java
+++ b/editor/src/org/netbeans/modules/editor/impl/highlighting/HLFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/impl/highlighting/NonLexerSyntaxHighlighting.java
+++ b/editor/src/org/netbeans/modules/editor/impl/highlighting/NonLexerSyntaxHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/options/AnnotationTypeActionsFolder.java
+++ b/editor/src/org/netbeans/modules/editor/options/AnnotationTypeActionsFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/options/AnnotationTypeOptions.java
+++ b/editor/src/org/netbeans/modules/editor/options/AnnotationTypeOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/options/AnnotationTypeOptionsBeanInfo.java
+++ b/editor/src/org/netbeans/modules/editor/options/AnnotationTypeOptionsBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/options/AnnotationTypeProcessor.java
+++ b/editor/src/org/netbeans/modules/editor/options/AnnotationTypeProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/options/AnnotationTypesFolder.java
+++ b/editor/src/org/netbeans/modules/editor/options/AnnotationTypesFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/options/AnnotationTypesNode.java
+++ b/editor/src/org/netbeans/modules/editor/options/AnnotationTypesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/url/HighlightURLs.java
+++ b/editor/src/org/netbeans/modules/editor/url/HighlightURLs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/url/HyperlinkImpl.java
+++ b/editor/src/org/netbeans/modules/editor/url/HyperlinkImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/src/org/netbeans/modules/editor/url/Parser.java
+++ b/editor/src/org/netbeans/modules/editor/url/Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/perf/src/org/netbeans/modules/editor/RobotTest.java
+++ b/editor/test/perf/src/org/netbeans/modules/editor/RobotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/perf/src/org/netbeans/modules/editor/data/Robot.java
+++ b/editor/test/perf/src/org/netbeans/modules/editor/data/Robot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/ArgumentTest.java
+++ b/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/ArgumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/InnerOutter.java
+++ b/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/InnerOutter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/Main.java
+++ b/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/TestFile.java
+++ b/editor/test/qa-functional/data/cp-prj-1/src/org/netbeans/test/editor/completion/TestFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceAll.pass
+++ b/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceAll.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceInSelectionOnly.pass
+++ b/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceInSelectionOnly.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceMatchCase.pass
+++ b/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceMatchCase.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceSelectionRepeated.pass
+++ b/editor/test/qa-functional/data/goldenfiles/org/netbeans/test/editor/search/ReplaceTest/testReplaceSelectionRepeated.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/org/netbeans/test/editor/data/GuiPanel.java
+++ b/editor/test/qa-functional/data/org/netbeans/test/editor/data/GuiPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/org/netbeans/test/editor/data/SomeJavaClass.java
+++ b/editor/test/qa-functional/data/org/netbeans/test/editor/data/SomeJavaClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/org/netbeans/test/editor/data/SomePlainTextFile.txt
+++ b/editor/test/qa-functional/data/org/netbeans/test/editor/data/SomePlainTextFile.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/org/netbeans/test/editor/data/dummy.txt
+++ b/editor/test/qa-functional/data/org/netbeans/test/editor/data/dummy.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/org/netbeans/test/editor/data/dummy_1.txt
+++ b/editor/test/qa-functional/data/org/netbeans/test/editor/data/dummy_1.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/abbrev/Test.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/abbrev/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/abbrev/Test2.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/abbrev/Test2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/dummy/sample1.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/dummy/sample1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/keymap/Main.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/keymap/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/keymap/Test.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/keymap/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/general/GeneralTypingTest/testJavaEnterBeginAndEnd.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/general/GeneralTypingTest/testJavaEnterBeginAndEnd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/highlight/testColor.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/highlight/testColor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/highlight/testCommentColor.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/highlight/testCommentColor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/highlight/testOtherColors.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/highlight/testOtherColors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/popup/MainMenuTest/testMainMenu.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/popup/MainMenuTest/testMainMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/IncrementalSearchTest/testSearchForward.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/IncrementalSearchTest/testSearchForward.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceAll.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceAll.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceDialogComboBox.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceDialogComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceDialogOpenClose.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceDialogOpenClose.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceInSelectionOnly.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceInSelectionOnly.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceMatchCase.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceMatchCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceSelectionRepeated.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/search/ReplaceTest/testReplaceSelectionRepeated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/shortcuts/BasicShortcuts/testReplaceInFile.java
+++ b/editor/test/qa-functional/data/projects/editor_test/src/org/netbeans/test/editor/shortcuts/BasicShortcuts/testReplaceInFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/Abbreviations.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/Abbreviations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/AddKeybinding.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/AddKeybinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/AddShortcutDialog.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/AddShortcutDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/CreateNewProfileDialog.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/CreateNewProfileDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/EditorPanelOperator.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/EditorPanelOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/EnterAbbreviation.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/EnterAbbreviation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/Find.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/Find.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/GoToLine.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/GoToLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/KeyBindings.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/KeyBindings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/KeyMapOperator.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/KeyMapOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/ManageProfilesDialogOperator.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/ManageProfilesDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/Replace.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/Replace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/ReplaceBarOperator.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/ReplaceBarOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/SearchBarOperator.java
+++ b/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/SearchBarOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/general/GeneralTypingTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/general/GeneralTypingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/highlight/SyntaxHighlightTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/highlight/SyntaxHighlightTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/lib/DummyTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/lib/DummyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/lib/EditorTestCase.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/lib/EditorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/lib/LineDiff.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/lib/LineDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/lib/MemoryTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/lib/MemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/popup/MainMenuTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/popup/MainMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/popup/MenuTestCase.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/popup/MenuTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/search/IncrementalSearchTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/search/IncrementalSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/search/ReplaceTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/search/ReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/shortcuts/BasicShortcuts.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/shortcuts/BasicShortcuts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/suites/GeneralSuite.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/suites/GeneralSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/suites/KeyMapSuite.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/suites/KeyMapSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/suites/SearchSuite.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/suites/SearchSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/suites/StableSuite.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/suites/StableSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/suites/abbrevs/AbbreviationsAddRemovePerformer.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/suites/abbrevs/AbbreviationsAddRemovePerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/qa-functional/src/org/netbeans/test/editor/suites/keybindings/KeyMapTest.java
+++ b/editor/test/qa-functional/src/org/netbeans/test/editor/suites/keybindings/KeyMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/editor/PlainDocumentCompatibilityRandomTest.java
+++ b/editor/test/unit/src/org/netbeans/editor/PlainDocumentCompatibilityRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/AnnotationLoadingTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/AnnotationLoadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/AnnotationsTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/AnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/AnnotationsUnitTestSuite.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/AnnotationsUnitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/BaseDocumentUnitTestCase.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/BaseDocumentUnitTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/DocumentUndoTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/DocumentUndoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/DocumentUnitTestSuite.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/DocumentUnitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/EditorTestConstants.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/EditorTestConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/EditorTestLookup.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/EditorTestLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/FormatterUnitTestSuite.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/FormatterUnitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/LineSeparatorDataEditorSupportTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/LineSeparatorDataEditorSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/NbEditorToolBarTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/NbEditorToolBarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/RandomDocumentUnitTestSuite.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/RandomDocumentUnitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/SmartBracketUnitTestSuite.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/SmartBracketUnitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/codegen/CodeGenerationTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/codegen/CodeGenerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/codegen/TestCodeGenerator.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/codegen/TestCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/impl/KitsTrackerTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/impl/KitsTrackerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/impl/SideBarFactoriesProviderTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/impl/SideBarFactoriesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedNbDocumentTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedNbDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedNotifyModifiedTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedNotifyModifiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedUndoRedoCooperationTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedUndoRedoCooperationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedUndoRedoTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedUndoRedoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedUndoRedoWrappingCooperationTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/openide/InheritedUndoRedoWrappingCooperationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/editor/test/unit/src/org/netbeans/modules/editor/url/ParserTest.java
+++ b/editor/test/unit/src/org/netbeans/modules/editor/url/ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/native/NbDDEBrowserImpl.cpp
+++ b/extbrowser/native/NbDDEBrowserImpl.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/native/NbDDEBrowserImpl.h
+++ b/extbrowser/native/NbDDEBrowserImpl.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/native/StdAfx.h
+++ b/extbrowser/native/StdAfx.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/BrowserUtils.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/BrowserUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/ChromeBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/ChromeBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/ChromeBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/ChromeBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/ChromiumBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/ChromiumBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/ChromiumBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/ChromiumBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/DelegatingWebBrowserImpl.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/DelegatingWebBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/ExtBrowserImpl.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/ExtBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/FirefoxBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/FirefoxBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/FirefoxBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/FirefoxBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/IExplorerBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/IExplorerBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/IExplorerBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/IExplorerBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/MacBrowserImpl.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/MacBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/MicrosoftEdgeBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/MicrosoftEdgeBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/MicrosoftEdgeBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/MicrosoftEdgeBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/MozillaBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/MozillaBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/MozillaBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/MozillaBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/NbBrowserException.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/NbBrowserException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/NbDdeBrowserImpl.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/NbDdeBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/NbDefaultUnixBrowserImpl.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/NbDefaultUnixBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/PrivateBrowserFamilyId.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/PrivateBrowserFamilyId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/SafariBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/SafariBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/SafariBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/SafariBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowserImpl.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowser.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowserBeanInfo.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowserBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/URLUtil.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/URLUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/src/org/netbeans/modules/extbrowser/UnixBrowserImpl.java
+++ b/extbrowser/src/org/netbeans/modules/extbrowser/UnixBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteCLBrowser.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteCLBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteCLFullPathBrowser.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteCLFullPathBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteExternalUnixBrowser.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteExternalUnixBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteSwingBrowser.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/execution/ExecuteSwingBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/settings/BrowserRegistry.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/settings/BrowserRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/settings/JspAndServletSettings.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/settings/JspAndServletSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/settings/SystemSettings.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/settings/SystemSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/using/Using.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/extbrowser/using/Using.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/util/BrowserUtils.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/util/BrowserUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/util/HttpRequestWaitable.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/util/HttpRequestWaitable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/util/JSPServletResponseWaitable.java
+++ b/extbrowser/test/ExtBrowser/qa-functional/src/org/netbeans/test/gui/web/util/JSPServletResponseWaitable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/ExtWebBrowserBeanInfoTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/ExtWebBrowserBeanInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/ExtWebBrowserTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/ExtWebBrowserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/MacBrowserImplTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/MacBrowserImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/NbDdeBrowserImplTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/NbDdeBrowserImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/SimpleExtBrowserBeanInfoTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/SimpleExtBrowserBeanInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/SimpleExtBrowserTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/SimpleExtBrowserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/URLUtilTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/URLUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/UnixBrowserImplTest.java
+++ b/extbrowser/test/unit/src/org/netbeans/modules/extbrowser/UnixBrowserImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/BaseExecutionDescriptor.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/BaseExecutionDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/BaseExecutionService.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/BaseExecutionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/Environment.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/Environment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/ParametrizedRunnable.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/ParametrizedRunnable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/ProcessBuilder.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/ProcessBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/Processes.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/Processes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputProcessor.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputProcessors.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputProcessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputReader.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputReaderTask.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputReaderTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputReaders.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/InputReaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/LineProcessor.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/LineProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/LineProcessors.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/LineProcessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/input/package-info.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/input/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/api/extexecution/base/package-info.java
+++ b/extexecution.base/src/org/netbeans/api/extexecution/base/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/EnvironmentAccessor.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/EnvironmentAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/ExternalProcessBuilder.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/ExternalProcessBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/ProcessBuilderAccessor.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/ProcessBuilderAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/ProcessInputStream.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/ProcessInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/ProcessParametersAccessor.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/ProcessParametersAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/WrapperProcess.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/WrapperProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/input/DefaultInputReader.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/input/DefaultInputReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/input/FileInputReader.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/input/FileInputReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/input/LineParsingHelper.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/input/LineParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/modules/extexecution/base/input/package-info.java
+++ b/extexecution.base/src/org/netbeans/modules/extexecution/base/input/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/spi/extexecution/base/EnvironmentFactory.java
+++ b/extexecution.base/src/org/netbeans/spi/extexecution/base/EnvironmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/spi/extexecution/base/EnvironmentImplementation.java
+++ b/extexecution.base/src/org/netbeans/spi/extexecution/base/EnvironmentImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessBuilderFactory.java
+++ b/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessBuilderImplementation.java
+++ b/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessBuilderImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessParameters.java
+++ b/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessesImplementation.java
+++ b/extexecution.base/src/org/netbeans/spi/extexecution/base/ProcessesImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/src/org/netbeans/spi/extexecution/base/package-info.java
+++ b/extexecution.base/src/org/netbeans/spi/extexecution/base/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/BaseExecutionServiceTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/BaseExecutionServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/ProcessBuilderTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/ProcessBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/ProcessesTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/ProcessesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputProcessorsTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputProcessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersFileTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersReaderTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersStreamTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/LineProcessorsTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/LineProcessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestInputProcessor.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestInputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestInputUtils.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestInputUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestInputWriter.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestInputWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestLineProcessor.java
+++ b/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/TestLineProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/modules/extexecution/base/ExternalProcessBuilderTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/modules/extexecution/base/ExternalProcessBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/modules/extexecution/base/input/LineParsingHelperTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/modules/extexecution/base/input/LineParsingHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.base/test/unit/src/org/netbeans/spi/extexecution/base/ProcessParametersTest.java
+++ b/extexecution.base/test/unit/src/org/netbeans/spi/extexecution/base/ProcessParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.impl/src/org/netbeans/modules/extexecution/impl/NbFileOpenHandler.java
+++ b/extexecution.impl/src/org/netbeans/modules/extexecution/impl/NbFileOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.impl/src/org/netbeans/modules/extexecution/impl/NbHttpOpenHandler.java
+++ b/extexecution.impl/src/org/netbeans/modules/extexecution/impl/NbHttpOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.impl/src/org/netbeans/modules/extexecution/impl/NbOptionOpenHandler.java
+++ b/extexecution.impl/src/org/netbeans/modules/extexecution/impl/NbOptionOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.process.jdk9/src/org/netbeans/modules/extexecution/process/jdk9/ProcessesImpl.java
+++ b/extexecution.process.jdk9/src/org/netbeans/modules/extexecution/process/jdk9/ProcessesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution.process/src/org/netbeans/modules/extexecution/process/ProcessesImpl.java
+++ b/extexecution.process/src/org/netbeans/modules/extexecution/process/ProcessesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/ExecutionDescriptor.java
+++ b/extexecution/src/org/netbeans/api/extexecution/ExecutionDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/ExecutionService.java
+++ b/extexecution/src/org/netbeans/api/extexecution/ExecutionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/ExternalProcessBuilder.java
+++ b/extexecution/src/org/netbeans/api/extexecution/ExternalProcessBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/ExternalProcessSupport.java
+++ b/extexecution/src/org/netbeans/api/extexecution/ExternalProcessSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/ProcessBuilder.java
+++ b/extexecution/src/org/netbeans/api/extexecution/ProcessBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/InputProcessor.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/InputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/InputProcessors.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/InputProcessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/InputReader.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/InputReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/InputReaderTask.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/InputReaderTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/InputReaders.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/InputReaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/LineProcessor.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/LineProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/LineProcessors.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/LineProcessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/input/package-info.java
+++ b/extexecution/src/org/netbeans/api/extexecution/input/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/package-info.java
+++ b/extexecution/src/org/netbeans/api/extexecution/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/print/ConvertedLine.java
+++ b/extexecution/src/org/netbeans/api/extexecution/print/ConvertedLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/print/InputProcessors.java
+++ b/extexecution/src/org/netbeans/api/extexecution/print/InputProcessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/print/LineConvertor.java
+++ b/extexecution/src/org/netbeans/api/extexecution/print/LineConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/print/LineConvertors.java
+++ b/extexecution/src/org/netbeans/api/extexecution/print/LineConvertors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/print/LineProcessors.java
+++ b/extexecution/src/org/netbeans/api/extexecution/print/LineProcessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/print/package-info.java
+++ b/extexecution/src/org/netbeans/api/extexecution/print/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/startup/StartupExtender.java
+++ b/extexecution/src/org/netbeans/api/extexecution/startup/StartupExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/api/extexecution/startup/package-info.java
+++ b/extexecution/src/org/netbeans/api/extexecution/startup/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/InputOutputManager.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/InputOutputManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/OptionsAction.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/OptionsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/ProcessBuilderAccessor.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/ProcessBuilderAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/RerunAction.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/RerunAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/StopAction.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/StopAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/input/BaseInputProcessor.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/input/BaseInputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/input/DelegatingInputProcessor.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/input/DelegatingInputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/input/LineParsingHelper.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/input/LineParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/input/package-info.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/input/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/open/DefaultFileOpenHandler.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/open/DefaultFileOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/open/DefaultHttpOpenHandler.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/open/DefaultHttpOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/print/FileListener.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/print/FileListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/print/UrlListener.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/print/UrlListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/startup/ProxyStartupExtender.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/startup/ProxyStartupExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/modules/extexecution/startup/StartupExtenderRegistrationProcessor.java
+++ b/extexecution/src/org/netbeans/modules/extexecution/startup/StartupExtenderRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/ProcessBuilderFactory.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/ProcessBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/ProcessBuilderImplementation.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/ProcessBuilderImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/destroy/ProcessDestroyPerformer.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/destroy/ProcessDestroyPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/destroy/package-info.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/destroy/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/open/FileOpenHandler.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/open/FileOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/open/HttpOpenHandler.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/open/HttpOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/open/OptionOpenHandler.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/open/OptionOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/open/package-info.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/open/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/package-info.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/startup/StartupExtender.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/startup/StartupExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/startup/StartupExtenderImplementation.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/startup/StartupExtenderImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/src/org/netbeans/spi/extexecution/startup/package-info.java
+++ b/extexecution/src/org/netbeans/spi/extexecution/startup/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/ExecutionServiceTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/ExecutionServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/ExternalProcessBuilderTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/ExternalProcessBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/ExternalProcessSupportTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/ExternalProcessSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/ProcessBuilderTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/ProcessBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputProcessorsTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputProcessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersFileTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersReaderTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersStreamTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/LineProcessorsTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/LineProcessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestInputProcessor.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestInputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestInputUtils.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestInputUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestInputWriter.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestInputWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestLineProcessor.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/input/TestLineProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/print/InputProcessorsTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/print/InputProcessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/print/LineConvertorsTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/print/LineConvertorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/print/LineProcessorsTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/print/LineProcessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/print/TestHttpOpenHandler.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/print/TestHttpOpenHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/startup/StartupExtenderTest.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/startup/StartupExtenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/api/extexecution/startup/TestStartupExtender.java
+++ b/extexecution/test/unit/src/org/netbeans/api/extexecution/startup/TestStartupExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/modules/extexecution/InputOutputManagerTest.java
+++ b/extexecution/test/unit/src/org/netbeans/modules/extexecution/InputOutputManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/modules/extexecution/RerunActionTest.java
+++ b/extexecution/test/unit/src/org/netbeans/modules/extexecution/RerunActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/modules/extexecution/StopActionTest.java
+++ b/extexecution/test/unit/src/org/netbeans/modules/extexecution/StopActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/extexecution/test/unit/src/org/netbeans/modules/extexecution/input/LineParsingHelperTest.java
+++ b/extexecution/test/unit/src/org/netbeans/modules/extexecution/input/LineParsingHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/src/org/netbeans/modules/favorites/Actions.java
+++ b/favorites/src/org/netbeans/modules/favorites/Actions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/src/org/netbeans/modules/favorites/FavoritesNode.java
+++ b/favorites/src/org/netbeans/modules/favorites/FavoritesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/src/org/netbeans/modules/favorites/Tab.java
+++ b/favorites/src/org/netbeans/modules/favorites/Tab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/src/org/netbeans/modules/favorites/api/Favorites.java
+++ b/favorites/src/org/netbeans/modules/favorites/api/Favorites.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/test/qa-functional/src/gui/core/favorites/BasicsTest.java
+++ b/favorites/test/qa-functional/src/gui/core/favorites/BasicsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/test/unit/src/org/netbeans/modules/favorites/FavoritesNodeTest.java
+++ b/favorites/test/unit/src/org/netbeans/modules/favorites/FavoritesNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/test/unit/src/org/netbeans/modules/favorites/IndexTest.java
+++ b/favorites/test/unit/src/org/netbeans/modules/favorites/IndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/test/unit/src/org/netbeans/modules/favorites/NodesTest.java
+++ b/favorites/test/unit/src/org/netbeans/modules/favorites/NodesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/test/unit/src/org/netbeans/modules/favorites/RootsTest.java
+++ b/favorites/test/unit/src/org/netbeans/modules/favorites/RootsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/test/unit/src/org/netbeans/modules/favorites/VisibilityQueryWorksTest.java
+++ b/favorites/test/unit/src/org/netbeans/modules/favorites/VisibilityQueryWorksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/favorites/test/unit/src/org/netbeans/modules/favorites/api/FavoritesTest.java
+++ b/favorites/test/unit/src/org/netbeans/modules/favorites/api/FavoritesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/findbugs.installer/src/org/netbeans/modules/findbugs/installer/FakeAnalyzer.java
+++ b/findbugs.installer/src/org/netbeans/modules/findbugs/installer/FakeAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/findbugs.installer/src/org/netbeans/modules/findbugs/installer/FindBugsOptionsPanelController.java
+++ b/findbugs.installer/src/org/netbeans/modules/findbugs/installer/FindBugsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/findbugs.installer/src/org/netbeans/modules/findbugs/installer/FindBugsPanel.java
+++ b/findbugs.installer/src/org/netbeans/modules/findbugs/installer/FindBugsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.binding/src/org/netbeans/modules/form/binding/BindingDesignSupportImpl.java
+++ b/form.binding/src/org/netbeans/modules/form/binding/BindingDesignSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.binding/src/org/netbeans/modules/form/binding/BindingDesignSupportProviderImpl.java
+++ b/form.binding/src/org/netbeans/modules/form/binding/BindingDesignSupportProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/DBColumnDrop.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/DBColumnDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/DBConnectionDrop.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/DBConnectionDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/DBTableDrop.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/DBTableDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/EntityManagerCreator.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/EntityManagerCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/Installer.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/J2EEComponentDropProvider.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/J2EEComponentDropProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/J2EEPropertyModifier.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/J2EEPropertyModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/J2EEUtils.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/J2EEUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/JPADataImporter.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/JPADataImporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/QueryCreator.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/QueryCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/QueryResultListCreator.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/QueryResultListCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/DetailPanel.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/DetailPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/MasterDetailGenerator.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/MasterDetailGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/MasterDetailWizard.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/MasterDetailWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/MasterPanel.java
+++ b/form.j2ee/src/org/netbeans/modules/form/j2ee/wizard/MasterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/FormDataNode.java
+++ b/form.nb/src/org/netbeans/modules/nbform/FormDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/FormDesignerTC.java
+++ b/form.nb/src/org/netbeans/modules/nbform/FormDesignerTC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/FormEditorSupport.java
+++ b/form.nb/src/org/netbeans/modules/nbform/FormEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/NbFormServices.java
+++ b/form.nb/src/org/netbeans/modules/nbform/NbFormServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/SwingAppLibDownloader.java
+++ b/form.nb/src/org/netbeans/modules/nbform/SwingAppLibDownloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/actions/InstallToPaletteAction.java
+++ b/form.nb/src/org/netbeans/modules/nbform/actions/InstallToPaletteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/AddToPaletteWizard.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/AddToPaletteWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/BeanInstaller.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/BeanInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/CategorySelector.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/CategorySelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/ChooseBeansWizardPanel.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/ChooseBeansWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/ChooseCategoryWizardPanel.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/ChooseCategoryWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/ChooseJARWizardPanel.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/ChooseJARWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/ChooseLibraryWizardPanel.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/ChooseLibraryWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/ChooseProjectWizardPanel.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/ChooseProjectWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/palette/FormPaletteActions.java
+++ b/form.nb/src/org/netbeans/modules/nbform/palette/FormPaletteActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.nb/src/org/netbeans/modules/nbform/project/ClassSourceResolver.java
+++ b/form.nb/src/org/netbeans/modules/nbform/project/ClassSourceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.refactoring/src/org/netbeans/modules/form/refactoring/FormRefactoringUpdate.java
+++ b/form.refactoring/src/org/netbeans/modules/form/refactoring/FormRefactoringUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.refactoring/src/org/netbeans/modules/form/refactoring/GuardedBlockHandlerFactoryImpl.java
+++ b/form.refactoring/src/org/netbeans/modules/form/refactoring/GuardedBlockHandlerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.refactoring/src/org/netbeans/modules/form/refactoring/RADComponentRenameRefactoringSupport.java
+++ b/form.refactoring/src/org/netbeans/modules/form/refactoring/RADComponentRenameRefactoringSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.refactoring/src/org/netbeans/modules/form/refactoring/RefactoringInfo.java
+++ b/form.refactoring/src/org/netbeans/modules/form/refactoring/RefactoringInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form.refactoring/src/org/netbeans/modules/form/refactoring/RefactoringPluginFactoryImpl.java
+++ b/form.refactoring/src/org/netbeans/modules/form/refactoring/RefactoringPluginFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/release/sources/org/netbeans/lib/awtextra/AbsoluteConstraints.java
+++ b/form/release/sources/org/netbeans/lib/awtextra/AbsoluteConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/release/sources/org/netbeans/lib/awtextra/AbsoluteLayout.java
+++ b/form/release/sources/org/netbeans/lib/awtextra/AbsoluteLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/BeanPropertyEditor.java
+++ b/form/src/org/netbeans/modules/form/BeanPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/BeanSupport.java
+++ b/form/src/org/netbeans/modules/form/BeanSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/BindingCustomizer.java
+++ b/form/src/org/netbeans/modules/form/BindingCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/BindingDescriptor.java
+++ b/form/src/org/netbeans/modules/form/BindingDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/BindingDesignSupport.java
+++ b/form/src/org/netbeans/modules/form/BindingDesignSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/BindingDesignSupportProvider.java
+++ b/form/src/org/netbeans/modules/form/BindingDesignSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/BindingProperty.java
+++ b/form/src/org/netbeans/modules/form/BindingProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CodeCustomEditor.java
+++ b/form/src/org/netbeans/modules/form/CodeCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CodeCustomizer.java
+++ b/form/src/org/netbeans/modules/form/CodeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CodeGenerator.java
+++ b/form/src/org/netbeans/modules/form/CodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ComboBoxWithTree.java
+++ b/form/src/org/netbeans/modules/form/ComboBoxWithTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ComponentChooserEditor.java
+++ b/form/src/org/netbeans/modules/form/ComponentChooserEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ComponentContainer.java
+++ b/form/src/org/netbeans/modules/form/ComponentContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ComponentConverter.java
+++ b/form/src/org/netbeans/modules/form/ComponentConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ComponentDragger.java
+++ b/form/src/org/netbeans/modules/form/ComponentDragger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ComponentInspector.java
+++ b/form/src/org/netbeans/modules/form/ComponentInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ComponentLayer.java
+++ b/form/src/org/netbeans/modules/form/ComponentLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ConnectionCustomEditor.java
+++ b/form/src/org/netbeans/modules/form/ConnectionCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CopySupport.java
+++ b/form/src/org/netbeans/modules/form/CopySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CreationDescriptor.java
+++ b/form/src/org/netbeans/modules/form/CreationDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CreationFactory.java
+++ b/form/src/org/netbeans/modules/form/CreationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CustomCodeData.java
+++ b/form/src/org/netbeans/modules/form/CustomCodeData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/CustomCodeView.java
+++ b/form/src/org/netbeans/modules/form/CustomCodeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/DataImporter.java
+++ b/form/src/org/netbeans/modules/form/DataImporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/DefaultRADAction.java
+++ b/form/src/org/netbeans/modules/form/DefaultRADAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/EditorSupport.java
+++ b/form/src/org/netbeans/modules/form/EditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/Event.java
+++ b/form/src/org/netbeans/modules/form/Event.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/EventCustomEditor.java
+++ b/form/src/org/netbeans/modules/form/EventCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/EventProperty.java
+++ b/form/src/org/netbeans/modules/form/EventProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ExternalValue.java
+++ b/form/src/org/netbeans/modules/form/ExternalValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FakeRADProperty.java
+++ b/form/src/org/netbeans/modules/form/FakeRADProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormAwareEditor.java
+++ b/form/src/org/netbeans/modules/form/FormAwareEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormCodeAwareEditor.java
+++ b/form/src/org/netbeans/modules/form/FormCodeAwareEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormContainer.java
+++ b/form/src/org/netbeans/modules/form/FormContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormCookie.java
+++ b/form/src/org/netbeans/modules/form/FormCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormCustomEditor.java
+++ b/form/src/org/netbeans/modules/form/FormCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormDataLoader.java
+++ b/form/src/org/netbeans/modules/form/FormDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormDataLoaderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/FormDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormDataObject.java
+++ b/form/src/org/netbeans/modules/form/FormDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormDesignValue.java
+++ b/form/src/org/netbeans/modules/form/FormDesignValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormDesignValueAdapter.java
+++ b/form/src/org/netbeans/modules/form/FormDesignValueAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormDesigner.java
+++ b/form/src/org/netbeans/modules/form/FormDesigner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormEditor.java
+++ b/form/src/org/netbeans/modules/form/FormEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormEditorCustomizer.java
+++ b/form/src/org/netbeans/modules/form/FormEditorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormEditorModule.java
+++ b/form/src/org/netbeans/modules/form/FormEditorModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormEditorPanelController.java
+++ b/form/src/org/netbeans/modules/form/FormEditorPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormEvents.java
+++ b/form/src/org/netbeans/modules/form/FormEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormJavaSource.java
+++ b/form/src/org/netbeans/modules/form/FormJavaSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormLAF.java
+++ b/form/src/org/netbeans/modules/form/FormLAF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormLoaderSettings.java
+++ b/form/src/org/netbeans/modules/form/FormLoaderSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormModel.java
+++ b/form/src/org/netbeans/modules/form/FormModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormModelEvent.java
+++ b/form/src/org/netbeans/modules/form/FormModelEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormModelListener.java
+++ b/form/src/org/netbeans/modules/form/FormModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormNode.java
+++ b/form/src/org/netbeans/modules/form/FormNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormOthersNode.java
+++ b/form/src/org/netbeans/modules/form/FormOthersNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormProperty.java
+++ b/form/src/org/netbeans/modules/form/FormProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormPropertyContext.java
+++ b/form/src/org/netbeans/modules/form/FormPropertyContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormPropertyCookie.java
+++ b/form/src/org/netbeans/modules/form/FormPropertyCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormPropertyEditor.java
+++ b/form/src/org/netbeans/modules/form/FormPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormPropertyEditorManager.java
+++ b/form/src/org/netbeans/modules/form/FormPropertyEditorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormRootNode.java
+++ b/form/src/org/netbeans/modules/form/FormRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormServices.java
+++ b/form/src/org/netbeans/modules/form/FormServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormSettings.java
+++ b/form/src/org/netbeans/modules/form/FormSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormToolBar.java
+++ b/form/src/org/netbeans/modules/form/FormToolBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/FormUtils.java
+++ b/form/src/org/netbeans/modules/form/FormUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/GandalfPersistenceManager.java
+++ b/form/src/org/netbeans/modules/form/GandalfPersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/HandleLayer.java
+++ b/form/src/org/netbeans/modules/form/HandleLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/I18nService.java
+++ b/form/src/org/netbeans/modules/form/I18nService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/I18nValue.java
+++ b/form/src/org/netbeans/modules/form/I18nValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/InPlaceEditLayer.java
+++ b/form/src/org/netbeans/modules/form/InPlaceEditLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/InvalidComponent.java
+++ b/form/src/org/netbeans/modules/form/InvalidComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/JavaCodeGenerator.java
+++ b/form/src/org/netbeans/modules/form/JavaCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ListSelector.java
+++ b/form/src/org/netbeans/modules/form/ListSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/MetaBinding.java
+++ b/form/src/org/netbeans/modules/form/MetaBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/MetaComponentCreator.java
+++ b/form/src/org/netbeans/modules/form/MetaComponentCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/MethodPicker.java
+++ b/form/src/org/netbeans/modules/form/MethodPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/MultiClassLoader.java
+++ b/form/src/org/netbeans/modules/form/MultiClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/NamedPropertyEditor.java
+++ b/form/src/org/netbeans/modules/form/NamedPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/NewComponentDrop.java
+++ b/form/src/org/netbeans/modules/form/NewComponentDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/NewComponentDropProvider.java
+++ b/form/src/org/netbeans/modules/form/NewComponentDropProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/NonVisualTray.java
+++ b/form/src/org/netbeans/modules/form/NonVisualTray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ParametersPicker.java
+++ b/form/src/org/netbeans/modules/form/ParametersPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/PersistenceException.java
+++ b/form/src/org/netbeans/modules/form/PersistenceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/PersistenceManager.java
+++ b/form/src/org/netbeans/modules/form/PersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/PersistenceObjectRegistry.java
+++ b/form/src/org/netbeans/modules/form/PersistenceObjectRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/PropertyModifier.java
+++ b/form/src/org/netbeans/modules/form/PropertyModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/PropertyPicker.java
+++ b/form/src/org/netbeans/modules/form/PropertyPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADComponent.java
+++ b/form/src/org/netbeans/modules/form/RADComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADComponentCookie.java
+++ b/form/src/org/netbeans/modules/form/RADComponentCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADComponentNode.java
+++ b/form/src/org/netbeans/modules/form/RADComponentNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADConnectionPropertyEditor.java
+++ b/form/src/org/netbeans/modules/form/RADConnectionPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADContainer.java
+++ b/form/src/org/netbeans/modules/form/RADContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADFormContainer.java
+++ b/form/src/org/netbeans/modules/form/RADFormContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADMenuComponent.java
+++ b/form/src/org/netbeans/modules/form/RADMenuComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADMenuItemComponent.java
+++ b/form/src/org/netbeans/modules/form/RADMenuItemComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADProperty.java
+++ b/form/src/org/netbeans/modules/form/RADProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADVisualComponent.java
+++ b/form/src/org/netbeans/modules/form/RADVisualComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADVisualContainer.java
+++ b/form/src/org/netbeans/modules/form/RADVisualContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RADVisualFormContainer.java
+++ b/form/src/org/netbeans/modules/form/RADVisualFormContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/RenameSupport.java
+++ b/form/src/org/netbeans/modules/form/RenameSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ResourcePanel.java
+++ b/form/src/org/netbeans/modules/form/ResourcePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ResourceService.java
+++ b/form/src/org/netbeans/modules/form/ResourceService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ResourceSupport.java
+++ b/form/src/org/netbeans/modules/form/ResourceSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ResourceValue.java
+++ b/form/src/org/netbeans/modules/form/ResourceValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ResourceWrapperEditor.java
+++ b/form/src/org/netbeans/modules/form/ResourceWrapperEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/Separator.java
+++ b/form/src/org/netbeans/modules/form/Separator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/ViewConverter.java
+++ b/form/src/org/netbeans/modules/form/ViewConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/VisualReplicator.java
+++ b/form/src/org/netbeans/modules/form/VisualReplicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/AddAction.java
+++ b/form/src/org/netbeans/modules/form/actions/AddAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/AlignAction.java
+++ b/form/src/org/netbeans/modules/form/actions/AlignAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/BindAction.java
+++ b/form/src/org/netbeans/modules/form/actions/BindAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/ChooseSameSizeAction.java
+++ b/form/src/org/netbeans/modules/form/actions/ChooseSameSizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/CustomCodeAction.java
+++ b/form/src/org/netbeans/modules/form/actions/CustomCodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/CustomizeEmptySpaceAction.java
+++ b/form/src/org/netbeans/modules/form/actions/CustomizeEmptySpaceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/CustomizeLayoutAction.java
+++ b/form/src/org/netbeans/modules/form/actions/CustomizeLayoutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/DefaultSizeAction.java
+++ b/form/src/org/netbeans/modules/form/actions/DefaultSizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/DesignParentAction.java
+++ b/form/src/org/netbeans/modules/form/actions/DesignParentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/DuplicateAction.java
+++ b/form/src/org/netbeans/modules/form/actions/DuplicateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/EditContainerAction.java
+++ b/form/src/org/netbeans/modules/form/actions/EditContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/EditFormAction.java
+++ b/form/src/org/netbeans/modules/form/actions/EditFormAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/EditLayoutSpacePanel.java
+++ b/form/src/org/netbeans/modules/form/actions/EditLayoutSpacePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/EncloseAction.java
+++ b/form/src/org/netbeans/modules/form/actions/EncloseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/EventsAction.java
+++ b/form/src/org/netbeans/modules/form/actions/EventsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/InPlaceEditAction.java
+++ b/form/src/org/netbeans/modules/form/actions/InPlaceEditAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/InstallBeanAction.java
+++ b/form/src/org/netbeans/modules/form/actions/InstallBeanAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/PropertyAction.java
+++ b/form/src/org/netbeans/modules/form/actions/PropertyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/ReloadAction.java
+++ b/form/src/org/netbeans/modules/form/actions/ReloadAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/SelectLayoutAction.java
+++ b/form/src/org/netbeans/modules/form/actions/SelectLayoutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/SetAnchoringAction.java
+++ b/form/src/org/netbeans/modules/form/actions/SetAnchoringAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/SetResizabilityAction.java
+++ b/form/src/org/netbeans/modules/form/actions/SetResizabilityAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/actions/TestAction.java
+++ b/form/src/org/netbeans/modules/form/actions/TestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/assistant/AssistantMessages.java
+++ b/form/src/org/netbeans/modules/form/assistant/AssistantMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/assistant/AssistantModel.java
+++ b/form/src/org/netbeans/modules/form/assistant/AssistantModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/assistant/AssistantView.java
+++ b/form/src/org/netbeans/modules/form/assistant/AssistantView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/ButtonBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/ButtonBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/CanvasBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/CanvasBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/CheckboxBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/CheckboxBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/ChoiceBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/ChoiceBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/ComponentBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/ComponentBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/LabelBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/LabelBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/ListBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/ListBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/MenuBarBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/MenuBarBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/MenuComponentBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/MenuComponentBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/MenuItemBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/MenuItemBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/PanelBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/PanelBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/PopupMenuBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/PopupMenuBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/ScrollPaneBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/ScrollPaneBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/ScrollbarBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/ScrollbarBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/TextAreaBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/TextAreaBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/TextComponentBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/TextComponentBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/TextFieldBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/TextFieldBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/awt/package-info.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/awt/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/BISupport.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/BISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/BevelBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/BevelBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/BorderLayoutBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/BorderLayoutBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/BoxLayoutBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/BoxLayoutBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/CardLayoutBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/CardLayoutBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/CompoundBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/CompoundBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/EmptyBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/EmptyBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/EtchedBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/EtchedBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/FlowLayoutBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/FlowLayoutBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/GridBagLayoutBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/GridBagLayoutBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/GridLayoutBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/GridLayoutBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/JDesktopPaneBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/JDesktopPaneBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/JLayeredPaneBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/JLayeredPaneBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/LineBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/LineBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/MatteBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/MatteBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/OverlayLayoutBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/OverlayLayoutBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/SoftBevelBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/SoftBevelBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/TitledBorderBeanInfo.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/TitledBorderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/beaninfo/swing/package-info.java
+++ b/form/src/org/netbeans/modules/form/beaninfo/swing/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/AbstractCodeStatement.java
+++ b/form/src/org/netbeans/modules/form/codestructure/AbstractCodeStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeExpression.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeExpressionOrigin.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeExpressionOrigin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeGroup.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeObjectUsage.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeObjectUsage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeStatement.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeStructure.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeStructure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeStructureChange.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeStructureChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeSupport.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/CodeVariable.java
+++ b/form/src/org/netbeans/modules/form/codestructure/CodeVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/DefaultCodeExpression.java
+++ b/form/src/org/netbeans/modules/form/codestructure/DefaultCodeExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/FormCodeSupport.java
+++ b/form/src/org/netbeans/modules/form/codestructure/FormCodeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/UsedCodeObject.java
+++ b/form/src/org/netbeans/modules/form/codestructure/UsedCodeObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/codestructure/UsingCodeObject.java
+++ b/form/src/org/netbeans/modules/form/codestructure/UsingCodeObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/AbstractFormatterFactoryEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/AbstractFormatterFactoryEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/ClassPathFileChooser.java
+++ b/form/src/org/netbeans/modules/form/editors/ClassPathFileChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/CustomCodeEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/CustomCodeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/CustomIconEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/CustomIconEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/EnumEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/EnumEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/FormatSelector.java
+++ b/form/src/org/netbeans/modules/form/editors/FormatSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/IconEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/IconEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/ImportImageWizard.java
+++ b/form/src/org/netbeans/modules/form/editors/ImportImageWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/KeyStrokeEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/KeyStrokeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/MnemonicEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/MnemonicEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/ModifierEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/ModifierEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/ModifierPanel.java
+++ b/form/src/org/netbeans/modules/form/editors/ModifierPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/PrimitiveTypeArrayEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/PrimitiveTypeArrayEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/SpinnerEditorEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/SpinnerEditorEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/StringArrayCustomEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/StringArrayCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/StringArrayCustomizable.java
+++ b/form/src/org/netbeans/modules/form/editors/StringArrayCustomizable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/StringArrayEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/StringArrayEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/StringEditor.java
+++ b/form/src/org/netbeans/modules/form/editors/StringEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors/TableCustomizer.java
+++ b/form/src/org/netbeans/modules/form/editors/TableCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/BorderDesignSupport.java
+++ b/form/src/org/netbeans/modules/form/editors2/BorderDesignSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/BorderEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/BorderEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/ColorEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/ColorEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/ComboBoxModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/ComboBoxModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/CursorEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/CursorEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/CustomTableModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/CustomTableModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/FontEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/FontEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/IconEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/IconEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/JTableHeaderEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/JTableHeaderEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/JTableSelectionModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/JTableSelectionModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/ListModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/ListModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/SpinnerModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/SpinnerModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/StringEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/StringEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/TableColumnModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/TableColumnModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/TableModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/TableModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/TreeModelCustomizer.java
+++ b/form/src/org/netbeans/modules/form/editors2/TreeModelCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/editors2/TreeModelEditor.java
+++ b/form/src/org/netbeans/modules/form/editors2/TreeModelEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeButtonPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeButtonPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeCanvasPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeCanvasPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeCheckboxPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeCheckboxPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeChoicePeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeChoicePeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeComponentPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeComponentPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeContainerPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeContainerPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeLabelPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeLabelPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeListPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeListPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakePanelPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakePanelPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakePeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakePeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakePeerContainer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakePeerContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakePeerInvocationHandler.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakePeerInvocationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakePeerSupport.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakePeerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakePeerUtils.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakePeerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeScrollPanePeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeScrollPanePeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeScrollbarPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeScrollbarPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeTextAreaPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeTextAreaPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeTextComponentPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeTextComponentPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/fakepeer/FakeTextFieldPeer.java
+++ b/form/src/org/netbeans/modules/form/fakepeer/FakeTextFieldPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/forminfo/FormInfo.java
+++ b/form/src/org/netbeans/modules/form/forminfo/FormInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutAligner.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutAligner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutComponent.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutConstants.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutDesigner.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutDesigner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutDragger.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutDragger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutEvent.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutFeeder.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutFeeder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutInterval.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutInterval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutModel.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutOperations.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutPainter.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutPersistenceManager.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutPersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutPosition.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutPosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutRegion.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutTestUtils.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/LayoutUtils.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/LayoutUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/VisualMapper.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/VisualMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/VisualState.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/VisualState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutBuilder.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutCodeGenerator.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutUtils.java
+++ b/form/src/org/netbeans/modules/form/layoutdesign/support/SwingLayoutUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/AbstractLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/AbstractLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/BeanCodeManager.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/BeanCodeManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/DefaultLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/DefaultLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/LayoutConstraints.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/LayoutConstraints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/LayoutNode.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/LayoutNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportContext.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportDelegate.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportManager.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportRegistry.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/LayoutSupportRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/MetaLayout.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/MetaLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/UnknownLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/UnknownLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/AbsoluteLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/AbsoluteLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/BorderLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/BorderLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/BoxLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/BoxLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/CardLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/CardLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/FlowLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/FlowLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagControlCenter.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagControlCenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagCustomizer.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/JScrollPaneSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/JScrollPaneSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/JSplitPaneSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/JSplitPaneSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/JTabbedPaneSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/JTabbedPaneSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/JToolBarSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/JToolBarSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/MenuFakeSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/MenuFakeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/NullLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/NullLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/OverlayLayoutSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/OverlayLayoutSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/delegates/ScrollPaneSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/delegates/ScrollPaneSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/AnimationLayer.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/AnimationLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/DesignerContext.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/DesignerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GlassPane.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GlassPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridBagCustomizer.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridBagCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridBagInfoProvider.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridBagInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridBagManager.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridBagManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridCustomizer.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridDesigner.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridDesigner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridInfoProvider.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridManager.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridUtils.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/UndoRedoSupport.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/UndoRedoSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/AbstractGridAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/AbstractGridAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/AddAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/AddAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/AddGapsAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/AddGapsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteColumnAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteColumnAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteColumnContentAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteColumnContentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteComponentAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteComponentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteRowAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteRowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteRowContentAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DeleteRowContentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DesignContainerAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/DesignContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/EncloseInContainerAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/EncloseInContainerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/GridAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/GridAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/GridActionPerformer.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/GridActionPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/GridBoundsChange.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/GridBoundsChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/InsertColumnAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/InsertColumnAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/InsertRowAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/InsertRowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/RemoveGapsAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/RemoveGapsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/SplitColumnAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/SplitColumnAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/SplitRowAction.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/actions/SplitRowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/AddSubItemAction.java
+++ b/form/src/org/netbeans/modules/form/menu/AddSubItemAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/DragOperation.java
+++ b/form/src/org/netbeans/modules/form/menu/DragOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/DropTargetLayer.java
+++ b/form/src/org/netbeans/modules/form/menu/DropTargetLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/InsertMenuAction.java
+++ b/form/src/org/netbeans/modules/form/menu/InsertMenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/KeyboardMenuNavigator.java
+++ b/form/src/org/netbeans/modules/form/menu/KeyboardMenuNavigator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/MenuEditLayer.java
+++ b/form/src/org/netbeans/modules/form/menu/MenuEditLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/VisualDesignerJPanelPopup.java
+++ b/form/src/org/netbeans/modules/form/menu/VisualDesignerJPanelPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/VisualDesignerPopupFactory.java
+++ b/form/src/org/netbeans/modules/form/menu/VisualDesignerPopupFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/menu/VisualDesignerPopupMenuUI.java
+++ b/form/src/org/netbeans/modules/form/menu/VisualDesignerPopupMenuUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/palette/BoxFillerInitializer.java
+++ b/form/src/org/netbeans/modules/form/palette/BoxFillerInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/palette/ChooseBeanInitializer.java
+++ b/form/src/org/netbeans/modules/form/palette/ChooseBeanInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/palette/PaletteItem.java
+++ b/form/src/org/netbeans/modules/form/palette/PaletteItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
+++ b/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/palette/PaletteMenuView.java
+++ b/form/src/org/netbeans/modules/form/palette/PaletteMenuView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/palette/PaletteUtils.java
+++ b/form/src/org/netbeans/modules/form/palette/PaletteUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/palette/ScrollPopupMenu.java
+++ b/form/src/org/netbeans/modules/form/palette/ScrollPopupMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/project/ClassPathUtils.java
+++ b/form/src/org/netbeans/modules/form/project/ClassPathUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/project/ClassSource.java
+++ b/form/src/org/netbeans/modules/form/project/ClassSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/project/FormClassLoader.java
+++ b/form/src/org/netbeans/modules/form/project/FormClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/project/ProjectClassLoader.java
+++ b/form/src/org/netbeans/modules/form/project/ProjectClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/resources/LayoutModelAutoTest_template
+++ b/form/src/org/netbeans/modules/form/resources/LayoutModelAutoTest_template
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/wizard/ConnectionPanel1.java
+++ b/form/src/org/netbeans/modules/form/wizard/ConnectionPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/wizard/ConnectionPanel2.java
+++ b/form/src/org/netbeans/modules/form/wizard/ConnectionPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/wizard/ConnectionPanel3.java
+++ b/form/src/org/netbeans/modules/form/wizard/ConnectionPanel3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/wizard/ConnectionWizard.java
+++ b/form/src/org/netbeans/modules/form/wizard/ConnectionWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/wizard/ConnectionWizardPanel1.java
+++ b/form/src/org/netbeans/modules/form/wizard/ConnectionWizardPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/wizard/ConnectionWizardPanel2.java
+++ b/form/src/org/netbeans/modules/form/wizard/ConnectionWizardPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/src/org/netbeans/modules/form/wizard/ConnectionWizardPanel3.java
+++ b/form/src/org/netbeans/modules/form/wizard/ConnectionWizardPanel3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/ConnectionPanel1.java
+++ b/form/test/qa-functional/data/OpenForm/ConnectionPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/ConnectionPanel2.java
+++ b/form/test/qa-functional/data/OpenForm/ConnectionPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/ConnectionPanel3.java
+++ b/form/test/qa-functional/data/OpenForm/ConnectionPanel3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/CustomCodeEditor.java
+++ b/form/test/qa-functional/data/OpenForm/CustomCodeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/EventCustomEditor.java
+++ b/form/test/qa-functional/data/OpenForm/EventCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/FormCustomEditor.java
+++ b/form/test/qa-functional/data/OpenForm/FormCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/FormCustomEditorAdvanced.java
+++ b/form/test/qa-functional/data/OpenForm/FormCustomEditorAdvanced.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/MethodPicker.java
+++ b/form/test/qa-functional/data/OpenForm/MethodPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/ParametersPicker.java
+++ b/form/test/qa-functional/data/OpenForm/ParametersPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/PropertyPicker.java
+++ b/form/test/qa-functional/data/OpenForm/PropertyPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/OpenForm/StringArrayCustomEditor.java
+++ b/form/test/qa-functional/data/OpenForm/StringArrayCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleDesktopApplication/src/data/clear_JFrame.java
+++ b/form/test/qa-functional/data/SampleDesktopApplication/src/data/clear_JFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleDesktopApplication/src/sampledesktopapplication/SampleDesktopAboutBox.java
+++ b/form/test/qa-functional/data/SampleDesktopApplication/src/sampledesktopapplication/SampleDesktopAboutBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleDesktopApplication/src/sampledesktopapplication/SampleDesktopApplication.java
+++ b/form/test/qa-functional/data/SampleDesktopApplication/src/sampledesktopapplication/SampleDesktopApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleDesktopApplication/src/sampledesktopapplication/SampleDesktopView.java
+++ b/form/test/qa-functional/data/SampleDesktopApplication/src/sampledesktopapplication/SampleDesktopView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/Bool2FaceConverter.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/Bool2FaceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/ConvertorAndValidatorTest.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/ConvertorAndValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/CustomComponentForm.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/CustomComponentForm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/FrameWithBundle.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/FrameWithBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/FrameWithBundleToMove.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/FrameWithBundleToMove.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/Gaps.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/Gaps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/LoginLengthValidator.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/LoginLengthValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/RenameComponentVariableTestFrame.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/RenameComponentVariableTestFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/SystemOutBindingListener.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/SystemOutBindingListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/TestNonVisualBean.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/TestNonVisualBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/TestVisualBean.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/TestVisualBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/clear_Frame.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/clear_Frame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/clear_JFrame.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/clear_JFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/data/components/CustomButton.java
+++ b/form/test/qa-functional/data/SampleProject/src/data/components/CustomButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testAdvancedIndentation.java
+++ b/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testAdvancedIndentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testBasicIndentation.java
+++ b/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testBasicIndentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testReformat.java
+++ b/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testReformat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testReformat2.java
+++ b/form/test/qa-functional/data/SampleProject/src/org/netbeans/test/editor/formatting/testReformat2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/lib/EditorTestCase.java
+++ b/form/test/qa-functional/src/lib/EditorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/BindDialogOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/BindDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/BorderCustomEditorOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/BorderCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/DeleteDir.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/DeleteDir.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/ExtJellyTestCase.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/ExtJellyTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/NewBeanFormOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/NewBeanFormOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/NewBeanFormSuperclassOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/NewBeanFormSuperclassOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/OpenFormTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/OpenFormTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/OpenTempl_defaultPackTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/OpenTempl_defaultPackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/OptionsForFormOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/OptionsForFormOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/PaletteManagerOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/PaletteManagerOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/SelectPaletteCategoryOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/SelectPaletteCategoryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/TemplateTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/TemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/VisualDevelopmentUtil.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/VisualDevelopmentUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/actions/actionsTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/actions/actionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/beans/AddAndRemoveBeansTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/beans/AddAndRemoveBeansTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/beans/AddBeanFormsTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/beans/AddBeanFormsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/binding/AdvancedBeansBindingTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/binding/AdvancedBeansBindingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/binding/SimpleBeansBindingTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/binding/SimpleBeansBindingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/databinding/MasterDetailFormTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/databinding/MasterDetailFormTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/databinding/SetUpDerbyDatabaseTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/databinding/SetUpDerbyDatabaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/gaps/EditLayoutSpaceOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/gaps/EditLayoutSpaceOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/gaps/GapsTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/gaps/GapsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/gridbagcustomizer/CustomizeLayoutOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/gridbagcustomizer/CustomizeLayoutOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/gridbagcustomizer/GridBagCustomizerTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/gridbagcustomizer/GridBagCustomizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/issues/CutAndPasteTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/issues/CutAndPasteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/jda/ApplicationActionsTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/jda/ApplicationActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/jda/ChooseClassOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/jda/ChooseClassOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/jda/CreateNewActionOperator.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/jda/CreateNewActionOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/jda/FrameViewPropertiesTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/jda/FrameViewPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/jda/SimpleJDAProjectTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/jda/SimpleJDAProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/options/AutomaticInternationalizationTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/options/AutomaticInternationalizationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/options/GeneratedComponentsDestionationTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/options/GeneratedComponentsDestionationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/MoveFormClassTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/MoveFormClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/RenameComponentVariableTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/RenameComponentVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/RenameFormClassTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/RenameFormClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/RenamePackageComponentAndCustomCodeTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/refactoring/RenamePackageComponentAndCustomCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/undoredo/BaseTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/undoredo/BaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/undoredo/data/goldenfiles/BaseTest/testJavaFile.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/undoredo/data/goldenfiles/BaseTest/testJavaFile.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/AddComponents_AWT.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/AddComponents_AWT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/AddComponents_SWING.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/AddComponents_SWING.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/FormGenerateCodeTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/FormGenerateCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/MenuAndPopupMenuTest.java
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/MenuAndPopupMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile_1.5.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile_1.5.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile_1.6.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile_1.6.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile_13.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_AWT/testJavaFile_13.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile_1.5.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile_1.5.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile_1.6.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile_1.6.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile_13.pass
+++ b/form/test/qa-functional/src/org/netbeans/qa/form/visualDevelopment/data/goldenfiles/AddComponents_SWING/testJavaFile_13.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/qa-functional/src/org/netbeans/test/editor/formatting/BasicTest.java
+++ b/form/test/qa-functional/src/org/netbeans/test/editor/formatting/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_AddingToColumn1Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_AddingToColumn1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_AddingToColumn2Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_AddingToColumn2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_AddingToColumn3Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_AddingToColumn3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Anchor01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Anchor01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Anchor02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Anchor02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Baseline07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_BorderPositions07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug124689Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug124689Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_1Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_2Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_3Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_4Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_4Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_5Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_5Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_6Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_6Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_7Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug125080_7Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug129494_1Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug129494_1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug129494_2Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug129494_2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug134368_1Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug134368_1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug134368_2Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug134368_2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug174593Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug174593Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug177608Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug177608Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug191075Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug191075Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug202708Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug202708Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203112Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203112Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203129Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203129Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203480Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203480Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203486Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203486Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203563Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203563Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203622Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203622Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203628Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203628Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203656Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203656Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203677Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203677Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203684Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203684Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203742Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug203742Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204044Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204044Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204704Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204704Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204747Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204747Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204814Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug204814Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug207040Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug207040Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug209957_1Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug209957_1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug209957_2Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug209957_2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug209975Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug209975Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug253745Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug253745Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug66431_3Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug66431_3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug66919Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug66919Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug69497Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug69497Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug70661Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug70661Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug70904Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Bug70904Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_CenteredResizing_Bug137738Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_CenteredResizing_Bug137738Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ClosedPosition04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_DefaultSize01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_DefaultSize01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Duplicating_Bug128426Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Duplicating_Bug128426Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Duplicating_Bug145134Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Duplicating_Bug145134Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Duplication01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Duplication01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization10Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization1Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization2Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization3Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization4Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization4Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization5Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization5Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization6Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization6Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization7Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization7Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization8Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization8Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization9aTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization9aTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization9bTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_GapsOptimization9bTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Indent04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Inserting01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Inserting01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize08Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize08Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize09Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize09Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize10Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize11Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize11Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize12Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize12Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize13Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize13Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize14Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MaintainSize14Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Move01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Move01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_MultiResizable04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition08Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition08Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition09Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition09Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition10Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition11Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition11Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition12Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition12Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition13Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition13Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition14Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition14Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition15Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition15Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition16Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition16Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition17Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition17Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition18Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition18Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition19Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition19Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition20Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition20Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition21Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition21Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition22Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition22Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition23Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition23Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition24Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition24Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition25Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition25Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition26Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ParallelPosition26Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning08Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning08Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning09aTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning09aTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning09bTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning09bTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning10Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning11Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning11Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning12Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning12Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning13Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning13Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning14Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning14Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning15Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning15Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning16Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning16Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning17Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning17Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning18Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning18Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning19Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning19Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning20Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Positioning20Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing08Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing08Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing09Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing09Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing10Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing11Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing11Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing12Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing12Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing13Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing13Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing14Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing14Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing15Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing15Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing16Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing16Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing17Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing17Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing18Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing18Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing19Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing19Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing20aTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing20aTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing20bTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing20bTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing20cTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing20cTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing21Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing21Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing22Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_Resizing22Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ResizingSizeTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ResizingSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing04bTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing04bTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing08Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing08Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing09Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing09Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing10Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing11Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing11Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing12Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing12Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing13Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing13Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing14Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing14Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing15Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing15Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing16Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing16Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing_Bug77875Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SeqResizing_Bug77875Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SequentialPosition01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SequentialPosition01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ShrinkingContainerTest.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_ShrinkingContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition08Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition08Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition09Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition09Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition10Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition11Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SizeDefinition11Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing06Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing06Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing07Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing07Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing08Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing08Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing09Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_SuppressedResizing09Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension02Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension02Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension03Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension03Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension04Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension04Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension05Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UnchangedDimension05Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UndoRedo01Test.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/ALT_UndoRedo01Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/FakeLayoutMapper.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/FakeLayoutMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/LayoutTestCase.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/LayoutTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/LayoutTestSuite.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/LayoutTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/form/test/unit/src/org/netbeans/modules/form/layoutdesign/TestsInPkgSuite.java
+++ b/form/test/unit/src/org/netbeans/modules/form/layoutdesign/TestsInPkgSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/Annotator.java
+++ b/git/src/org/netbeans/modules/git/Annotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/FileInformation.java
+++ b/git/src/org/netbeans/modules/git/FileInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/FileStatusCache.java
+++ b/git/src/org/netbeans/modules/git/FileStatusCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/FilesystemInterceptor.java
+++ b/git/src/org/netbeans/modules/git/FilesystemInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/Git.java
+++ b/git/src/org/netbeans/modules/git/Git.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/GitFileNode.java
+++ b/git/src/org/netbeans/modules/git/GitFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/GitModuleConfig.java
+++ b/git/src/org/netbeans/modules/git/GitModuleConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/GitRepositories.java
+++ b/git/src/org/netbeans/modules/git/GitRepositories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/GitStatusNode.java
+++ b/git/src/org/netbeans/modules/git/GitStatusNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/GitVCS.java
+++ b/git/src/org/netbeans/modules/git/GitVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/HistoryProvider.java
+++ b/git/src/org/netbeans/modules/git/HistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/HistoryRegistry.java
+++ b/git/src/org/netbeans/modules/git/HistoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ModuleLifecycleManager.java
+++ b/git/src/org/netbeans/modules/git/ModuleLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/VersionsCache.java
+++ b/git/src/org/netbeans/modules/git/VersionsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/api/Git.java
+++ b/git/src/org/netbeans/modules/git/api/Git.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/client/CommandReport.java
+++ b/git/src/org/netbeans/modules/git/client/CommandReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/client/CredentialsCallback.java
+++ b/git/src/org/netbeans/modules/git/client/CredentialsCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/client/GitCanceledException.java
+++ b/git/src/org/netbeans/modules/git/client/GitCanceledException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/client/GitClient.java
+++ b/git/src/org/netbeans/modules/git/client/GitClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/client/GitClientExceptionHandler.java
+++ b/git/src/org/netbeans/modules/git/client/GitClientExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/client/GitProgressSupport.java
+++ b/git/src/org/netbeans/modules/git/client/GitProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/client/ProgressDelegate.java
+++ b/git/src/org/netbeans/modules/git/client/ProgressDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/options/AnnotationColorProvider.java
+++ b/git/src/org/netbeans/modules/git/options/AnnotationColorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/options/GitAdvancedOption.java
+++ b/git/src/org/netbeans/modules/git/options/GitAdvancedOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/options/GitOptionsPanel.java
+++ b/git/src/org/netbeans/modules/git/options/GitOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/options/GitOptionsPanelController.java
+++ b/git/src/org/netbeans/modules/git/options/GitOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/options/LabelsPanel.java
+++ b/git/src/org/netbeans/modules/git/options/LabelsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/ActionProgress.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/ActionProgress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/ActionProgressSupport.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/ActionProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/AddAction.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/AddAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/AddAllAction.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/AddAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/ContextHolder.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/ContextHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/GitAction.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/GitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/MultipleRepositoryAction.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/MultipleRepositoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/actions/SingleRepositoryAction.java
+++ b/git/src/org/netbeans/modules/git/ui/actions/SingleRepositoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/AnnotateAction.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/AnnotateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/AnnotateLine.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/AnnotateLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/AnnotationBar.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/AnnotationBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/AnnotationBarManager.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/AnnotationBarManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/AnnotationMark.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/AnnotationMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/AnnotationMarkInstaller.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/AnnotationMarkInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/AnnotationMarkProvider.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/AnnotationMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/LinesReader.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/LinesReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/blame/TooltipWindow.java
+++ b/git/src/org/netbeans/modules/git/ui/blame/TooltipWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/BranchSynchronizer.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/BranchSynchronizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/CherryPick.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/CherryPick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/CherryPickAction.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/CherryPickAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/CherryPickPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/CherryPickPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/CreateBranch.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/CreateBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/CreateBranchAction.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/CreateBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/CreateBranchPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/CreateBranchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/DeleteBranchAction.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/DeleteBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/SelectTrackedBranch.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/SelectTrackedBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/SelectTrackedBranchPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/SelectTrackedBranchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/branch/SetTrackingAction.java
+++ b/git/src/org/netbeans/modules/git/ui/branch/SetTrackingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/AbstractCheckoutAction.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/AbstractCheckoutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/AbstractCheckoutRevision.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/AbstractCheckoutRevision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/CheckoutPaths.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/CheckoutPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/CheckoutPathsAction.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/CheckoutPathsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/CheckoutPathsPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/CheckoutPathsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/CheckoutRevisionAction.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/CheckoutRevisionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/CheckoutRevisionPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/CheckoutRevisionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/RevertAllChangesAction.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/RevertAllChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/RevertChanges.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/RevertChanges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/RevertChangesAction.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/RevertChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/RevertChangesPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/RevertChangesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/checkout/SwitchBranchAction.java
+++ b/git/src/org/netbeans/modules/git/ui/checkout/SwitchBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/clone/CloneAction.java
+++ b/git/src/org/netbeans/modules/git/ui/clone/CloneAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/clone/CloneDestinationPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/clone/CloneDestinationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/clone/CloneDestinationStep.java
+++ b/git/src/org/netbeans/modules/git/ui/clone/CloneDestinationStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/clone/CloneWizard.java
+++ b/git/src/org/netbeans/modules/git/ui/clone/CloneWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/clone/FetchBranchesStep.java
+++ b/git/src/org/netbeans/modules/git/ui/clone/FetchBranchesStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/clone/RepositoryStep.java
+++ b/git/src/org/netbeans/modules/git/ui/clone/RepositoryStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/clone/RepositoryStepPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/clone/RepositoryStepPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/CommitAction.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/CommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/CommitAllAction.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/CommitAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/CommitPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/CommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/DeleteLocalAction.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/DeleteLocalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/ExcludeFromCommitAction.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/ExcludeFromCommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/GitCommitPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/GitCommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/GitCommitParameters.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/GitCommitParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/GitCommitTable.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/GitCommitTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/IncludeInCommitAction.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/IncludeInCommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/MessageArea.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/MessageArea.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/commit/MessageAreaBuilder.java
+++ b/git/src/org/netbeans/modules/git/ui/commit/MessageAreaBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/conflicts/MarkResolvedAction.java
+++ b/git/src/org/netbeans/modules/git/ui/conflicts/MarkResolvedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/conflicts/ResolveAllConflictsAction.java
+++ b/git/src/org/netbeans/modules/git/ui/conflicts/ResolveAllConflictsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/conflicts/ResolveConflictsAction.java
+++ b/git/src/org/netbeans/modules/git/ui/conflicts/ResolveConflictsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/conflicts/ResolveConflictsExecutor.java
+++ b/git/src/org/netbeans/modules/git/ui/conflicts/ResolveConflictsExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/conflicts/ResolveTreeConflictPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/conflicts/ResolveTreeConflictPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffAction.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffAllAction.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffCurrentToRepositoryAction.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffCurrentToRepositoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffCurrentToTrackedAction.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffCurrentToTrackedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffFileTable.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffFileTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffFileTreeImpl.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffFileTreeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffFileViewComponent.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffFileViewComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffNode.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffStreamSource.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffStreamSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffToRevision.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffToRevision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffToRevisionAction.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffToRevisionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffToRevisionKind.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffToRevisionKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffToRevisionPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffToRevisionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/DiffTopComponent.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/DiffTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/ExportAsFilePanel.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/ExportAsFilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/ExportCommit.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/ExportCommit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/ExportCommitAction.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/ExportCommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/ExportCommitPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/ExportCommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/ExportUncommittedChangesAction.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/ExportUncommittedChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/MultiDiffPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/MultiDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/MultiDiffPanelController.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/MultiDiffPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/diff/Setup.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/Setup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/BranchMapping.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/BranchMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/FetchAction.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/FetchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/FetchBranchesStep.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/FetchBranchesStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/FetchFromUpstreamAction.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/FetchFromUpstreamAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/FetchUtils.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/FetchUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/FetchWizard.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/FetchWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/PullAction.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/PullAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/PullBranchesStep.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/PullBranchesStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/PullFromUpstreamAction.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/PullFromUpstreamAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/fetch/PullWizard.java
+++ b/git/src/org/netbeans/modules/git/ui/fetch/PullWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/BranchSelector.java
+++ b/git/src/org/netbeans/modules/git/ui/history/BranchSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/DiffResultsView.java
+++ b/git/src/org/netbeans/modules/git/ui/history/DiffResultsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/DiffResultsViewForLine.java
+++ b/git/src/org/netbeans/modules/git/ui/history/DiffResultsViewForLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/DiffTreeTable.java
+++ b/git/src/org/netbeans/modules/git/ui/history/DiffTreeTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/RepositoryRevision.java
+++ b/git/src/org/netbeans/modules/git/ui/history/RepositoryRevision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/RevisionNode.java
+++ b/git/src/org/netbeans/modules/git/ui/history/RevisionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/RevisionNodeChildren.java
+++ b/git/src/org/netbeans/modules/git/ui/history/RevisionNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchCriteriaPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchCriteriaPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchExecutor.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchHistoryAction.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchHistoryPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchHistoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchHistoryTopComponent.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchHistoryTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchIncoming.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchIncoming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchIncomingAction.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchIncomingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchIncomingTopComponent.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchIncomingTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchIncomingWithContextAction.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchIncomingWithContextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchOutgoing.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchOutgoing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchOutgoingAction.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchOutgoingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchOutgoingTopComponent.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchOutgoingTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchOutgoingWithContextAction.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchOutgoingWithContextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SearchRepositoryHistoryAction.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SearchRepositoryHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/history/SummaryView.java
+++ b/git/src/org/netbeans/modules/git/ui/history/SummaryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/ignore/IgnoreAction.java
+++ b/git/src/org/netbeans/modules/git/ui/ignore/IgnoreAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/ignore/UnignoreAction.java
+++ b/git/src/org/netbeans/modules/git/ui/ignore/UnignoreAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/init/InitAction.java
+++ b/git/src/org/netbeans/modules/git/ui/init/InitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/init/InitPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/init/InitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/BranchMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/BranchMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/CheckoutMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/CheckoutMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/DiffMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/DiffMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/DynamicMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/DynamicMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/IgnoreMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/IgnoreMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/PatchesMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/PatchesMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/RemoteMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/RemoteMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/RepositoryMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/RepositoryMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/RevertMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/RevertMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/menu/ShelveMenu.java
+++ b/git/src/org/netbeans/modules/git/ui/menu/ShelveMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/merge/MergeRevision.java
+++ b/git/src/org/netbeans/modules/git/ui/merge/MergeRevision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/merge/MergeRevisionAction.java
+++ b/git/src/org/netbeans/modules/git/ui/merge/MergeRevisionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/merge/MergeRevisionPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/merge/MergeRevisionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/output/OpenOutputAction.java
+++ b/git/src/org/netbeans/modules/git/ui/output/OpenOutputAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/output/OutputLogger.java
+++ b/git/src/org/netbeans/modules/git/ui/output/OutputLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/push/PushAction.java
+++ b/git/src/org/netbeans/modules/git/ui/push/PushAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/push/PushBranchesStep.java
+++ b/git/src/org/netbeans/modules/git/ui/push/PushBranchesStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/push/PushMapping.java
+++ b/git/src/org/netbeans/modules/git/ui/push/PushMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/push/PushToUpstreamAction.java
+++ b/git/src/org/netbeans/modules/git/ui/push/PushToUpstreamAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/push/PushWizard.java
+++ b/git/src/org/netbeans/modules/git/ui/push/PushWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/push/UpdateBranchReferencesStep.java
+++ b/git/src/org/netbeans/modules/git/ui/push/UpdateBranchReferencesStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/rebase/BasicPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/rebase/BasicPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/rebase/Rebase.java
+++ b/git/src/org/netbeans/modules/git/ui/rebase/Rebase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/rebase/RebaseAction.java
+++ b/git/src/org/netbeans/modules/git/ui/rebase/RebaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/rebase/RebaseKind.java
+++ b/git/src/org/netbeans/modules/git/ui/rebase/RebaseKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/rebase/RebasePanel.java
+++ b/git/src/org/netbeans/modules/git/ui/rebase/RebasePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/rebase/SelectDestPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/rebase/SelectDestPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/ControlToolbar.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/ControlToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/GitRepositoryTopComponent.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/GitRepositoryTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/OpenConfigurationAction.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/OpenConfigurationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/OpenGlobalConfigurationAction.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/OpenGlobalConfigurationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/OpenRepositoryAction.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/OpenRepositoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RepositoryBrowserAction.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RepositoryBrowserAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RepositoryBrowserPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RepositoryBrowserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RepositoryInfo.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RepositoryInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/Revision.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/Revision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RevisionDialog.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RevisionDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RevisionDialogController.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RevisionDialogController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RevisionInfoPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RevisionInfoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RevisionInfoPanelController.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RevisionInfoPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RevisionListPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RevisionListPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RevisionPicker.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RevisionPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/RevisionPickerDialog.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/RevisionPickerDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/SelectBranchPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/SelectBranchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/ConnectionSettings.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/ConnectionSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteConfig.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteRepository.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteRepositoryPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteRepositoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/RemoveRemoteConfig.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/RemoveRemoteConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/SSHPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/SSHPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/SelectUriPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/SelectUriPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/SelectUriStep.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/SelectUriStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/repository/remote/UserPasswordPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/repository/remote/UserPasswordPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/reset/Reset.java
+++ b/git/src/org/netbeans/modules/git/ui/reset/Reset.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/reset/ResetAction.java
+++ b/git/src/org/netbeans/modules/git/ui/reset/ResetAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/reset/ResetPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/reset/ResetPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/revert/RevertCommit.java
+++ b/git/src/org/netbeans/modules/git/ui/revert/RevertCommit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/revert/RevertCommitAction.java
+++ b/git/src/org/netbeans/modules/git/ui/revert/RevertCommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/revert/RevertCommitPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/revert/RevertCommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/selectors/ItemSelector.java
+++ b/git/src/org/netbeans/modules/git/ui/selectors/ItemSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/selectors/ItemsPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/selectors/ItemsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/shelve/ShelveChangesAction.java
+++ b/git/src/org/netbeans/modules/git/ui/shelve/ShelveChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/stash/ApplyStashAction.java
+++ b/git/src/org/netbeans/modules/git/ui/stash/ApplyStashAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/stash/SaveStash.java
+++ b/git/src/org/netbeans/modules/git/ui/stash/SaveStash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/stash/SaveStashAction.java
+++ b/git/src/org/netbeans/modules/git/ui/stash/SaveStashAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/stash/SaveStashPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/stash/SaveStashPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/stash/Stash.java
+++ b/git/src/org/netbeans/modules/git/ui/stash/Stash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/FileTreeViewImpl.java
+++ b/git/src/org/netbeans/modules/git/ui/status/FileTreeViewImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/GitStatusTable.java
+++ b/git/src/org/netbeans/modules/git/ui/status/GitStatusTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/GitVersioningTopComponent.java
+++ b/git/src/org/netbeans/modules/git/ui/status/GitVersioningTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/OpenStatusAction.java
+++ b/git/src/org/netbeans/modules/git/ui/status/OpenStatusAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/StatusAction.java
+++ b/git/src/org/netbeans/modules/git/ui/status/StatusAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/StatusAllAction.java
+++ b/git/src/org/netbeans/modules/git/ui/status/StatusAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/VersioningPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/status/VersioningPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/status/VersioningPanelController.java
+++ b/git/src/org/netbeans/modules/git/ui/status/VersioningPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/tag/CreateTag.java
+++ b/git/src/org/netbeans/modules/git/ui/tag/CreateTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/tag/CreateTagAction.java
+++ b/git/src/org/netbeans/modules/git/ui/tag/CreateTagAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/tag/CreateTagPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/tag/CreateTagPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/tag/ManageTags.java
+++ b/git/src/org/netbeans/modules/git/ui/tag/ManageTags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/tag/ManageTagsAction.java
+++ b/git/src/org/netbeans/modules/git/ui/tag/ManageTagsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/tag/ManageTagsPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/tag/ManageTagsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/ui/wizards/AbstractWizardPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/wizards/AbstractWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/utils/GitUtils.java
+++ b/git/src/org/netbeans/modules/git/utils/GitUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/utils/JGitUtils.java
+++ b/git/src/org/netbeans/modules/git/utils/JGitUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/utils/LogUtils.java
+++ b/git/src/org/netbeans/modules/git/utils/LogUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/utils/ResultProcessor.java
+++ b/git/src/org/netbeans/modules/git/utils/ResultProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/src/org/netbeans/modules/git/utils/WizardStepProgressSupport.java
+++ b/git/src/org/netbeans/modules/git/utils/WizardStepProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/GitStableTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/GitStableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/archeology/AnnotationsTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/archeology/AnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/commit/CloneTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/commit/CloneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/commit/CommitDataTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/commit/CommitDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/commit/CommitUiTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/commit/CommitUiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/commit/IgnoreTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/commit/IgnoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/commit/InitializeTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/commit/InitializeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/delete/DeleteTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/delete/DeleteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/delete/RefactoringTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/delete/RefactoringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/diff/DiffTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/diff/DiffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/main/diff/ExportDiffPatchTest.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/main/diff/ExportDiffPatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/CommitOperator.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/CommitOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/DiffOperator.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/DiffOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/NewJavaFileNameLocationStepOperator.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/NewJavaFileNameLocationStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/NewJavaProjectNameLocationStepOperator.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/NewJavaProjectNameLocationStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/RevertModificationsOperator.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/RevertModificationsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/SourcePackagesNode.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/SourcePackagesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/VersioningOperator.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/VersioningOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/actions/CommitAction.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/actions/CommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/operators/actions/RevertAction.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/operators/actions/RevertAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/utils/MessageHandler.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/utils/MessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/utils/RepositoryMaintenance.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/utils/RepositoryMaintenance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/utils/StreamHandler.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/utils/StreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/utils/TestKit.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/utils/TestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/qa-functional/src/org/netbeans/test/git/utils/gitExistsChecker.java
+++ b/git/test/qa-functional/src/org/netbeans/test/git/utils/gitExistsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/AbstractGitTestCase.java
+++ b/git/test/unit/src/org/netbeans/modules/git/AbstractGitTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ExternalChangesTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ExternalChangesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/FilesystemInterceptorTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/FilesystemInterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/GitClientTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/GitClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/GitTestKit.java
+++ b/git/test/unit/src/org/netbeans/modules/git/GitTestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/GitUtilsTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/GitUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/HistoryTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/HistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/StatusTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/StatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/VersioningQueryTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/VersioningQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/getTopmostTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/getTopmostTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/commit/CommitDialogTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/commit/CommitDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/commit/CommitParametersTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/commit/CommitParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/commit/CommitTableTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/commit/CommitTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/diff/DiffTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/diff/DiffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/merge/MergeTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/merge/MergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/repository/RepositoryInfoTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/repository/RepositoryInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/repository/remote/ConnectTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/repository/remote/ConnectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/git/test/unit/src/org/netbeans/modules/git/ui/status/StatusTest.java
+++ b/git/test/unit/src/org/netbeans/modules/git/ui/status/StatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gototest/src/org/netbeans/modules/gototest/GotoOppositeAction.java
+++ b/gototest/src/org/netbeans/modules/gototest/GotoOppositeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gototest/src/org/netbeans/modules/gototest/OppositeCandidateChooser.java
+++ b/gototest/src/org/netbeans/modules/gototest/OppositeCandidateChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gototest/src/org/netbeans/modules/gototest/PopupUtil.java
+++ b/gototest/src/org/netbeans/modules/gototest/PopupUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gototest/src/org/netbeans/spi/gototest/TestLocator.java
+++ b/gototest/src/org/netbeans/spi/gototest/TestLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageAction.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageBar.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageDocInfo.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageDocInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageHighlightsContainer.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageHighlightsLayerFactory.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageHighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageManagerImpl.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageReportTopComponent.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageReportTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageSideBar.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageSideBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageActionFactory.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageActionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageManager.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageProvider.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageProviderHelper.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageProviderHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageType.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/CoverageType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/FileCoverageDetails.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/FileCoverageDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/FileCoverageSummary.java
+++ b/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/api/FileCoverageSummary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ClassNameTextField.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ClassNameTextField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/CommonTestsCfgOfCreate.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/CommonTestsCfgOfCreate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/MessageStack.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/MessageStack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultBar.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultDisplayHandler.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultDisplayHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelOutput.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelTree.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultTreeView.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultWindow.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultWindowOpenAction.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultWindowOpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/RootNode.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/RootNodeChildren.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/RootNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/StatisticsPanel.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/StatisticsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestCreatorAction.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestCreatorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodDebuggerAction.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodDebuggerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodNodeChildren.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodRunnerAction.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodRunnerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestRunnerSettings.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestRunnerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestsuiteNodeChildren.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestsuiteNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/CallstackFrameNode.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/CallstackFrameNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/DefaultTestRunnerNodeFactory.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/DefaultTestRunnerNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/DiffViewAction.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/DiffViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Locator.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Locator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Manager.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Manager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/OutputLineHandler.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/OutputLineHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestCreatorPanelDisplayer.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestCreatorPanelDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodDebuggerProvider.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodDebuggerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodNode.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodRunnerProvider.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodRunnerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestNodeAction.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestNodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestRunnerNodeFactory.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestRunnerNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestsuiteNode.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestsuiteNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/UICommonUtils.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/UICommonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputDocument.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputEditorKit.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputUtils.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputView.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/spi/TestCreatorConfiguration.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/spi/TestCreatorConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/spi/TestCreatorConfigurationProvider.java
+++ b/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/spi/TestCreatorConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/test/unit/src/org/netbeans/modules/gsf/testrunner/ui/ClassNameTextFieldTest.java
+++ b/gsf.testrunner.ui/test/unit/src/org/netbeans/modules/gsf/testrunner/ui/ClassNameTextFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner.ui/test/unit/src/org/netbeans/modules/gsf/testrunner/ui/MessageStackTest.java
+++ b/gsf.testrunner.ui/test/unit/src/org/netbeans/modules/gsf/testrunner/ui/MessageStackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/CoreManagerProcessor.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/CoreManagerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/TestCreatorProviderProcessor.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/TestCreatorProviderProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/CommonUtils.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/CommonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/CoreManager.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/CoreManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/NamedObject.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/NamedObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/OutputLine.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/OutputLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Report.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Report.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/RerunHandler.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/RerunHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/RerunType.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/RerunType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/SelfResizingPanel.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/SelfResizingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/SizeRestrictedPanel.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/SizeRestrictedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Status.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestCreatorProvider.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestCreatorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestMethodNodeAction.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestMethodNodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestSession.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestSuite.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Testcase.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Testcase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Trouble.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/Trouble.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/UnitTestsUsage.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/UnitTestsUsage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/CommonPlugin.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/CommonPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/CommonSettingsProvider.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/CommonSettingsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/CommonTestUtilProvider.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/CommonTestUtilProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/GuiUtilsProvider.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/GuiUtilsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/RootsProvider.java
+++ b/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/plugin/RootsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/catalog/HibernateCatalog.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/catalog/HibernateCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/cfg/HibernateCfgProperties.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/cfg/HibernateCfgProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/cfg/HibernateCfgXmlConstants.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/cfg/HibernateCfgXmlConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/cfg/model/package-info.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/cfg/model/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/CompletionContext.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/CompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/Completor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/Completor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionManager.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionQuery.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCompletionDocumentation.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCompletionDocumentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCompletionItem.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionManager.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionQuery.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateRevengCompletionManager.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateRevengCompletionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateRevengCompletionProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateRevengCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateRevengCompletionQuery.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/HibernateRevengCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/completion/LazyTypeCompletionItem.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/completion/LazyTypeCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/editor/ContextUtilities.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/editor/ContextUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/editor/DocumentContext.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/editor/DocumentContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/editor/EditorContextFactory.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/editor/EditorContextFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/editor/HibernateEditorUtil.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/editor/HibernateEditorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hqleditor/HQLEditorController.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hqleditor/HQLEditorController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hqleditor/HQLExecutor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hqleditor/HQLExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hqleditor/HQLResult.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hqleditor/HQLResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hqleditor/ui/HQLEditorAction.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hqleditor/ui/HQLEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hqleditor/ui/HQLEditorTopComponent.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hqleditor/ui/HQLEditorTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HibernateCfgHyperlinkProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HibernateCfgHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HibernateMappingHyperlinkProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HibernateMappingHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HyperlinkEnv.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HyperlinkEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HyperlinkProcessor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hyperlink/HyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hyperlink/JavaClassHyperlinkProcessor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hyperlink/JavaClassHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hyperlink/PropertyHyperlinkProcessor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hyperlink/PropertyHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/hyperlink/ResourceHyperlinkProcessor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/hyperlink/ResourceHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/HbXmlMultiViewEditorSupport.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/HbXmlMultiViewEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataLoader.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataLoaderBeanInfo.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataNode.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataObject.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgMetadata.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/HibernateCfgMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/BrowseFolders.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/BrowseFolders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachesPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachesTableModel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachesTablePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/ClassCachesTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachesPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachesTableModel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachesTablePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/CollectionCachesTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventListenerPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventListenerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventTableModel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventTablePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/EventTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/GrantPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/GrantPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/HibernateCfgPanelFactory.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/HibernateCfgPanelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/HibernateCfgToolBarMVElement.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/HibernateCfgToolBarMVElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingsPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingsTableModel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingsTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingsTablePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/MappingsTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/NewEventPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/NewEventPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertiesPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertiesTableModel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertiesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertiesTablePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertiesTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertyPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/PropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/SecurityPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/SecurityPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/SecurityTableModel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/SecurityTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/SecurityTablePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/SecurityTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/Util.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/cfg/multiview/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataLoader.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataLoaderBeanInfo.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataNode.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataObject.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingMetadata.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/mapping/HibernateMappingMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataLoader.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataLoaderBeanInfo.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataNode.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataObject.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengMetadata.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/loaders/reveng/HibernateRevengMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/mapping/HibernateMappingXmlConstants.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/mapping/HibernateMappingXmlConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/mapping/model/package-info.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/mapping/model/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateFindUsagesPlugin.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateFindUsagesPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingFindUsagesPlugin.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingFindUsagesPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingMovePlugin.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingMovePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingRefactoringActionsProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingRefactoringActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingRenamePlugin.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingRenamePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingRenameTransaction.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingRenameTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingWhereUsedQueryUI.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMappingWhereUsedQueryUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMovePlugin.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateMovePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRefactoringElement.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRefactoringElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRefactoringPluginFactory.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRefactoringPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRefactoringUtil.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRefactoringUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRenamePlugin.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRenamePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRenameRefactoringElement.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/HibernateRenameRefactoringElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaClassRenameTransaction.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaClassRenameTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaFieldRenameTransaction.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaFieldRenameTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaPackageRenameTransaction.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaPackageRenameTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaRenameChanger.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/JavaRenameChanger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/MoveMappingFilePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/MoveMappingFilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/MoveMappingFilesRefactoringUI.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/MoveMappingFilesRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/RenameMappingFilePanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/RenameMappingFilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/RenameMappingFileRefactoringUI.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/RenameMappingFileRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/refactoring/RenameTransaction.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/refactoring/RenameTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/reveng/HibernateRevengXmlConstants.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/reveng/HibernateRevengXmlConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/reveng/model/package-info.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/reveng/model/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/service/TableColumn.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/service/TableColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/service/api/HibernateEnvironment.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/service/api/HibernateEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/service/listener/ProjectOpenedHookImpl.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/service/listener/ProjectOpenedHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/service/spi/HibernateEnvironmentImpl.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/service/spi/HibernateEnvironmentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/service/spi/HibernateVerificationWarningOverrider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/service/spi/HibernateVerificationWarningOverrider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/spi/hibernate/HibernateFileLocationProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/spi/hibernate/HibernateFileLocationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/util/CustomClassLoader.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/util/CustomClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/util/CustomJDBCConnectionProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/util/CustomJDBCConnectionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/util/HibernateUtil.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/util/HibernateUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodGenNameLocationWizardDescriptor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodGenNameLocationWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenWizard.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenWizardDescriptor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenWizardHelper.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenWizardHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenerationPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateCodeGenerationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateConfigurationWizard.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateConfigurationWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateConfigurationWizardDescriptor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateConfigurationWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateConfigurationWizardPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateConfigurationWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateMappingWizard.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateMappingWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateMappingWizardDescriptor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateMappingWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateMappingWizardPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateMappingWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateRevengDatabaseTablesPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateRevengDatabaseTablesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateRevengDbTablesWizardDescriptor.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateRevengDbTablesWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateRevengWizard.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/HibernateRevengWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/Util.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/WizardErrorPanel.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/WizardErrorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaFileList.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaFileList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaManager.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaTableProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaTableProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaUISupport.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/DBSchemaUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/EmptyTableProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/EmptyTableProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/SelectedTables.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/SelectedTables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/SourceGroupUISupport.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/SourceGroupUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/Table.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/Table.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableClosure.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableClosure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableProvider.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableSource.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableUISupport.java
+++ b/hibernate/src/org/netbeans/modules/hibernate/wizards/support/TableUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionManagerTest.java
+++ b/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/HibernateCfgCompletionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/HibernateCompletionTestBase.java
+++ b/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/HibernateCompletionTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionManagerTest.java
+++ b/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/HibernateMappingCompletionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/Util.java
+++ b/hibernate/test/unit/src/org/netbeans/modules/hibernate/completion/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/test/unit/src/org/netbeans/modules/hibernate/hyperlink/HibernateCfgHyperlinkProviderTest.java
+++ b/hibernate/test/unit/src/org/netbeans/modules/hibernate/hyperlink/HibernateCfgHyperlinkProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/test/unit/src/org/netbeans/modules/hibernate/hyperlink/HibernateMappingHyperlinkProviderTest.java
+++ b/hibernate/test/unit/src/org/netbeans/modules/hibernate/hyperlink/HibernateMappingHyperlinkProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hibernate/test/unit/src/org/netbeans/modules/hibernate/mimeresolver/HibernateMIMEResolver.java
+++ b/hibernate/test/unit/src/org/netbeans/modules/hibernate/mimeresolver/HibernateMIMEResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/CustomAttributeCompletionItem.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/CustomAttributeCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/CustomHintFixProvider.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/CustomHintFixProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/CustomHtmlExtension.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/CustomHtmlExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/CustomTagCompletionItem.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/CustomTagCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/conf/Attribute.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/conf/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/conf/Configuration.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/conf/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/conf/Element.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/conf/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/conf/Tag.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/conf/Tag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/AddAttributeFix.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/AddAttributeFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/AddAttributeToSourceFix.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/AddAttributeToSourceFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/AddElementFix.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/AddElementFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/CheckerElementVisitor.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/CheckerElementVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/CustomElementHint.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/CustomElementHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/EditProjectsConfFix.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/EditProjectsConfFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/MissingRequiredAttributes.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/MissingRequiredAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/RemoveElementFix.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/RemoveElementFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/UnknownAttributes.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/UnknownAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/src/org/netbeans/modules/html/custom/hints/Utils.java
+++ b/html.custom/src/org/netbeans/modules/html/custom/hints/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.custom/test/unit/src/org/netbeans/modules/html/custom/ConfigurationTest.java
+++ b/html.custom/test/unit/src/org/netbeans/modules/html/custom/ConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/DTD2HtmlTag.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/DTD2HtmlTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/ElementsIteratorHandle.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/ElementsIteratorHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/ElementsParser.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/ElementsParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/ElementsParserCache.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/ElementsParserCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/EmptyResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/EmptyResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/Html4ModelProvider.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/Html4ModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/HtmlSourceVersionQuery.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/HtmlSourceVersionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/RootNode.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/SimpleXHTMLParser.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/SimpleXHTMLParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/XmlSTElements.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/XmlSTElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/XmlSyntaxTreeBuilder.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/XmlSyntaxTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/DefaultHelpItem.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/DefaultHelpItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/DefaultHtmlParseResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/DefaultHtmlParseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/DefaultParseResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/DefaultParseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HelpItem.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HelpItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HelpResolver.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HelpResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParseResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParser.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParserFactory.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParsingResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlParsingResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlSource.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlSourceVersionController.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlSourceVersionController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlVersion.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/HtmlVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/MaskedAreas.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/MaskedAreas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ParseException.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ParseResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ParseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/ProblemDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SourceElementHandle.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SourceElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzer.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerElements.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/dtd/ReaderProvider.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/dtd/ReaderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/dtd/ReaderProviderFactory.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/dtd/ReaderProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Attribute.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/AttributeFilter.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/AttributeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/CloseTag.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/CloseTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Declaration.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Declaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Element.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementFilter.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementType.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementUtils.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementVisitor.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementsIterator.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/ElementsIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/FeaturedNode.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/FeaturedNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Named.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Named.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Node.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/OpenTag.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/OpenTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/TreePath.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/elements/TreePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/CharSequenceReader.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/CharSequenceReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/MaskingChSReader.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/MaskingChSReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/SimpleMaskingChSReader.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/SimpleMaskingChSReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/UndeclaredContentResolver.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/foreign/UndeclaredContentResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModel.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModelFactory.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModelProvider.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTag.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTagAttribute.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTagAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTagAttributeType.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTagAttributeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTagType.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/HtmlTagType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/NamedCharRef.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/model/NamedCharRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidationContext.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidationException.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidationResult.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/Validator.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/Validator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidatorService.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/validation/ValidatorService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/DTD.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/DTD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/DTDParser.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/DTDParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/InvalidateEvent.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/InvalidateEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/InvalidateListener.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/InvalidateListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/Registry.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/dtd/Registry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AbstractElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AbstractElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AbstractTagElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AbstractTagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AttributeElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AttributeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AttributelessOpenTagElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/AttributelessOpenTagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/CommentElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/CommentElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/DeclarationElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/DeclarationElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/EndTagElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/EndTagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/EntityReferenceElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/EntityReferenceElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/ErrorElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/ErrorElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/LongOpenTagElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/LongOpenTagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/OpenTagElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/OpenTagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/ProblematicAttributelessOpenTagElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/ProblematicAttributelessOpenTagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/ProblematicOpenTagElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/ProblematicOpenTagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/TextElement.java
+++ b/html.editor.lib/src/org/netbeans/modules/html/editor/lib/plain/TextElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/ElementsParserCacheTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/ElementsParserCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/ElementsParserTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/ElementsParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/XmlSyntaxTreeBuilderTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/XmlSyntaxTreeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/HtmlVersionTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/HtmlVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerResultTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/elements/ElementUtilsTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/elements/ElementUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/elements/ElementsIteratorTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/elements/ElementsIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/elements/TreePathTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/elements/TreePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModelFactoryTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/api/model/HtmlModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/plain/AttributeElementTest.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/plain/AttributeElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/test/RepositoryImpl.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/test/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/test/TestBase.java
+++ b/html.editor.lib/test/unit/src/org/netbeans/modules/html/editor/lib/test/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/APIAccessor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/APIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/CreateHtmlFromTemplateAttributeProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/CreateHtmlFromTemplateAttributeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlBracesMatching.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlBracesMatching.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlCaretAwareSourceTask.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlCaretAwareSourceTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlCompletionOptionsPanel.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlCompletionOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlElementProperties.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlElementProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlErrorFilter.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlErrorFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlExtensions.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlExtensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlExternalDropHandler.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlExternalDropHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlPreferences.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlSettingsFactory.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlSettingsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlSourceUtils.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlSourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/HtmlTransferHandler.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/HtmlTransferHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/NbReaderProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/NbReaderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/NbReaderProviderFactory.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/NbReaderProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/ProjectDefaultHtmlSourceVersionController.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/ProjectDefaultHtmlSourceVersionController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/Utils.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/ViewAction.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/ViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/AccessorImpl.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/HtmlEditorUtils.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/HtmlEditorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/HtmlKit.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/HtmlKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/Utils.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/actions/AbstractSourceElementAction.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/actions/AbstractSourceElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/actions/DeleteElementAction.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/actions/DeleteElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/actions/ModifyElementRulesAction.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/actions/ModifyElementRulesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/completion/HtmlCompletionItem.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/completion/HtmlCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/gsf/CustomAttribute.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/gsf/CustomAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/gsf/CustomTag.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/gsf/CustomTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/gsf/ErrorBadgingRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/gsf/ErrorBadgingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/gsf/HtmlErrorFilterContext.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/gsf/HtmlErrorFilterContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/gsf/HtmlExtension.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/gsf/HtmlExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/gsf/HtmlParserResult.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/gsf/HtmlParserResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/api/index/HtmlIndex.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/api/index/HtmlIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/codegen/LoremIpsumGenerator.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/codegen/LoremIpsumGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/codegen/LoremIpsumPanel.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/codegen/LoremIpsumPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/coloring/EmbeddingHighlightsContainer.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/coloring/EmbeddingHighlightsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/coloring/EmbeddingHighlightsLayerFactory.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/coloring/EmbeddingHighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/completion/AttrValuesCompletion.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/completion/AttrValuesCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQuery.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlPaletteCompletionProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlPaletteCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/embedding/CssEmbeddingProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/embedding/CssEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/embedding/CssHtmlTranslator.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/embedding/CssHtmlTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/embedding/JsEPPluginQuery.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/embedding/JsEPPluginQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/embedding/JsEmbeddingProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/embedding/JsEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlCommentHandler.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlCommentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlDeclarationFinder.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlDeclarationFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlElementHandle.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlFoldTypeProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlFoldTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlGSFParser.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlGSFParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlKeystrokeHandler.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlKeystrokeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlLanguage.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlParserResultAccessor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlParserResultAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlRenameHandler.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlRenameHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlSemanticAnalyzer.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlSemanticAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlStructureItem.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlStructureItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlStructureScanner.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlStructureScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Attribute.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/CharacterReference.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/CharacterReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Comments.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Comments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Doctype.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Doctype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Element.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/EmbeddingUtil.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/EmbeddingUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Encoding.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Encoding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/FatalHtmlRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/FatalHtmlRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/ForeignContent.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/ForeignContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Form.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Form.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/HeadContent.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/HeadContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/HintsAdvancedOption.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/HintsAdvancedOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlHintsProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlHintsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlRuleContext.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlRuleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlValidatorRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/HtmlValidatorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Ids.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Ids.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Internal.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Internal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Nesting.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Nesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Normalization.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Normalization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/NotValidButCommon.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/NotValidButCommon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/NotValidatedContent.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/NotValidatedContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Obsolete.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Obsolete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Other.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Other.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/PatternRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/PatternRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/ProcessingInstruction.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/ProcessingInstruction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/StrayContent.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/StrayContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/Table.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/Table.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/TagsMatching.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/TagsMatching.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/UnexpectedChars.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/UnexpectedChars.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/AddStylesheetLinkHintFix.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/AddStylesheetLinkHintFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/CssClassesVisitor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/CssClassesVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/CssElementType.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/CssElementType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/CssIdsVisitor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/CssIdsVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/HintContext.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/HintContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingClassRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingClassRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingClassRuleInApp.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingClassRuleInApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingCssElement.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingCssElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingIdRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/css/MissingIdRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/other/ExtractInlinedStyleHint.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/other/ExtractInlinedStyleHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/other/ExtractInlinedStyleRule.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/other/ExtractInlinedStyleRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/other/RemoveSurroundingTag.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/other/RemoveSurroundingTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/hints/other/SurroundWithTag.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/hints/other/SurroundWithTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/indent/HtmlIndentTask.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/indent/HtmlIndentTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/indent/HtmlIndentTaskFactory.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/indent/HtmlIndentTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/indent/HtmlIndenter.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/indent/HtmlIndenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/indexing/Entry.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/indexing/Entry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlFileModel.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlFileModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlIndexer.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlLinkEntry.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlLinkEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/javadoc/HelpItem.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/javadoc/HelpItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/javadoc/HelpManager.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/javadoc/HelpManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/javadoc/SAXHelpHandler.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/javadoc/SAXHelpHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/javadoc/TagHelpItem.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/javadoc/TagHelpItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/options/ui/FmtOptions.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/options/ui/FmtOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/options/ui/FmtOptionsPanel.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/options/ui/FmtOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/DeclarationItem.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/DeclarationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/DiffElement.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/DiffElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStylePanel.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStylePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringPlugin.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringUI.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlActionsImplementationProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlActionsImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlRefactoringPluginFactory.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlRefactoringPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlRenameRefactoringPlugin.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlRenameRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlSpecificActionsImplementationFactory.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlSpecificActionsImplementationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlSpecificActionsImplementationProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlSpecificActionsImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlSpecificRefactoringsProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlSpecificRefactoringsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/InlinedStyleInfo.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/InlinedStyleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/RefactoringContext.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/RefactoringContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/ResolveDeclarationItem.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/ResolveDeclarationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/ResolveDeclarationsPanel.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/ResolveDeclarationsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/actions/ExtractInlinedStyleAction.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/actions/ExtractInlinedStyleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/actions/HtmlRefactoringActionsFactory.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/actions/HtmlRefactoringActionsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/actions/HtmlRefactoringGlobalAction.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/actions/HtmlRefactoringGlobalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/api/ExtractInlinedStyleRefactoring.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/api/ExtractInlinedStyleRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/refactoring/api/SelectorType.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/refactoring/api/SelectorType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/spi/HintFixProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/spi/HintFixProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/spi/embedding/JsEmbeddingProviderPlugin.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/spi/embedding/JsEmbeddingProviderPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlCamelCaseInterceptor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlCamelCaseInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlDeletedTextInterceptor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlDeletedTextInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypedBreakInterceptor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypedBreakInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypedTextInterceptor.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypedTextInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/ui/ModifyElementRulesPanel.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/ui/ModifyElementRulesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/xhtml/ELEmbeddingProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/xhtml/ELEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElEmbeddingProvider.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElHighlighting.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElLanguage.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElLexer.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElTokenId.java
+++ b/html.editor/src/org/netbeans/modules/html/editor/xhtml/XhtmlElTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/editor/ext/html/DTDParserTest.java
+++ b/html.editor/test/unit/src/org/netbeans/editor/ext/html/DTDParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/HtmlEmbeddingTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/HtmlEmbeddingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/HtmlMatcherTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/HtmlMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/NbReaderProviderTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/NbReaderProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/api/gsf/HtmlParserResultTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/api/gsf/HtmlParserResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/codegen/LoremIpsumGeneratorTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/codegen/LoremIpsumGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/Html5CompletionQueryTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/Html5CompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProviderTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQueryTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionTestBase.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionTestSupport.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/XhtmlCompletionQueryTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/XhtmlCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/embedding/CssEmbeddingProviderTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/embedding/CssEmbeddingProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/embedding/CssHtmlTranslatorTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/embedding/CssHtmlTranslatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/embedding/JsEmbeddingProviderTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/embedding/JsEmbeddingProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlElementHandleTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlElementHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlGSFParserTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlGSFParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlKeystrokeHandlerTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlKeystrokeHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlStructureItemTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/gsf/HtmlStructureItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/DoctypeTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/DoctypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/EncodingTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/EncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/HtmlHintsProviderTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/HtmlHintsProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/css/CssClassesVisitorTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/hints/css/CssClassesVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/indent/HtmlIndenterTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/indent/HtmlIndenterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/indexing/HtmlFileModelTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/indexing/HtmlFileModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/spi/embedding/JsEmbeddingProviderPluginTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/spi/embedding/JsEmbeddingProviderPluginTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/RepositoryImpl.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/TestBase.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/TestBase2.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/TestBase2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/Utils.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/test/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypedBreakInterceptorTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypedBreakInterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypingHooksTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/typinghooks/HtmlTypingHooksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.editor/test/unit/src/org/netbeans/modules/html/editor/xhtml/XhtmlElLexerTest.java
+++ b/html.editor/test/unit/src/org/netbeans/modules/html/editor/xhtml/XhtmlElLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/src/org/netbeans/api/html/lexer/HTMLTokenId.java
+++ b/html.lexer/src/org/netbeans/api/html/lexer/HTMLTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/src/org/netbeans/api/html/lexer/HtmlLexerPlugin.java
+++ b/html.lexer/src/org/netbeans/api/html/lexer/HtmlLexerPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/src/org/netbeans/lib/html/lexer/HtmlElements.java
+++ b/html.lexer/src/org/netbeans/lib/html/lexer/HtmlElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/src/org/netbeans/lib/html/lexer/HtmlLexer.java
+++ b/html.lexer/src/org/netbeans/lib/html/lexer/HtmlLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/src/org/netbeans/lib/html/lexer/HtmlPlugins.java
+++ b/html.lexer/src/org/netbeans/lib/html/lexer/HtmlPlugins.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/test/unit/src/org/netbeans/api/html/lexer/HtmlLexerPluginTest.java
+++ b/html.lexer/test/unit/src/org/netbeans/api/html/lexer/HtmlLexerPluginTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLanguageTest.java
+++ b/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLanguageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLexerBatchTest.java
+++ b/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLexerBatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLexerRandomTest.java
+++ b/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLexerRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLexerTest.java
+++ b/html.lexer/test/unit/src/org/netbeans/lib/html/lexer/HtmlLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/ElementsFactory.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/ElementsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/Html5Model.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/Html5Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/Html5Parser.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/Html5Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/HtmlDocumentation.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/HtmlDocumentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/ParseTreeBuilder.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/ParseTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/Util.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/Attribute.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/Constants.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/ContentType.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/ContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/EDHtmlTag.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/EDHtmlTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/EDHtmlTagAttribute.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/EDHtmlTagAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/ElementDescriptor.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/ElementDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/ElementDescriptorRules.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/ElementDescriptorRules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/FormAssociatedElementsCategory.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/FormAssociatedElementsCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/HtmlTagProvider.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/HtmlTagProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/Link.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/Link.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/NamedCharacterReference.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/NamedCharacterReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/src/org/netbeans/modules/html/parser/model/UnknownHtmlTag.java
+++ b/html.parser/src/org/netbeans/modules/html/parser/model/UnknownHtmlTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/DocumentationTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/DocumentationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/ElementsFactoryTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/ElementsFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/Html5ParserTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/Html5ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/MaskingChSReaderTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/MaskingChSReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/SimpleMaskingChSReaderTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/SimpleMaskingChSReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/AttributeTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/AttributeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/ElementDescriptorRulesTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/ElementDescriptorRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/ElementDescriptorTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/ElementDescriptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/GenerateElementsIndex.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/GenerateElementsIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/HtmlTagProviderTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/HtmlTagProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/NamedCharacterReferenceTest.java
+++ b/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/NamedCharacterReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/src/org/netbeans/modules/html/validation/CharacterHandlerReader.java
+++ b/html.validation/src/org/netbeans/modules/html/validation/CharacterHandlerReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/src/org/netbeans/modules/html/validation/LinesMapper.java
+++ b/html.validation/src/org/netbeans/modules/html/validation/LinesMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/src/org/netbeans/modules/html/validation/NbMessageEmitter.java
+++ b/html.validation/src/org/netbeans/modules/html/validation/NbMessageEmitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/src/org/netbeans/modules/html/validation/NbValidationTransaction.java
+++ b/html.validation/src/org/netbeans/modules/html/validation/NbValidationTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/src/org/netbeans/modules/html/validation/ProblemDescriptionFilter.java
+++ b/html.validation/src/org/netbeans/modules/html/validation/ProblemDescriptionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/src/org/netbeans/modules/html/validation/ProblemsHandler.java
+++ b/html.validation/src/org/netbeans/modules/html/validation/ProblemsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/src/org/netbeans/modules/html/validation/ValidatorImpl.java
+++ b/html.validation/src/org/netbeans/modules/html/validation/ValidatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/test/unit/src/org/netbeans/modules/html/validation/HtmlSpecTest.java
+++ b/html.validation/test/unit/src/org/netbeans/modules/html/validation/HtmlSpecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/test/unit/src/org/netbeans/modules/html/validation/LibrariesTest.java
+++ b/html.validation/test/unit/src/org/netbeans/modules/html/validation/LibrariesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html.validation/test/unit/src/org/netbeans/modules/html/validation/LinesMapperTest.java
+++ b/html.validation/test/unit/src/org/netbeans/modules/html/validation/LinesMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/HtmlDataObject.java
+++ b/html/src/org/netbeans/modules/html/HtmlDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/HtmlLoader.java
+++ b/html/src/org/netbeans/modules/html/HtmlLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/HtmlLoaderBeanInfo.java
+++ b/html/src/org/netbeans/modules/html/HtmlLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/XhtmlLoader.java
+++ b/html/src/org/netbeans/modules/html/XhtmlLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/api/HtmlDataNode.java
+++ b/html/src/org/netbeans/modules/html/api/HtmlDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/catalog/HtmlCatalog.java
+++ b/html/src/org/netbeans/modules/html/catalog/HtmlCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/package-info.java
+++ b/html/src/org/netbeans/modules/html/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/BrowseFolders.java
+++ b/html/src/org/netbeans/modules/html/palette/BrowseFolders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/HtmlEditorDropDefault.java
+++ b/html/src/org/netbeans/modules/html/palette/HtmlEditorDropDefault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/HtmlPaletteActions.java
+++ b/html/src/org/netbeans/modules/html/palette/HtmlPaletteActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/HtmlPaletteCustomizerAction.java
+++ b/html/src/org/netbeans/modules/html/palette/HtmlPaletteCustomizerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/HtmlPaletteFactory.java
+++ b/html/src/org/netbeans/modules/html/palette/HtmlPaletteFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/HtmlPaletteUtilities.java
+++ b/html/src/org/netbeans/modules/html/palette/HtmlPaletteUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/api/HtmlPaletteFolderProvider.java
+++ b/html/src/org/netbeans/modules/html/palette/api/HtmlPaletteFolderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/A.java
+++ b/html/src/org/netbeans/modules/html/palette/items/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/ACustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/ACustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/BUTTON.java
+++ b/html/src/org/netbeans/modules/html/palette/items/BUTTON.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/BUTTONCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/BUTTONCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/CHECKBOX.java
+++ b/html/src/org/netbeans/modules/html/palette/items/CHECKBOX.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/CHECKBOXCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/CHECKBOXCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/FILESEL.java
+++ b/html/src/org/netbeans/modules/html/palette/items/FILESEL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/FILESELCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/FILESELCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/FORM.java
+++ b/html/src/org/netbeans/modules/html/palette/items/FORM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/FORMCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/FORMCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/IMG.java
+++ b/html/src/org/netbeans/modules/html/palette/items/IMG.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/IMGCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/IMGCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/INPUT.java
+++ b/html/src/org/netbeans/modules/html/palette/items/INPUT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/INPUTCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/INPUTCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/META.java
+++ b/html/src/org/netbeans/modules/html/palette/items/META.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/METACustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/METACustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/OL.java
+++ b/html/src/org/netbeans/modules/html/palette/items/OL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/OLCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/OLCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/RADIO.java
+++ b/html/src/org/netbeans/modules/html/palette/items/RADIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/RADIOCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/RADIOCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/SELECT.java
+++ b/html/src/org/netbeans/modules/html/palette/items/SELECT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/SELECTCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/SELECTCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/TABLE.java
+++ b/html/src/org/netbeans/modules/html/palette/items/TABLE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/TABLECustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/TABLECustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/TEXTAREA.java
+++ b/html/src/org/netbeans/modules/html/palette/items/TEXTAREA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/TEXTAREACustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/TEXTAREACustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/UL.java
+++ b/html/src/org/netbeans/modules/html/palette/items/UL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/src/org/netbeans/modules/html/palette/items/ULCustomizer.java
+++ b/html/src/org/netbeans/modules/html/palette/items/ULCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/test/unit/src/org/netbeans/modules/html/EncodingTest.java
+++ b/html/test/unit/src/org/netbeans/modules/html/EncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/test/unit/src/org/netbeans/modules/html/HtmlDataObjectTest.java
+++ b/html/test/unit/src/org/netbeans/modules/html/HtmlDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/html/test/unit/src/org/netbeans/modules/html/Utils.java
+++ b/html/test/unit/src/org/netbeans/modules/html/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/GrantAccessEvent.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/GrantAccessEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/GrantAccessListener.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/GrantAccessListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/GrantAccessPanel.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/GrantAccessPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/HostPropertyCustomEditor.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/HostPropertyCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/HostPropertyEditor.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/HostPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/HttpServerModule.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/HttpServerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/HttpServerSettings.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/HttpServerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/HttpServerURLMapper.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/HttpServerURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/NbBaseServlet.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/NbBaseServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/NbLoaderInterceptor.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/NbLoaderInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/NbServletsInterceptor.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/NbServletsInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/NotFoundServlet.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/NotFoundServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/src/org/netbeans/modules/httpserver/WrapperServlet.java
+++ b/httpserver/src/org/netbeans/modules/httpserver/WrapperServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/test/qa-functional/src/org/netbeans/test/gui/httpserver/Module.java
+++ b/httpserver/test/qa-functional/src/org/netbeans/test/gui/httpserver/Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/test/unit/src/org/netbeans/modules/httpserver/ServletExecutionTest.java
+++ b/httpserver/test/unit/src/org/netbeans/modules/httpserver/ServletExecutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/test/unit/src/org/netbeans/modules/httpserver/URLMapperTest.java
+++ b/httpserver/test/unit/src/org/netbeans/modules/httpserver/URLMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/test/unit/src/org/netbeans/modules/servlettest/ModuleServlet.java
+++ b/httpserver/test/unit/src/org/netbeans/modules/servlettest/ModuleServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/httpserver/test/unit/testfs/org/netbeans/test/httpserver/testResource.txt
+++ b/httpserver/test/unit/testfs/org/netbeans/test/httpserver/testResource.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ant/src/org/netbeans/modules/hudson/ant/AntBasedJobCreator.java
+++ b/hudson.ant/src/org/netbeans/modules/hudson/ant/AntBasedJobCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ant/src/org/netbeans/modules/hudson/ant/JobCreator.java
+++ b/hudson.ant/src/org/netbeans/modules/hudson/ant/JobCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ant/src/org/netbeans/modules/hudson/ant/ProjectTypes.java
+++ b/hudson.ant/src/org/netbeans/modules/hudson/ant/ProjectTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.git/src/org/netbeans/modules/hudson/git/HudsonGitSCM.java
+++ b/hudson.git/src/org/netbeans/modules/hudson/git/HudsonGitSCM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.git/test/unit/src/org/netbeans/modules/hudson/git/HudsonGitSCMTest.java
+++ b/hudson.git/test/unit/src/org/netbeans/modules/hudson/git/HudsonGitSCMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.maven/src/org/netbeans/modules/hudson/maven/HpiPluginWarning.java
+++ b/hudson.maven/src/org/netbeans/modules/hudson/maven/HpiPluginWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.maven/src/org/netbeans/modules/hudson/maven/HudsonProviderImpl.java
+++ b/hudson.maven/src/org/netbeans/modules/hudson/maven/HudsonProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.maven/src/org/netbeans/modules/hudson/maven/JobCreator.java
+++ b/hudson.maven/src/org/netbeans/modules/hudson/maven/JobCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.maven/test/unit/src/org/netbeans/modules/hudson/maven/HudsonProviderImplTest.java
+++ b/hudson.maven/test/unit/src/org/netbeans/modules/hudson/maven/HudsonProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/HudsonMercurialSCM.java
+++ b/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/HudsonMercurialSCM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/MercurialHyperlink.java
+++ b/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/MercurialHyperlink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.mercurial/test/unit/src/org/netbeans/modules/hudson/mercurial/HudsonMercurialSCMTest.java
+++ b/hudson.mercurial/test/unit/src/org/netbeans/modules/hudson/mercurial/HudsonMercurialSCMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.subversion/src/org/netbeans/modules/hudson/subversion/HudsonSubversionSCM.java
+++ b/hudson.subversion/src/org/netbeans/modules/hudson/subversion/HudsonSubversionSCM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.subversion/src/org/netbeans/modules/hudson/subversion/SubversionHyperlink.java
+++ b/hudson.subversion/src/org/netbeans/modules/hudson/subversion/SubversionHyperlink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.subversion/src/org/netbeans/modules/hudson/subversion/SvnUtils.java
+++ b/hudson.subversion/src/org/netbeans/modules/hudson/subversion/SvnUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.subversion/test/unit/src/org/netbeans/modules/hudson/subversion/HudsonSubversionSCMTest.java
+++ b/hudson.subversion/test/unit/src/org/netbeans/modules/hudson/subversion/HudsonSubversionSCMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.tasklist/src/org/netbeans/modules/hudson/tasklist/AnalysisPluginImpl.java
+++ b/hudson.tasklist/src/org/netbeans/modules/hudson/tasklist/AnalysisPluginImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.tasklist/src/org/netbeans/modules/hudson/tasklist/HudsonScanner.java
+++ b/hudson.tasklist/src/org/netbeans/modules/hudson/tasklist/HudsonScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.tasklist/src/org/netbeans/modules/hudson/tasklist/JobScanner.java
+++ b/hudson.tasklist/src/org/netbeans/modules/hudson/tasklist/JobScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.tasklist/test/unit/src/org/netbeans/modules/hudson/tasklist/AnalysisPluginImplTest.java
+++ b/hudson.tasklist/test/unit/src/org/netbeans/modules/hudson/tasklist/AnalysisPluginImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/APITokenConnectionAuthenticator.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/APITokenConnectionAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/FormLogin.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/FormLogin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/AddInstanceAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/AddInstanceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/AddTestInstanceAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/AddTestInstanceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/CreateJob.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/CreateJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/CreateJobPanel.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/CreateJobPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/Hyperlinker.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/Hyperlinker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/LogInAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/LogInAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/OpenUrlAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/OpenUrlAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/PersistInstanceAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/PersistInstanceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ProjectAssociationAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ProjectAssociationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ProjectRenderer.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ProjectRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ShowBuildConsole.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ShowBuildConsole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ShowChanges.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ShowChanges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ShowFailures.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ShowFailures.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/StartJobAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/StartJobAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/SynchronizeAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/SynchronizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ViewConfigAction.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ViewConfigAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ViewSwitcher.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ViewSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/api/HudsonSCMHelper.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/api/HudsonSCMHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/api/UI.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/api/UI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/HudsonConsoleDisplayer.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/HudsonConsoleDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/HudsonFailureDisplayer.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/HudsonFailureDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/HudsonLoggerHelper.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/HudsonLoggerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/JavaHudsonLogger.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/JavaHudsonLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/MetadataProjectHudsonProvider.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/MetadataProjectHudsonProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/OpenProjectstHudsonManagerAgent.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/OpenProjectstHudsonManagerAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/PlainLogger.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/PlainLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/SearchProviderImpl.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/SearchProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/UIExtensionImpl.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/UIExtensionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonArtifactsNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonArtifactsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonFolderNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonFolderNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonInstanceNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonInstanceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonJobBuildNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonJobBuildNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonJobNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonJobNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonMavenModuleBuildNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonMavenModuleBuildNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonRootNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonWorkspaceNode.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/nodes/HudsonWorkspaceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/notification/ProblemNotification.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/notification/ProblemNotification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/notification/ProblemNotificationController.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/notification/ProblemNotificationController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/notification/ProblemPanel.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/notification/ProblemPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonJobCreatorFactory.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonJobCreatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonProvider.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/util/UsageLogging.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/util/UsageLogging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/wizard/InstanceDialog.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/wizard/InstanceDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/src/org/netbeans/modules/hudson/ui/wizard/InstancePropertiesVisual.java
+++ b/hudson.ui/src/org/netbeans/modules/hudson/ui/wizard/InstancePropertiesVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/test/unit/src/org/netbeans/modules/hudson/ui/actions/CreateJobTest.java
+++ b/hudson.ui/test/unit/src/org/netbeans/modules/hudson/ui/actions/CreateJobTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/test/unit/src/org/netbeans/modules/hudson/ui/impl/PlainLoggerTest.java
+++ b/hudson.ui/test/unit/src/org/netbeans/modules/hudson/ui/impl/PlainLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson.ui/test/unit/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonProviderTest.java
+++ b/hudson.ui/test/unit/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/Installer.java
+++ b/hudson/src/org/netbeans/modules/hudson/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/ConnectionBuilder.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/ConnectionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonChangeAdapter.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonChangeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonChangeListener.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonFolder.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonInstance.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonJob.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonJobBuild.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonJobBuild.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonManager.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonMavenModuleBuild.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonMavenModuleBuild.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonVersion.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/HudsonView.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/HudsonView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/Utilities.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/ui/ConsoleDataDisplayer.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/ui/ConsoleDataDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/ui/FailureDataDisplayer.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/ui/FailureDataDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/api/ui/OpenableInBrowser.java
+++ b/hudson/src/org/netbeans/modules/hudson/api/ui/OpenableInBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/constants/HudsonInstanceConstants.java
+++ b/hudson/src/org/netbeans/modules/hudson/constants/HudsonInstanceConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/constants/HudsonJobChangeFileConstants.java
+++ b/hudson/src/org/netbeans/modules/hudson/constants/HudsonJobChangeFileConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/constants/HudsonJobChangeItemConstants.java
+++ b/hudson/src/org/netbeans/modules/hudson/constants/HudsonJobChangeItemConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/constants/HudsonJobConstants.java
+++ b/hudson/src/org/netbeans/modules/hudson/constants/HudsonJobConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/constants/HudsonViewConstants.java
+++ b/hudson/src/org/netbeans/modules/hudson/constants/HudsonViewConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/constants/HudsonXmlApiConstants.java
+++ b/hudson/src/org/netbeans/modules/hudson/constants/HudsonXmlApiConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonConnector.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonConsoleDataProvider.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonConsoleDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonFailureDataProvider.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonFailureDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonFolderImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonFolderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonInstanceImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonInstanceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonInstanceProperties.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonInstanceProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonJobBuildImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonJobBuildImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonJobImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonJobImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonManagerImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonRemoteFileSystem.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonRemoteFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/HudsonViewImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/HudsonViewImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/impl/ServletConnectionAuthenticator.java
+++ b/hudson/src/org/netbeans/modules/hudson/impl/ServletConnectionAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/BuilderConnector.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/BuilderConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/ConnectionAuthenticator.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/ConnectionAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/ConsoleDataDisplayerImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/ConsoleDataDisplayerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/FailureDataDisplayerImpl.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/FailureDataDisplayerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/HudsonJobChangeItem.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/HudsonJobChangeItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/HudsonLogger.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/HudsonLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/HudsonManagerAgent.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/HudsonManagerAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/HudsonSCM.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/HudsonSCM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/PasswordAuthorizer.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/PasswordAuthorizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/RemoteFileSystem.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/RemoteFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/spi/UIExtension.java
+++ b/hudson/src/org/netbeans/modules/hudson/spi/UIExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/src/org/netbeans/modules/hudson/util/HudsonPropertiesSupport.java
+++ b/hudson/src/org/netbeans/modules/hudson/util/HudsonPropertiesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/test/unit/src/org/netbeans/modules/hudson/api/HudsonJobTest.java
+++ b/hudson/test/unit/src/org/netbeans/modules/hudson/api/HudsonJobTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/test/unit/src/org/netbeans/modules/hudson/api/UtilitiesTest.java
+++ b/hudson/test/unit/src/org/netbeans/modules/hudson/api/UtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonInstanceImplTest.java
+++ b/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonInstanceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonInstancePropertiesTest.java
+++ b/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonInstancePropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonJobBuildImplTest.java
+++ b/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonJobBuildImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonManagerImplTest.java
+++ b/hudson/test/unit/src/org/netbeans/modules/hudson/impl/HudsonManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nInteger.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nInteger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nIntegerEditor.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nIntegerEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nMnemonic.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nMnemonic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nMnemonicEditor.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nMnemonicEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nString.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nStringEditor.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nStringEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nSupport.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/FormI18nSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/I18nFormCrossModule.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/I18nFormCrossModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/src/org/netbeans/modules/i18n/form/I18nServiceImpl.java
+++ b/i18n.form/src/org/netbeans/modules/i18n/form/I18nServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n.form/test/unit/src/org/netbeans/modules/i18n/form/FormI18nIntegerEditorTest.java
+++ b/i18n.form/test/unit/src/org/netbeans/modules/i18n/form/FormI18nIntegerEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/EmptyPropertyPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/EmptyPropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/FactoryRegistry.java
+++ b/i18n/src/org/netbeans/modules/i18n/FactoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/FileSelector.java
+++ b/i18n/src/org/netbeans/modules/i18n/FileSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/FilteredNode.java
+++ b/i18n/src/org/netbeans/modules/i18n/FilteredNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/HardCodedString.java
+++ b/i18n/src/org/netbeans/modules/i18n/HardCodedString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/HelpStringCustomEditor.java
+++ b/i18n/src/org/netbeans/modules/i18n/HelpStringCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/I18nAction.java
+++ b/i18n/src/org/netbeans/modules/i18n/I18nAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/I18nManager.java
+++ b/i18n/src/org/netbeans/modules/i18n/I18nManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/I18nOptions.java
+++ b/i18n/src/org/netbeans/modules/i18n/I18nOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/I18nPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/I18nPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/I18nString.java
+++ b/i18n/src/org/netbeans/modules/i18n/I18nString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/I18nSupport.java
+++ b/i18n/src/org/netbeans/modules/i18n/I18nSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/I18nUtil.java
+++ b/i18n/src/org/netbeans/modules/i18n/I18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/InfoPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/InfoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/InsertI18nStringAction.java
+++ b/i18n/src/org/netbeans/modules/i18n/InsertI18nStringAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/LocalePropertyEditor.java
+++ b/i18n/src/org/netbeans/modules/i18n/LocalePropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/PropertyPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/PropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/ResourceHolder.java
+++ b/i18n/src/org/netbeans/modules/i18n/ResourceHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/SelectorUtils.java
+++ b/i18n/src/org/netbeans/modules/i18n/SelectorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/Util.java
+++ b/i18n/src/org/netbeans/modules/i18n/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/JavaI18nFinder.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/JavaI18nFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/JavaI18nString.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/JavaI18nString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/JavaI18nSupport.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/JavaI18nSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/JavaPropertyPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/JavaPropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/JavaReplacePanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/JavaReplacePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/JavaResourceHolder.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/JavaResourceHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/ParamsPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/ParamsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/java/Util.java
+++ b/i18n/src/org/netbeans/modules/i18n/java/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/jsp/JspI18nSupport.java
+++ b/i18n/src/org/netbeans/modules/i18n/jsp/JspI18nSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/regexp/Generator.java
+++ b/i18n/src/org/netbeans/modules/i18n/regexp/Generator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/regexp/ParseException.java
+++ b/i18n/src/org/netbeans/modules/i18n/regexp/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/regexp/Parser.java
+++ b/i18n/src/org/netbeans/modules/i18n/regexp/Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/regexp/Translator.java
+++ b/i18n/src/org/netbeans/modules/i18n/regexp/Translator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/regexp/TreeNode.java
+++ b/i18n/src/org/netbeans/modules/i18n/regexp/TreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/regexp/TreeNodeRoot.java
+++ b/i18n/src/org/netbeans/modules/i18n/regexp/TreeNodeRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/AdditionalWizardPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/AdditionalWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/HardStringWizardPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/HardStringWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/I18nTestWizardAction.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/I18nTestWizardAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/I18nWizardAction.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/I18nWizardAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/I18nWizardDescriptor.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/I18nWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/ProgressWizardPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/ProgressWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/ResourceWizardPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/ResourceWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/SourceData.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/SourceData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/SourceWizardPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/SourceWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/TestStringWizardPanel.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/TestStringWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/src/org/netbeans/modules/i18n/wizard/Util.java
+++ b/i18n/src/org/netbeans/modules/i18n/wizard/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/qa-functional/data/projects/ProjectI18n/src/projecti18n/Internationalize.java
+++ b/i18n/test/qa-functional/data/projects/ProjectI18n/src/projecti18n/Internationalize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/qa-functional/data/projects/ProjectI18n/src/projecti18n/Main.java
+++ b/i18n/test/qa-functional/data/projects/ProjectI18n/src/projecti18n/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/qa-functional/src/lib/InternationalizationTestCase.java
+++ b/i18n/test/qa-functional/src/lib/InternationalizationTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/qa-functional/src/org/netbeans/i18n/jelly/InternationalizeOperator.java
+++ b/i18n/test/qa-functional/src/org/netbeans/i18n/jelly/InternationalizeOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/qa-functional/src/org/netbeans/i18n/jelly/NewBundleOperator.java
+++ b/i18n/test/qa-functional/src/org/netbeans/i18n/jelly/NewBundleOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/qa-functional/src/org/netbeans/i18n/test/LineDiff.java
+++ b/i18n/test/qa-functional/src/org/netbeans/i18n/test/LineDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/qa-functional/src/org/netbeans/i18n/test/internationalize/Internationalize.java
+++ b/i18n/test/qa-functional/src/org/netbeans/i18n/test/internationalize/Internationalize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/unit/src/org/netbeans/modules/i18n/java/JavaI18nFinderTest.java
+++ b/i18n/test/unit/src/org/netbeans/modules/i18n/java/JavaI18nFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/unit/src/org/netbeans/modules/i18n/java/JavaI18nSupportTest.java
+++ b/i18n/test/unit/src/org/netbeans/modules/i18n/java/JavaI18nSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/i18n/test/unit/src/org/netbeans/modules/i18n/java/resources/JFrame.txt
+++ b/i18n/test/unit/src/org/netbeans/modules/i18n/java/resources/JFrame.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.branding/release-toplevel/netbeans.css
+++ b/ide.branding/release-toplevel/netbeans.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.branding/test/unit/src/org/netbeans/modules/ide/branding/SaveIsAsynchronousTest.java
+++ b/ide.branding/test/unit/src/org/netbeans/modules/ide/branding/SaveIsAsynchronousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/src/org/netbeans/modules/ide/kit/PackagePrivate.java
+++ b/ide.kit/src/org/netbeans/modules/ide/kit/PackagePrivate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/coverage-manual/selectjars/src/selectjars/SelectJars.java
+++ b/ide.kit/test/coverage-manual/selectjars/src/selectjars/SelectJars.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
+++ b/ide.kit/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
+++ b/ide.kit/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/data/permanentUI/utils/MenuChecker.java
+++ b/ide.kit/test/qa-functional/data/permanentUI/utils/MenuChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/data/permanentUI/utils/NbMenuItem.java
+++ b/ide.kit/test/qa-functional/data/permanentUI/utils/NbMenuItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/data/permanentUI/utils/ProjectContext.java
+++ b/ide.kit/test/qa-functional/data/permanentUI/utils/ProjectContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/data/permanentUI/utils/Utilities.java
+++ b/ide.kit/test/qa-functional/data/permanentUI/utils/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/PackagePrivateTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/PackagePrivateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/editor/EditorSanityTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/editor/EditorSanityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/AUTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/AUTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandler.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandlerSingleton.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandlerSingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesViolationException.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesViolationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/CountingSecurityManager.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/CountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/GeneralSanityTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/GeneralSanityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/InstallationCompletenessTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/InstallationCompletenessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/PassThroughProxyHandler.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/PassThroughProxyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/ReadAccessTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/ReadAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/ThreadsTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/ThreadsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/VCSClassLoadingTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/VCSClassLoadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/ide/WhitelistTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/ide/WhitelistTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/MainMenuJavaTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/MainMenuJavaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/MainMenuTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/MainMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/MainMenuTestCase.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/MainMenuTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/NewProjectTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/NewProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/OptionsTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/OptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/PermUITestCase.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/PermUITestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/TeamMenuVCSActivatedTest.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/TeamMenuVCSActivatedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/MenuChecker.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/MenuChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/NbMenuItem.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/NbMenuItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/ProjectContext.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/ProjectContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/Utilities.java
+++ b/ide.kit/test/qa-functional/src/org/netbeans/test/permanentUI/utils/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/macosx/NetBeansLauncher/NBExecutor.h
+++ b/ide/launcher/macosx/NetBeansLauncher/NBExecutor.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/macosx/NetBeansLauncher/NBExecutor.m
+++ b/ide/launcher/macosx/NetBeansLauncher/NBExecutor.m
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/macosx/NetBeansLauncher/NBPreferences.h
+++ b/ide/launcher/macosx/NetBeansLauncher/NBPreferences.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/macosx/NetBeansLauncher/NBPreferences.m
+++ b/ide/launcher/macosx/NetBeansLauncher/NBPreferences.m
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/macosx/NetBeansLauncher/main.m
+++ b/ide/launcher/macosx/NetBeansLauncher/main.m
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/windows/cmdargs.h
+++ b/ide/launcher/windows/cmdargs.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/windows/nblauncher.cpp
+++ b/ide/launcher/windows/nblauncher.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/windows/nblauncher.h
+++ b/ide/launcher/windows/nblauncher.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/windows/netbeans.cpp
+++ b/ide/launcher/windows/netbeans.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/windows/netbeans.rc
+++ b/ide/launcher/windows/netbeans.rc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/windows/version.h
+++ b/ide/launcher/windows/version.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/launcher/windows/version.rc
+++ b/ide/launcher/windows/version.rc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/ArgsHandler.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/ArgsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/BrowseNetBeansDialog.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/BrowseNetBeansDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/FileLogHandler.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/FileLogHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/NBInstallation.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/NBInstallation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/ProjectType.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/ProjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/ProxySettingsDialog.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/ProxySettingsDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/SaveProjectDialog.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/SaveProjectDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/SavedProjects.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/SavedProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/UserdirScanner.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/UserdirScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/Utils.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/src/org/netbeans/projectopener/WSProjectOpener.java
+++ b/ide/projectopener/src/org/netbeans/projectopener/WSProjectOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ide/projectopener/test/org/netbeans/projectopener/ArgsHandlerTest.java
+++ b/ide/projectopener/test/org/netbeans/projectopener/ArgsHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/CustomZoomAction.java
+++ b/image/src/org/netbeans/modules/image/CustomZoomAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/CustomZoomPanel.java
+++ b/image/src/org/netbeans/modules/image/CustomZoomPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ImageDataLoader.java
+++ b/image/src/org/netbeans/modules/image/ImageDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ImageDataLoaderBeanInfo.java
+++ b/image/src/org/netbeans/modules/image/ImageDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ImageDataObject.java
+++ b/image/src/org/netbeans/modules/image/ImageDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ImageOpenSupport.java
+++ b/image/src/org/netbeans/modules/image/ImageOpenSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ImagePrintSupport.java
+++ b/image/src/org/netbeans/modules/image/ImagePrintSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ImageViewer.java
+++ b/image/src/org/netbeans/modules/image/ImageViewer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/NBImageIcon.java
+++ b/image/src/org/netbeans/modules/image/NBImageIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ZoomInAction.java
+++ b/image/src/org/netbeans/modules/image/ZoomInAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/ZoomOutAction.java
+++ b/image/src/org/netbeans/modules/image/ZoomOutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/action/ExternalEditAction.java
+++ b/image/src/org/netbeans/modules/image/action/ExternalEditAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/navigation/ImageNavigatorPanel.java
+++ b/image/src/org/netbeans/modules/image/navigation/ImageNavigatorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/image/src/org/netbeans/modules/image/navigation/ImagePreviewPanel.java
+++ b/image/src/org/netbeans/modules/image/navigation/ImagePreviewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/SourceGroups.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/SourceGroups.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/Strings.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/Strings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/classpath/ContainerClassPathModifier.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/classpath/ContainerClassPathModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/GenerationUtils.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/GenerationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/JavaIdentifiers.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/JavaIdentifiers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/SourceUtils.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/SourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodCustomizer.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodCustomizerFactory.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodCustomizerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModel.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/progress/ProgressSupport.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/progress/ProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/wizard/DelegatingWizardDescriptorPanel.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/wizard/DelegatingWizardDescriptorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/wizard/Wizards.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/wizard/Wizards.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ExceptionsPanel.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ExceptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/MethodCustomizerPanel.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/MethodCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ParametersPanel.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ParametersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ReturnTypeUIHelper.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ReturnTypeUIHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ValidatingPropertyChangeListener.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/support/java/method/ValidatingPropertyChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/utilities/ProgressPanel.java
+++ b/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/utilities/ProgressPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/data/JavaApp/src/Foo.java
+++ b/j2ee.core.utilities/test/unit/data/JavaApp/src/Foo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/data/JavaApp/src/foo/bar/baz/FooBar.java
+++ b/j2ee.core.utilities/test/unit/data/JavaApp/src/foo/bar/baz/FooBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/data/JavaApp/src/javaapp/Main.java
+++ b/j2ee.core.utilities/test/unit/data/JavaApp/src/javaapp/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/data/JavaApp/test/foo/bar/baz/FooBarTest.java
+++ b/j2ee.core.utilities/test/unit/data/JavaApp/test/foo/bar/baz/FooBarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/SourceGroupsTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/SourceGroupsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/StringsTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/StringsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/ClassPathProviderImpl.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/ClassPathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/FakeJavaDataLoaderPool.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/FakeJavaDataLoaderPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/GenerationUtilsTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/GenerationUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/JavaIdentifiersTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/JavaIdentifiersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/SourceLevelQueryImpl.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/SourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/SourceUtilsTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/SourceUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/TestUtilities.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupportTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/method/RepositoryImpl.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/method/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/progress/ProgressSupportTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/progress/ProgressSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/support/java/method/ParametersPanelTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/support/java/method/ParametersPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/support/java/method/ValidatingPropertyChangeListenerTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/support/java/method/ValidatingPropertyChangeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/utilities/ProgressPanelTest.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/utilities/ProgressPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.core.utilities/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
+++ b/j2ee.core.utilities/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/EntityAnnotationReference.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/EntityAnnotationReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/EntityAssociationResolver.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/EntityAssociationResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/JPARefactoringFactory.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/JPARefactoringFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/PersistenceXmlRefactoring.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/PersistenceXmlRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/RefactoringUtil.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/RefactoringUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/RelationshipMappingRefactoringFactory.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/RelationshipMappingRefactoringFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/moveclass/PersistenceXmlMoveClass.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/moveclass/PersistenceXmlMoveClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/EntityRename.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/EntityRename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/PersistenceXmlPackageRename.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/PersistenceXmlPackageRename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/PersistenceXmlRename.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/PersistenceXmlRename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/RelationshipMappingRename.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/RelationshipMappingRename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/safedelete/PersistenceXmlSafeDelete.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/safedelete/PersistenceXmlSafeDelete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/util/PositionBoundsResolver.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/util/PositionBoundsResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/whereused/PersistenceXmlWhereUsed.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/whereused/PersistenceXmlWhereUsed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/whereused/RelationshipMappingWhereUsed.java
+++ b/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/whereused/RelationshipMappingWhereUsed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/data/entities/Customer.java
+++ b/j2ee.jpa.refactoring/test/unit/data/entities/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/data/entities/Department.java
+++ b/j2ee.jpa.refactoring/test/unit/data/entities/Department.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/data/entities/Employee.java
+++ b/j2ee.jpa.refactoring/test/unit/data/entities/Employee.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/data/entities/Group.java
+++ b/j2ee.jpa.refactoring/test/unit/data/entities/Group.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/data/entities/Order.java
+++ b/j2ee.jpa.refactoring/test/unit/data/entities/Order.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/data/entities/User.java
+++ b/j2ee.jpa.refactoring/test/unit/data/entities/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/ClassPathProviderImpl.java
+++ b/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/ClassPathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/EntityAssociationResolverTest.java
+++ b/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/EntityAssociationResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/FakeJavaDataLoaderPool.java
+++ b/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/FakeJavaDataLoaderPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/RefactoringUtilTest.java
+++ b/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/RefactoringUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/SourceTestSupport.java
+++ b/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/SourceTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
+++ b/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/AccessType.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/AccessType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/AttributeWrapper.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/AttributeWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/JPAAnnotations.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/JPAAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/JPAHelper.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/JPAHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/ModelUtils.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/model/ModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/CancelListener.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/CancelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAEntityAttributeCheck.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAEntityAttributeCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAProblemContext.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAProblemContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAProblemFinder.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAProblemFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAProblemFinderFactory.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAProblemFinderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAVerificationTaskProvider.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/JPAVerificationTaskProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/api/JPAVerificationWarningIds.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/api/JPAVerificationWarningIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/api/VerificationWarningOverrider.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/api/VerificationWarningOverrider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/common/ProblemContext.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/common/ProblemContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/common/Utilities.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/common/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/AbstractCreateAnnotationHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/AbstractCreateAnnotationHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/AbstractCreateRelationshipHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/AbstractCreateRelationshipHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateDefaultConstructor.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateDefaultConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateId.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateManyToManyRelationshipHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateManyToManyRelationshipHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateManyToOneRelationshipHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateManyToOneRelationshipHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateOneToManyRelationshipHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateOneToManyRelationshipHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateOneToOneRelationshipHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateOneToOneRelationshipHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreatePersistenceUnit.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreatePersistenceUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateRelationshipPanel.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateRelationshipPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateTemporalAnnotationHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateTemporalAnnotationHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateUnidirManyToOneRelationship.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateUnidirManyToOneRelationship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateUnidirOneToManyRelationshipHint.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateUnidirOneToManyRelationshipHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateUnidirOneToOneRelationship.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateUnidirOneToOneRelationship.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/ImplementSerializable.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/ImplementSerializable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/MakeClassPublic.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/MakeClassPublic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/PickOrCreateFieldPanel.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/PickOrCreateFieldPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/RemoveFinalModifier.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/RemoveFinalModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/UnifyAccessType.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/UnifyAccessType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/GeneratedValueIsId.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/GeneratedValueIsId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/MVRelationshipForEntityTypeAttrDefined.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/MVRelationshipForEntityTypeAttrDefined.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/RelationshipForEntityTypeAttrDefined.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/RelationshipForEntityTypeAttrDefined.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/TemporalFieldsAnnotated.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/TemporalFieldsAnnotated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidBasicType.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidBasicType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidColumnName.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidColumnName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidModifiers.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidModifiers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidVersionType.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/attribute/ValidVersionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/ConsistentAccessType.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/ConsistentAccessType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/HasNoArgConstructor.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/HasNoArgConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/IdClassOverridesEqualsAndHashCode.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/IdClassOverridesEqualsAndHashCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/IdDefinedInHierarchy.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/IdDefinedInHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/JPAAnnotsOnlyOnAccesor.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/JPAAnnotsOnlyOnAccesor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/JPQLValidation.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/JPQLValidation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/LegalCombinationOfAnnotations.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/LegalCombinationOfAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/NoIdClassOnEntitySubclass.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/NoIdClassOnEntitySubclass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/NonFinalClass.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/NonFinalClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/OnlyEntityOrMappedSuperclassCanUseIdClass.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/OnlyEntityOrMappedSuperclassCanUseIdClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/PersistenceUnitPresent.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/PersistenceUnitPresent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/PublicClass.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/PublicClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/QueriesProperlyDefined.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/QueriesProperlyDefined.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/SerializableClass.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/SerializableClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/TopLevelClass.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/TopLevelClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/UniqueEntityName.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/UniqueEntityName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/ValidAttributes.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/ValidAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/ValidPrimaryTableName.java
+++ b/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/rules/entity/ValidPrimaryTableName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationHandler.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationHelper.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationModelHelper.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationModelHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationScanner.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/JavaContextListener.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/JavaContextListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/ObjectProvider.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/ObjectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObject.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManager.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/AnnotationParser.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/AnnotationParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/AnnotationValueHandler.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/AnnotationValueHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ArrayValueHandler.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ArrayValueHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/DefaultProvider.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/DefaultProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ParseResult.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ParseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ValueProvider.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ValueProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/support/PersistentObjectList.java
+++ b/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/support/PersistentObjectList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationModelHelperTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationModelHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationScannerTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/ClassIndexAdapter.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/ClassIndexAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/InterruptibleObjectProviderImpl.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/InterruptibleObjectProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerEventTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerInterruptedTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerInterruptedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerMultipleTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerMultipleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/PersistentObjectManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/Table.javax
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/Table.javax
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/AnnotationParserTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/AnnotationParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ParseResultTest.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/parser/ParseResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/JavaSourceTestCase.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/JavaSourceTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/PersistenceTestCase.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/PersistenceTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/SimpleClassPathProvider.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/SimpleClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/TestUtilities.java
+++ b/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/MetadataModelAccessor.java
+++ b/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/MetadataModelAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModel.java
+++ b/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelAction.java
+++ b/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelException.java
+++ b/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/spi/MetadataModelFactory.java
+++ b/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/spi/MetadataModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/spi/MetadataModelImplementation.java
+++ b/j2ee.metadata/src/org/netbeans/modules/j2ee/metadata/model/spi/MetadataModelImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/TestBase.java
+++ b/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelCompatibilityTest.java
+++ b/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelCompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelExceptionTest.java
+++ b/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/MetadataModelExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/SimpleMetadataModelImpl.java
+++ b/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/api/SimpleMetadataModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/spi/MetadataModelFactoryTest.java
+++ b/j2ee.metadata/test/unit/src/org/netbeans/modules/j2ee/metadata/model/spi/MetadataModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/action/EntityManagerGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/action/EntityManagerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/action/GenerationOptions.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/action/GenerationOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/action/UseEntityManagerCodeGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/action/UseEntityManagerCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/api/entity/generator/EntitiesFromDBGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/api/entity/generator/EntitiesFromDBGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/JavaPersistenceQLKeywords.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/JavaPersistenceQLKeywords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/ORMMetadata.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/ORMMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceMetadata.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceUtils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/JPAParseUtils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/JPAParseUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/ParseUtils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/ParseUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/Persistence.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/Persistence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/PersistenceUnit.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/PersistenceUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/Properties.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/Properties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/Property.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/common/Property.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/orm/model_1_0/package-info.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/orm/model_1_0/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/orm/model_2_0/package-info.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/orm/model_2_0/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/orm/model_2_1/package-info.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/orm/model_2_1/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/persistence/model_1_0/package-info.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/persistence/model_1_0/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/persistence/model_2_0/package-info.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/persistence/model_2_0/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/persistence/model_2_1/package-info.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/persistence/model_2_1/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/CompletionContext.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/CompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/ContextUtilities.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/ContextUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/DocumentContext.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/DocumentContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/EditorContextFactory.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/EditorContextFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/JPAEditorUtil.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/JPAEditorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/PersistenceCfgXmlConstants.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/PersistenceCfgXmlConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/AnnotationUtils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/AnnotationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCParser.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CompletionContextResolver.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CompletionContextResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/ETCompletionContextResolver.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/ETCompletionContextResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACodeCompletionProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACodeCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACompletionItem.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletionManager.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletionProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletor.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PersistenceCompletionDocumentation.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PersistenceCompletionDocumentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/Utils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Catalog.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Catalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBCompletionContextResolver.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBCompletionContextResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataUtils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Schema.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Schema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/hyperlink/NamedQueryHyperlinkProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/hyperlink/NamedQueryHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/CMPMappingModel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/CMPMappingModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEntityMember.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEntityMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityClass.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityMember.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityRelation.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityRelation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/GeneratedTables.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/GeneratedTables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/RelationshipRole.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/RelationshipRole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/SQLType.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/SQLType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/indexing/CopyResourcesIndexer.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/indexing/CopyResourcesIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLEditorController.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLEditorController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLExecutor.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLResult.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/Utils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/completion/JPQLEditorCodeCompletionProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/completion/JPQLEditorCodeCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLLanguage.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLLanguageHierarchy.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLLanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLLexer.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLParserConstants.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLParserConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLTokenId.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/lexer/JPQLTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/JPQLEditorAction.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/JPQLEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/JPQLEditorTopComponent.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/JPQLEditorTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectionInfo.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectiveTableModel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectiveTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ResultTableCellRenderer.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ResultTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DataNucleusProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DataNucleusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DefaultProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DefaultProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/EclipseLinkProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/EclipseLinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/HibernateProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/HibernateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/InvalidPersistenceXmlException.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/InvalidPersistenceXmlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/KodoProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/KodoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/OpenJPAProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/OpenJPAProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/ProviderUtil.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/ProviderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/ToplinkProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/ToplinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/datasource/JPADataSource.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/datasource/JPADataSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/datasource/JPADataSourcePopulator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/datasource/JPADataSourcePopulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/datasource/JPADataSourceProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/datasource/JPADataSourceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionInJ2SE.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionInJ2SE.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionInjectableInEJB.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionInjectableInEJB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionInjectableInWeb.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionInjectableInWeb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionNonInjectableInEJB.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionNonInjectableInEJB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionNonInjectableInWeb.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ApplicationManagedResourceTransactionNonInjectableInWeb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ContainerManagedJTAInjectableInEJB.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ContainerManagedJTAInjectableInEJB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ContainerManagedJTAInjectableInWeb.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ContainerManagedJTAInjectableInWeb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ContainerManagedJTANonInjectableInWeb.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/ContainerManagedJTANonInjectableInWeb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategy.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategyResolver.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategyResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategyResolverFactory.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategyResolverFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategySupport.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Constructor.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Constructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Embeddable.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Embeddable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Entity.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Entity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/ManagedType.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/ManagedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/ManagedTypeProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/ManagedTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/MappedSuperclass.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/MappedSuperclass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Mapping.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Mapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Query.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Type.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Type.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/TypeDeclaration.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/TypeDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/TypeRepository.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/TypeRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/support/JPAAttribute.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/support/JPAAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/support/Utils.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/support/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/moduleinfo/JPAModuleInfo.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/moduleinfo/JPAModuleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/provider/PersistenceProviderSupplier.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/provider/PersistenceProviderSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/server/ServerStatusProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/server/ServerStatusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/server/ServerStatusProvider2.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/server/ServerStatusProvider2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/targetinfo/JPATargetInfo.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/targetinfo/JPATargetInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/AddEntityDialog.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/AddEntityDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/AddEntityPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/AddEntityPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PUDataLoader.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PUDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PUDataNode.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PUDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PUDataObject.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PUDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PanelFactory.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PanelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCatalog.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCfgProperties.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCfgProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceToolBarMVElement.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceToolBarMVElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitPanelFactory.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitPanelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceValidator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertiesPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertiesTableModel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertiesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertiesTablePanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertiesTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertyPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/Util.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/CustomClassLoader.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/CustomClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/EntityMethodGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/EntityMethodGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/JPAClassPathHelper.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/JPAClassPathHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/MetadataModelReadHelper.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/MetadataModelReadHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/PersistenceEnvironmentImpl.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/PersistenceEnvironmentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/PersistenceProviderComboboxHelper.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/PersistenceProviderComboboxHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/SourceLevelChecker.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/util/SourceLevelChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/EntityClosure.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/EntityClosure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/PersistenceClientEntitySelection.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/PersistenceClientEntitySelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/PersistenceClientEntitySelectionVisual.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/PersistenceClientEntitySelectionVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/Util.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/WizardProperties.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/WizardProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/DBScriptPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/DBScriptPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/DBScriptWizard.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/DBScriptWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/DBScriptWizardDescriptor.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/DBScriptWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/GenerateScriptExecutor.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/dbscript/GenerateScriptExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizard.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizardDescriptor.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizardPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/WrapperPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/entity/WrapperPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaFileList.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaFileList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaManager.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaTableProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaTableProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaUISupport.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/EmptyTableProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/EmptyTableProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/EntityClassesPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/EntityClassesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/FacadeGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/FacadeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/FacadeGeneratorProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/FacadeGeneratorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JavaPersistenceGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JavaPersistenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JavaPersistenceGeneratorProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JavaPersistenceGeneratorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/MappingOptionsPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/MappingOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/PersistenceGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/PersistenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/PersistenceGeneratorProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/PersistenceGeneratorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/ProgressPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/ProgressPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/RelatedCMPHelper.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/RelatedCMPHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/RelatedCMPWizard.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/RelatedCMPWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/SelectedTables.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/SelectedTables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/SourceGroupUISupport.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/SourceGroupUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/Table.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/Table.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosure.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableProvider.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableSource.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableUISupport.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/UpdateType.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/UpdateType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerGenerator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerIterator.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerSetupPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerSetupPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerSetupPanelVisual.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerSetupPanelVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerUtil.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/ProgressReporter.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/ProgressReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/ProgressReporterDelegate.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/ProgressReporterDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/WizardProperties.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/WizardProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/J2SEVolumeCustomizer.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/J2SEVolumeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibraryCustomizer.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibraryCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibraryPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibraryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibrarySupport.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibrarySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/VolumeContentModel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/VolumeContentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/JdbcListCellRenderer.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/JdbcListCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizard.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardDescriptor.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanel.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelDS.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelDS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelJdbc.java
+++ b/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelJdbc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/ConnectionImpl.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/ConnectionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/DatabaseMetaDataImpl.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/DatabaseMetaDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/JDBCStubUtil.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/JDBCStubUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/JDBCStubUtilTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/JDBCStubUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/ResultSetImpl.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/ResultSetImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/ResultSetImplTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/ResultSetImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxInjEJBTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxInjEJBTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxInjWebTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxInjWebTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxJ2SETest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxJ2SETest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxNonInjEJBTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxNonInjEJBTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxNonInjWebTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/AppMgdResTxNonInjWebTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTAInjectableInEJBTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTAInjectableInEJBTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTAInjectableInWebTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTAInjectableInWebTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTANonInjectableInWebTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTANonInjectableInWebTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/EntityManagerGenerationTestSupport.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/action/EntityManagerGenerationTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/CatalogTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/CatalogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProviderTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/SchemaTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/SchemaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/SimpleDatabaseMetaDataImpl.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/SimpleDatabaseMetaDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGeneratorTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectionInfoTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectionInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/provider/ProviderUtilTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/provider/ProviderUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/ClassPathProviderImpl.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/ClassPathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/FakeJavaDataLoaderPool.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/FakeJavaDataLoaderPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/SourceTestSupport.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/SourceTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategySupportTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PUDataLoaderTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PUDataLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PUDataObjectTestBase.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PUDataObjectTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceEditorTestBase.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceEditorTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceMultiviewEditorTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceMultiviewEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitDataObjectTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceValidatorTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizardTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/entity/EntityWizardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JPAGenTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JPAGenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/PersistenceGeneratorImpl.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/PersistenceGeneratorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/ProgressPanelTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/ProgressPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/SelectedTablesTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/SelectedTablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureDisabledTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureDisabledTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureJoinTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureJoinTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureQueueTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableProviderImpl.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableSourceTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibraryPanelTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibraryPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/Stub.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/Stub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/StubDelegate.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/StubDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/StubTest.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/StubTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistence/test/unit/src/org/netbeans/test/stub/spi/StubImplementation.java
+++ b/j2ee.persistence/test/unit/src/org/netbeans/test/stub/spi/StubImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/EntityClassScope.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/EntityClassScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceEnvironment.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceLocation.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceScope.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceScopes.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceScopes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/AssociationOverride.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/AssociationOverride.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/AttributeOverride.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/AttributeOverride.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Attributes.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Attributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Basic.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Basic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/CascadeType.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/CascadeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Column.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Column.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/ColumnResult.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/ColumnResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/DiscriminatorColumn.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/DiscriminatorColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Embeddable.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Embeddable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EmbeddableAttributes.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EmbeddableAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Embedded.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Embedded.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EmbeddedId.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EmbeddedId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EmptyType.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EmptyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Entity.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Entity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityListener.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityListeners.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityListeners.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityMappings.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityMappings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityMappingsMetadata.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityMappingsMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityResult.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/EntityResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/FieldResult.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/FieldResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/GeneratedValue.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/GeneratedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Id.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Id.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/IdClass.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/IdClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Inheritance.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Inheritance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/JoinColumn.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/JoinColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/JoinTable.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/JoinTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Lob.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Lob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/ManyToMany.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/ManyToMany.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/ManyToOne.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/ManyToOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/MapKey.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/MapKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/MappedSuperclass.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/MappedSuperclass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/NamedNativeQuery.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/NamedNativeQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/NamedQuery.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/NamedQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/OneToMany.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/OneToMany.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/OneToOne.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/OneToOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PersistenceUnitDefaults.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PersistenceUnitDefaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PersistenceUnitMetadata.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PersistenceUnitMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostLoad.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostLoad.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostPersist.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostPersist.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostRemove.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostRemove.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostUpdate.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PostUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PrePersist.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PrePersist.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PreRemove.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PreRemove.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PreUpdate.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PreUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PrimaryKeyJoinColumn.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/PrimaryKeyJoinColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/QueryHint.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/QueryHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/SecondaryTable.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/SecondaryTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/SequenceGenerator.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/SequenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/SqlResultSetMapping.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/SqlResultSetMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Table.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Table.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/TableGenerator.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/TableGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Transient.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Transient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/UniqueConstraint.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/UniqueConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Version.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/metadata/orm/Version.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/EntityClassScopeFactory.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/EntityClassScopeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/EntityClassScopeImplementation.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/EntityClassScopeImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/EntityClassScopeProvider.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/EntityClassScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceLocationProvider.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceLocationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopeFactory.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopeImplementation.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopeImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopeProvider.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopesFactory.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopesImplementation.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopesImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopesProvider.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/PersistenceScopesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/support/EntityMappingsMetadataModelHelper.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/support/EntityMappingsMetadataModelHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/support/PersistenceScopesHelper.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/spi/support/PersistenceScopesHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/EntityClassScopeAccessor.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/EntityClassScopeAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/PersistenceScopeAccessor.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/PersistenceScopeAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/PersistenceScopesAccessor.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/PersistenceScopesAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectEntityClassScopeProvider.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectEntityClassScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectPersistenceScopeProvider.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectPersistenceScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AssociationOverrideImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AssociationOverrideImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributeOverrideImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributeOverrideImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesHelper.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/BasicImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/BasicImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/CascadeTypeImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/CascadeTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ColumnImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ColumnImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ColumnResultImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ColumnResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/DiscriminatorColumnImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/DiscriminatorColumnImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableAttributesImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableAttributesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddedIdImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddedIdImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddedImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmptyTypeImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmptyTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityListenerImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityListenerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityListenersImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityListenersImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataModelFactory.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataModelImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsUtilities.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityResultImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/FieldResultImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/FieldResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/GeneratedValueImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/GeneratedValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/IdClassImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/IdClassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/IdImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/IdImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/InheritanceImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/InheritanceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/JoinColumnImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/JoinColumnImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/JoinTableImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/JoinTableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/LobImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/LobImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToManyImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToManyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToOneImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToOneImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MapKeyImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MapKeyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MappedSuperclassImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MappedSuperclassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/NamedNativeQueryImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/NamedNativeQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/NamedQueryImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/NamedQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToManyImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToManyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToOneImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToOneImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PersistenceUnitDefaultsImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PersistenceUnitDefaultsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PersistenceUnitMetadataImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PersistenceUnitMetadataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostLoadImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostLoadImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostPersistImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostPersistImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostRemoveImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostRemoveImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostUpdateImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PostUpdateImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PrePersistImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PrePersistImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PreRemoveImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PreRemoveImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PreUpdateImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PreUpdateImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PrimaryKeyJoinColumnImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/PrimaryKeyJoinColumnImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/QueryHintImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/QueryHintImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/SecondaryTableImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/SecondaryTableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/SequenceGeneratorImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/SequenceGeneratorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/SqlResultSetMappingImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/SqlResultSetMappingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/TableGeneratorImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/TableGeneratorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/TableImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/TableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/TransientImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/TransientImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/UniqueConstraintImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/UniqueConstraintImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/VersionImpl.java
+++ b/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/VersionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistence/spi/support/PersistenceScopesHelperTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistence/spi/support/PersistenceScopesHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddedIdImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddedIdImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataModelTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsMetadataModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsTestCase.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsUtilitiesTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/IdImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/IdImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToManyImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToManyImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToOneImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToOneImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MappedSuperclassTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MappedSuperclassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToManyImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToManyImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToOneImplTest.java
+++ b/j2ee.persistenceapi/test/unit/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToOneImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/ModuleRoots.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/ModuleRoots.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/Roots.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/Roots.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/SourceRoots.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/SourceRoots.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/ant/PackageModifierImplementation.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/ant/PackageModifierImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/ant/UpdateHelper.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/ant/UpdateHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/ant/UpdateImplementation.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/ant/UpdateImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/applet/AppletSupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/applet/AppletSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/AbstractClassPathProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/AbstractClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/BootClassPathImplementation.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/BootClassPathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathExtender.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathModifier.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathModifierSupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathModifierSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathProviderImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathSupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathSupportFactory.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathSupportFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPaths.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/MultiModuleClassPathProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/MultiModuleClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/SourcePathImplementation.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/SourcePathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/ClassPathPackageAccessor.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/ClassPathPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/DefaultProjectModulesModifier.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/DefaultProjectModulesModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/ExportPackageAction.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/ExportPackageAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/MultiModule.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/MultiModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/ProjectAntLogger.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/ProjectAntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/RootsAccessor.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/RootsAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/TemplateModuleDeclarator.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/TemplateModuleDeclarator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/impl/Utilities.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/impl/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/problems/MissingModuleProblemsProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/problems/MissingModuleProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/problems/ProjectProblemsProviders.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/problems/ProjectProblemsProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ActionProviderSupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ActionProviderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/BaseActionProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/BaseActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/JavaActionProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/JavaActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/MultiModuleActionProviderBuilder.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/MultiModuleActionProviderBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectConfigurations.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectConfigurations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectHooks.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectOperations.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectPlatformProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectPlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectProperties.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ProjectProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/PropertyEvaluatorProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/PropertyEvaluatorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ActionFilterNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ActionFilterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ClassPathUiSupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ClassPathUiSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/EditRootAction.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/EditRootAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/JavaSourceNodeFactory.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/JavaSourceNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesSourceGroup.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesSourceGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LogicalViewProvider2.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LogicalViewProvider2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LogicalViewProviders.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LogicalViewProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ModuleNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ModuleNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/MultiModuleNodeFactory.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/MultiModuleNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/PackageViewFilterNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/PackageViewFilterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/PlatformNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/PlatformNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/PreselectPropertiesAction.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/PreselectPropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ProjectNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ProjectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ProjectUISupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ProjectUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/RemoveClassPathRootAction.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/RemoveClassPathRootAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ShowJavadocAction.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ShowJavadocAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/AntArtifactChooser.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/AntArtifactChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/AntArtifactItem.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/AntArtifactItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/ClassPathListCellRenderer.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/ClassPathListCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/CustomizerProvider2.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/CustomizerProvider2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/CustomizerProvider3.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/CustomizerProvider3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/EditMediator.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/EditMediator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/MainClassChooser.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/MainClassChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/MainClassWarning.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/MainClassWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/ProjectSharability.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/ProjectSharability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/AbstractJavaVMOptionParser.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/AbstractJavaVMOptionParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/JavaVMOption.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/JavaVMOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/OptionValue.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/OptionValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/OptionsDialog.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/OptionsDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/ParametrizedNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/ParametrizedNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/SwitchNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/SwitchNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/UnknownOption.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/UnknownOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/UnrecognizedOption.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/UnrecognizedOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/UserPropertyNode.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/UserPropertyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VMOptionEditorPanel.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VMOptionEditorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VMOptionTreeAdaptor.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VMOptionTreeAdaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VMOptionsTableModel.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VMOptionsTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/ValueCellEditor.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/ValueCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/gen/CommandLine.g
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/gen/CommandLine.g
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/gen/CommandLineLexer.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/gen/CommandLineLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/gen/CommandLineParser.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/gen/CommandLineParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/wizards/FolderList.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/wizards/FolderList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/AnnotationProcessingQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/AnnotationProcessingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/AutomaticModuleNameCompilerOptionsQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/AutomaticModuleNameCompilerOptionsQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/BinaryForSourceQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/BinaryForSourceQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/CompiledSourceForBinaryQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/CompiledSourceForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/CompilerOptionsQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/CompilerOptionsQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/EvaluatorPropertyProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/EvaluatorPropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/FileBuiltQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/FileBuiltQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/FileEncodingQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/FileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/JavadocForBinaryQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/JavadocForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/ModuleInfoAccessibilityQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/ModuleInfoAccessibilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleAntArtifactProvider.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleAntArtifactProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleBinaryForSourceQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleBinaryForSourceQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleFileBuiltQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleFileBuiltQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleGroupQuery.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleGroupQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleGroupQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleGroupQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleJavadocForBinaryQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleJavadocForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleSourceForBinaryQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleSourceForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestForSourceQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestForSourceQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestsCompilerOptionsQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestsCompilerOptionsQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/ProjectInfoImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/ProjectInfoImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/QuerySupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/QuerySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/SharabilityQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/SharabilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/SourceLevelQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/SourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/SourceLevelQueryImpl2.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/SourceLevelQueryImpl2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/SourcesImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/SourcesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/TemplateAttributesProviderImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/TemplateAttributesProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/UnitTestForSourceQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/UnitTestForSourceQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/queries/UnitTestsCompilerOptionsQueryImpl.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/queries/UnitTestsCompilerOptionsQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/ui/PlatformFilter.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/ui/PlatformFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/ui/PlatformUiSupport.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/ui/PlatformUiSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/util/CommonModuleUtils.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/util/CommonModuleUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/src/org/netbeans/modules/java/api/common/util/CommonProjectUtils.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/util/CommonProjectUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/TestJavaPlatform.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/TestJavaPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/TestProject.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/TestProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/TestRoots.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/TestRoots.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ClassPathProviderImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ClassPathProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPathsTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPathsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/MultiModuleBinariesTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/MultiModuleBinariesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/MultiModuleClassPathProviderTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/MultiModuleClassPathProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/impl/ModuleTestUtilities.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/impl/ModuleTestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/impl/MultiModuleTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/impl/MultiModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/BaseActionProviderTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/BaseActionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/JavaActionProviderTestSupport.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/JavaActionProviderTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/ui/JavaSourceNodeFactoryTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/ui/JavaSourceNodeFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/ui/customizer/CustomizerProvider3Test.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/ui/customizer/CustomizerProvider3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VmOptionsGrammarTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/project/ui/customizer/vmo/VmOptionsGrammarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/AutomaticModuleNameCompilerOptionsQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/AutomaticModuleNameCompilerOptionsQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/FileEncodingQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/FileEncodingQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/GeneratedSourceRootTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/GeneratedSourceRootTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/JavadocForBinaryQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/JavadocForBinaryQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleBinaryForSourceQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleBinaryForSourceQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleFileBuiltQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleFileBuiltQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleGroupQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleGroupQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleJavadocForBinaryQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleJavadocForBinaryQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleSourceForBinaryQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleSourceForBinaryQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestForSourceQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestForSourceQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestsCompilerOptionsQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/MultiModuleUnitTestsCompilerOptionsQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/QuerySupportTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/QuerySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/SourceLevelQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/SourceLevelQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/SourcesImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/SourcesImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/UnitTestsCompilerOptionsQueryImplTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/UnitTestsCompilerOptionsQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/ui/PlatformFilterTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/ui/PlatformFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/util/CommonModuleUtilsTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/util/CommonModuleUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/util/CommonProjectUtilsTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/util/CommonProjectUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/src/org/netbeans/modules/java/completion/BaseTask.java
+++ b/java.completion/src/org/netbeans/modules/java/completion/BaseTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/src/org/netbeans/modules/java/completion/JavaDocumentationTask.java
+++ b/java.completion/src/org/netbeans/modules/java/completion/JavaDocumentationTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/src/org/netbeans/modules/java/completion/JavaTooltipTask.java
+++ b/java.completion/src/org/netbeans/modules/java/completion/JavaTooltipTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/src/org/netbeans/modules/java/completion/Utilities.java
+++ b/java.completion/src/org/netbeans/modules/java/completion/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/AdvancedMethodBody.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/AdvancedMethodBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorNonDefaultConstructor.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorNonDefaultConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorTest.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorWithConstructors.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorWithConstructors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorWithDefaultConstructor.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/CreateConstructorWithDefaultConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Empty.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Empty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Field.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/FieldNoInit.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/FieldNoInit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/For.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/For.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/ForEach.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/ForEach.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Generics.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Generics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsEmptyMethodBody.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsEmptyMethodBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsMethod.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsMethodBodyStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsMethodBodyStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsMethodNoTypeParams.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsMethodNoTypeParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsNoTypeParams.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsNoTypeParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/GenericsStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Import.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Initializers.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Initializers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/InitializersStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/InitializersStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Interface.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Interface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/LambdaExpression.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/LambdaExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/LambdaExpressionEmptyMethodBody.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/LambdaExpressionEmptyMethodBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/LambdaExpressionStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/LambdaExpressionStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Method.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Method.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/MethodNoParamsAndThrows.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/MethodNoParamsAndThrows.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/MethodStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/MethodStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractList.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractList2.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractList2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractList3.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractList3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractListAbstract.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideAbstractListAbstract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideInInnerClass.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideInInnerClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideInInnerClassUnresolvable.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideInInnerClassUnresolvable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverridePackagePrivateMethod.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverridePackagePrivateMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverridePrivateMethod.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverridePrivateMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideTypedException.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/OverrideTypedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Simple.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Simple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleEmptyMethodBody.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleEmptyMethodBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleEnum.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleEnumNoImplements.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleEnumNoImplements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleInterface.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleInterfaceNoExtends.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleInterfaceNoExtends.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleLambdaExpression.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleLambdaExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleLambdaExpressionEmptyMethodBody.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleLambdaExpressionEmptyMethodBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleLambdaExpressionStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleLambdaExpressionStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleMethodBody.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleMethodBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleMethodBodyStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleMethodBodyStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleNoExtendsAndImplements.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleNoExtendsAndImplements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleNoPackage.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleNoPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleTWR.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleTWR.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleTWRNoRes.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleTWRNoRes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleTWRStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SimpleTWRStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Switch.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/Switch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/TWR.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/TWR.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/TWRNoRes.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/TWRNoRes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/TWRStart.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/TWRStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/UnimplementedMethod.java
+++ b/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/UnimplementedMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask15FeaturesTest.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask15FeaturesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask17FeaturesTest.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask17FeaturesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask18FeaturesTest.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask18FeaturesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask19FeaturesTest.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask19FeaturesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTaskAdvancedTest.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTaskAdvancedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTaskBasicTest.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTaskBasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTaskElementCreatingTest.java
+++ b/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTaskElementCreatingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/ClasspathNavigatorProviderImpl.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/ClasspathNavigatorProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/CommentNode.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/CommentNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/CommentsNode.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/CommentsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/DocTreeNode.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/DocTreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/ElementNavigatorJavaSourceFactory.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/ElementNavigatorJavaSourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/ElementNavigatorProviderImpl.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/ElementNavigatorProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/ElementNode.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/ElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/ErrorNavigatorProviderImpl.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/ErrorNavigatorProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/ErrorNode.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/ErrorNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/HighlightsLayerFactoryImpl.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/HighlightsLayerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/OffsetProvider.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/OffsetProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/SourceForBinaryQueryImpl.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/SourceForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/TreeNavigatorJavaSourceFactory.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/TreeNavigatorJavaSourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/TreeNavigatorProviderImpl.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/TreeNavigatorProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.debug/src/org/netbeans/modules/java/debug/TreeNode.java
+++ b/java.debug/src/org/netbeans/modules/java/debug/TreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/fold/JavaElementFoldVisitor.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/fold/JavaElementFoldVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/imports/UnusedImports.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/imports/UnusedImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocCompletionUtils.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocCompletionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocImports.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/options/MarkOccurencesSettingsNames.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/options/MarkOccurencesSettingsNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/ColoringAttributes.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/ColoringAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/FindLocalUsagesQuery.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/FindLocalUsagesQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MethodExitDetector.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MethodExitDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/TokenList.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/TokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/Utilities.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/javadoc/JavadocCompletionUtilsTest.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/javadoc/JavadocCompletionUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/javadoc/JavadocImportsTest.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/javadoc/JavadocImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/javadoc/JavadocTestSupport.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/javadoc/JavadocTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/DetectorTest.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/DetectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/HighlightImpl.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/HighlightImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/MarkOccDetTest.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/MarkOccDetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/ShowGoldenFiles.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/ShowGoldenFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/ShowGoldenFilesPanel.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/ShowGoldenFilesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/TestBase.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/UnusedImportsTest.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/UnusedImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.lib/src/org/netbeans/editor/ext/java/JavaDocSyntax.java
+++ b/java.editor.lib/src/org/netbeans/editor/ext/java/JavaDocSyntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFoldManager.java
+++ b/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFormatSupport.java
+++ b/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFormatSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFormatter.java
+++ b/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.lib/src/org/netbeans/editor/ext/java/JavaLayerTokenContext.java
+++ b/java.editor.lib/src/org/netbeans/editor/ext/java/JavaLayerTokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.lib/src/org/netbeans/editor/ext/java/JavaSyntax.java
+++ b/java.editor.lib/src/org/netbeans/editor/ext/java/JavaSyntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor.lib/src/org/netbeans/editor/ext/java/JavaTokenContext.java
+++ b/java.editor.lib/src/org/netbeans/editor/ext/java/JavaTokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/AutoImport.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/AutoImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/CamelCaseOperations.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/CamelCaseOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/ComputeOffAWT.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/ComputeOffAWT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/FileObjectAccessor.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/FileObjectAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/GoToSupport.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/GoToSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaBracesMatcher.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaBracesMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateFilter.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessor.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionDoc.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionDoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItemFactory.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItemFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionProvider.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaKit.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/JavaMoveCodeElementAction.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaMoveCodeElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/LazyJavaCompletionItem.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/LazyJavaCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/LazySortText.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/LazySortText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/MethodParamsTipPaintComponent.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/MethodParamsTipPaintComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/NbJavaSettingsInitializer.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/NbJavaSettingsInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/SelectCodeElementAction.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/SelectCodeElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/SupportedAnnotationTypesCompletion.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/SupportedAnnotationTypesCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/TokenBalance.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/TokenBalance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/editor/java/Utilities.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/JavaEditorWarmUpTask.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/JavaEditorWarmUpTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/CodeDeleter.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/CodeDeleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ConstructorGenerator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ConstructorGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ContextProvider.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/DelegateMethodGenerator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/DelegateMethodGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/EqualsHashCodeGenerator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/EqualsHashCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/GeneratorUtils.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/GeneratorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/GetterSetterGenerator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/GetterSetterGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ImplementOverrideMethodGenerator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ImplementOverrideMethodGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/InsertSemicolonAction.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/InsertSemicolonAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/LoggerGenerator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/LoggerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/RemoveSurroundingCodeAction.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/RemoveSurroundingCodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/RemoveSurroundingCodePanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/RemoveSurroundingCodePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ToStringGenerator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ToStringGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/CheckRenderer.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/CheckRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/CheckTreeView.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/CheckTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ConstructorPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ConstructorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/DelegatePanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/DelegatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ElementNode.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ElementSelectorPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ElementSelectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/EqualsHashCodePanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/EqualsHashCodePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/GetterSetterPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/GetterSetterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ImplementOverridePanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ImplementOverridePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ToStringPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ToStringPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManagerFactory.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManagerTaskFactory.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManagerTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/JavaFoldTypeProvider.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/JavaFoldTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/MessagePattern.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/MessagePattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/ParsingFoldSupport.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/ParsingFoldSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceContentReader.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceContentReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringFoldInfo.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringFoldInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringFoldProvider.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringFoldProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringLoader.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/hyperlink/JavaHyperlinkProvider.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/hyperlink/JavaHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardHandler.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardImportPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardImportPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/imports/ComputeImports.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/imports/ComputeImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/imports/FastImportAction.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/imports/FastImportAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/imports/FixDuplicateImportStmts.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/imports/FixDuplicateImportStmts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/imports/ImportClassPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/imports/ImportClassPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/imports/JavaFixAllImports.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/imports/JavaFixAllImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavaReference.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavaReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionItem.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionProvider.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionQuery.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/javadoc/TagRegistery.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/javadoc/TagRegistery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/options/CodeCompletionPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/options/CodeCompletionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/options/MarkOccurencesOptionsPanelController.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/options/MarkOccurencesOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/options/MarkOccurencesPanel.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/options/MarkOccurencesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/options/MarkOccurencesSettings.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/options/MarkOccurencesSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/AnnotationType.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/AnnotationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/AnnotationsHolder.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/AnnotationsHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeAnnotations.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriders.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriding.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/ElementDescription.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/ElementDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/GoToImplementation.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/GoToImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/GoToSuperTypeAction.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/GoToSuperTypeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotation.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotationAction.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenPopup.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenVisitor.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/overridden/PopupUtil.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/overridden/PopupUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenameAction.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformer.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/rename/SyncDocumentRegion.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/rename/SyncDocumentRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/ColoringManager.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/ColoringManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/EmbeddedLexerBasedHighlightSequence.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/EmbeddedLexerBasedHighlightSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/GoToMarkOccurrencesAction.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/GoToMarkOccurrencesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/HighlightsLayerFactoryImpl.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/HighlightsLayerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/LexerBasedHighlightLayer.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/LexerBasedHighlightLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/LexerBasedHighlightSequence.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/LexerBasedHighlightSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/MarkOccurrencesHighlighter.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/MarkOccurrencesHighlighter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/MarkOccurrencesHighlighterFactory.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/MarkOccurrencesHighlighterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/OccurrencesMarkProvider.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/OccurrencesMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/OccurrencesMarkProviderCreator.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/OccurrencesMarkProviderCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/RemoveUnusedImportFix.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/RemoveUnusedImportFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/ScanningCancellableTask.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/ScanningCancellableTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/SemanticHighlighter.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/SemanticHighlighter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/SemanticHighlighterFactory.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/SemanticHighlighterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/semantic/UnusedTooltipResolver.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/semantic/UnusedTooltipResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/whitelist/WhiteListCheckTask.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/whitelist/WhiteListCheckTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/src/org/netbeans/modules/java/editor/whitelist/WhiteListTaskProvider.java
+++ b/java.editor/src/org/netbeans/modules/java/editor/whitelist/WhiteListTaskProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/data/CC15Tests/src/org/netbeans/test/editor/parametertip/Parameter.java
+++ b/java.editor/test/qa-functional/data/CC15Tests/src/org/netbeans/test/editor/parametertip/Parameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/EditorActionsTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/EditorActionsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/JavaEditActionsTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/JavaEditActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/JavaEditorActionsTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/JavaEditorActionsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/JavaNavigationActionsTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/actions/JavaNavigationActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/breadcrumbs/Breadcrumbs.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/breadcrumbs/Breadcrumbs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/CreateConstructorTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/CreateConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/CreateEqualsHashcodeTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/CreateEqualsHashcodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/CreateGetterSetterTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/CreateGetterSetterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/GenerateCodeTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/GenerateCodeTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/ImplementMethodTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codegeneration/ImplementMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/CodeTemplatesTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/CodeTemplatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/CustomizedLog.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/CustomizedLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/operators/CodeTemplatesOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/operators/CodeTemplatesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/AllCCTests.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/AllCCTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/CompletionTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/CompletionTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/NormalCCTests.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/NormalCCTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/SmartCCTests.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completion/SmartCCTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completiongui/GuiTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/completiongui/GuiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/CodeFoldingTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/CodeFoldingTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/JavaCodeFoldingTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/JavaCodeFoldingTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/JavaFoldsNavigationTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/JavaFoldsNavigationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/JavaFoldsTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/folding/JavaFoldsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/AlignmentTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/AlignmentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/BasicTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/BlankLinesTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/BlankLinesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/BracesTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/BracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/FormattingOptionsTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/FormattingOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/GeneralFormattingOptionsTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/GeneralFormattingOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/JavaTabsAndIndentsTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/JavaTabsAndIndentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/SpacesTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/SpacesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/WrappingTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/WrappingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/AlignmentOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/AlignmentOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/AllLanguageTabsAndIndentsOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/AllLanguageTabsAndIndentsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/BlankLinesOperatror.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/BlankLinesOperatror.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/BracesOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/BracesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/FormattingOptionsOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/FormattingOptionsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/FormattingPanelOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/FormattingPanelOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/JavaTabsAndIndentsOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/JavaTabsAndIndentsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/SpacesOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/SpacesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/WrappingOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/formatting/operators/WrappingOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateConstructorOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateConstructorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateEqualsAndHashCodeOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateEqualsAndHashCodeOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateEqualsOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateEqualsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateGettersAndSettersOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateGettersAndSettersOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateHashCodeOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/GenerateHashCodeOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/ImplementMethodsOperator.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/jelly/ImplementMethodsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/lib/EditorTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/lib/EditorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/lib/JavaEditorTestCase.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/lib/JavaEditorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/lib/LineDiff.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/lib/LineDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/occurrences/MarkOccurrencesTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/occurrences/MarkOccurrencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/remove/RemoveSurroundingTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/remove/RemoveSurroundingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/semantic/SemanticHighlightTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/semantic/SemanticHighlightTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/smart_bracket/JavaSmartBracketTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/smart_bracket/JavaSmartBracketTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/smart_enter/SmartEnterTest.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/smart_enter/SmartEnterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/CodeCompletionSuite.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/CodeCompletionSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/CodeGenerationSuite.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/CodeGenerationSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/EditorNavigationSuite.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/EditorNavigationSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/FoldingSuite.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/FoldingSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/StableSuite.java
+++ b/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/suites/StableSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/GoToSupportTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/GoToSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaBaseDocumentUnitTestCase.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaBaseDocumentUnitTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterArrayInitOrEnumUnitTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterArrayInitOrEnumUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterUnitTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterUnitTestCase.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterUnitTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterUnitTestSuite.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaFormatterUnitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/TestSourceLevelQueryImplementation.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/TestSourceLevelQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/TestUtils.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/editor/java/UtilitiesTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/editor/java/UtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/codegen/DelegateMethodGeneratorTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/codegen/DelegateMethodGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/codegen/EqualsHashCodeGeneratorTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/codegen/EqualsHashCodeGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/codegen/GeneratorUtilsTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/codegen/GeneratorUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/CompletionTestBase.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/CompletionTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/JavaCompletionItemElementCreatingTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/JavaCompletionItemElementCreatingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ClipboardHandlerTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ClipboardHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ComputeImportsTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ComputeImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/UnusedImportsTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/UnusedImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavaReferenceTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavaReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionQueryTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/overridden/ComputeOverridersTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/overridden/ComputeOverridersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/overridden/GoToImplementationTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/overridden/GoToImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotationCreatorTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotationCreatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/rename/InstantRenameActionTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/rename/InstantRenameActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformerTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.editor/test/unit/src/org/netbeans/modules/java/editor/view/JavaViewHierarchyRandomTest.java
+++ b/java.editor/test/unit/src/org/netbeans/modules/java/editor/view/JavaViewHierarchyRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/AgeConverter.java
+++ b/java.examples/ClientEditor/src/clienteditor/AgeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/AgeValidator.java
+++ b/java.examples/ClientEditor/src/clienteditor/AgeValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/Client.java
+++ b/java.examples/ClientEditor/src/clienteditor/Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/ClientEditor.java
+++ b/java.examples/ClientEditor/src/clienteditor/ClientEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/EmailValidator.java
+++ b/java.examples/ClientEditor/src/clienteditor/EmailValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/LoggingBindingListener.java
+++ b/java.examples/ClientEditor/src/clienteditor/LoggingBindingListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/MaritalStatusConverter.java
+++ b/java.examples/ClientEditor/src/clienteditor/MaritalStatusConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/ClientEditor/src/clienteditor/RequiredStringValidator.java
+++ b/java.examples/ClientEditor/src/clienteditor/RequiredStringValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/GUIFormExamples/src/examples/Antenna.java
+++ b/java.examples/GUIFormExamples/src/examples/Antenna.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/GUIFormExamples/src/examples/ContactEditor.java
+++ b/java.examples/GUIFormExamples/src/examples/ContactEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/GUIFormExamples/src/examples/Find.java
+++ b/java.examples/GUIFormExamples/src/examples/Find.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/anagrams/src/com/toy/anagrams/lib/StaticWordLibrary.java
+++ b/java.examples/anagrams/src/com/toy/anagrams/lib/StaticWordLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/anagrams/src/com/toy/anagrams/lib/WordLibrary.java
+++ b/java.examples/anagrams/src/com/toy/anagrams/lib/WordLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/anagrams/src/com/toy/anagrams/ui/About.java
+++ b/java.examples/anagrams/src/com/toy/anagrams/ui/About.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/anagrams/src/com/toy/anagrams/ui/Anagrams.java
+++ b/java.examples/anagrams/src/com/toy/anagrams/ui/Anagrams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/anagrams/test/com/toy/anagrams/lib/WordLibraryTest.java
+++ b/java.examples/anagrams/test/com/toy/anagrams/lib/WordLibraryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/FoldersListSettings.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/FoldersListSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectGenerator.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProject.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProjectVisual.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProjectVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/PanelProjectLocationVisual.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/PanelProjectLocationVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/SettingsPanel.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/SettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.examples/src/org/netbeans/modules/java/examples/WizardProperties.java
+++ b/java.examples/src/org/netbeans/modules/java/examples/WizardProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/AnnotationProcessingQueryImpl.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/AnnotationProcessingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/Classpaths.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/Classpaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/JavaActions.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/JavaActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/JavaFreeformFileBuiltQuery.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/JavaFreeformFileBuiltQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectGenerator.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectNature.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectNature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/JavadocQuery.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/JavadocQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/LookupMergerImpl.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/LookupMergerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/LookupProviderImpl.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/LookupProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/SourceForBinaryQueryImpl.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/SourceForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/SourceLevelQueryImpl.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/SourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/TestQuery.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/TestQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/UsageLogger.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/UsageLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/jdkselection/JdkConfiguration.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/jdkselection/JdkConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/spi/support/NewJavaFreeformProjectSupport.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/spi/support/NewJavaFreeformProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathCategoryProvider.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathWizardPanel.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/NewJ2SEFreeformProjectWizardIterator.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/NewJ2SEFreeformProjectWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputCategoryProvider.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputPanel.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputWizardPanel.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/ProjectModel.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/ProjectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersCategoryProvider.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersPanel.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersWizardPanel.java
+++ b/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ClasspathsTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ClasspathsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/DummyJavaPlatformProvider.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/DummyJavaPlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/FileEncodingQueryTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/FileEncodingQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaActionsTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaFreeformFileBuiltQueryTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaFreeformFileBuiltQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaProjectGeneratorTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaProjectGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaProjectNatureTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavaProjectNatureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavadocQueryTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/JavadocQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/SourceForBinaryQueryImplTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/SourceForBinaryQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/SourceLevelQueryImplTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/SourceLevelQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/TestQueryTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/TestQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ui/ProjectModelTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ui/ProjectModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ui/SourceFoldersPanelTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ui/SourceFoldersPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ui/ViewTest.java
+++ b/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ui/ViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/CenteredZoomAnimator.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/CenteredZoomAnimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/DependencyGraphScene.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/DependencyGraphScene.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/EdgeWidget.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/EdgeWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/FruchtermanReingoldLayout.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/FruchtermanReingoldLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/GraphEdge.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/GraphEdge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/GraphNode.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/GraphNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/GraphNodeImplementation.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/GraphNodeImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/GraphNodeVisitor.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/GraphNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/HighlightVisitor.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/HighlightVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/NodeWidget.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/NodeWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.graph/src/org/netbeans/modules/java/graph/SearchVisitor.java
+++ b/java.graph/src/org/netbeans/modules/java/graph/SearchVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/src/org/netbeans/modules/java/guards/GuardTag.java
+++ b/java.guards/src/org/netbeans/modules/java/guards/GuardTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedReader.java
+++ b/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedSectionsFactory.java
+++ b/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedSectionsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedSectionsProvider.java
+++ b/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedSectionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedWriter.java
+++ b/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/src/org/netbeans/modules/java/guards/SectionDescriptor.java
+++ b/java.guards/src/org/netbeans/modules/java/guards/SectionDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/test/unit/src/org/netbeans/modules/java/guards/Editor.java
+++ b/java.guards/test/unit/src/org/netbeans/modules/java/guards/Editor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/test/unit/src/org/netbeans/modules/java/guards/JavaGuardedReaderTest.java
+++ b/java.guards/test/unit/src/org/netbeans/modules/java/guards/JavaGuardedReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.guards/test/unit/src/org/netbeans/modules/java/guards/JavaGuardedWriterTest.java
+++ b/java.guards/test/unit/src/org/netbeans/modules/java/guards/JavaGuardedWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative.test/src/org/netbeans/modules/java/hints/declarative/test/api/DeclarativeHintsTestBase.java
+++ b/java.hints.declarative.test/src/org/netbeans/modules/java/hints/declarative/test/api/DeclarativeHintsTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/APIAccessor.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/APIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/ClassPathProviderImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/ClassPathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Condition.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Condition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/ConditionAPIHacks.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/ConditionAPIHacks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeFix.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintLexer.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistry.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintTokenId.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsOptions.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsWorker.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/EmbeddingProviderImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/EmbeddingProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Hacks.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Hacks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/HintDataObject.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/HintDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContext.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/PatternConvertorImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/PatternConvertorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Utilities.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Context.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/DefaultRuleUtilities.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/DefaultRuleUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Matcher.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Matcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Variable.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Variable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/DebuggingHighlightsLayerFactory.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/DebuggingHighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/EvaluationSpanTask.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/EvaluationSpanTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/HintWrapper.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/HintWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/ToggleDebuggingAction.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/ToggleDebuggingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsActionProvider.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsTask.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/JavadocForBinaryQueryImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/JavadocForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/ParserImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/ParserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/resources/HintSample.hint
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/resources/HintSample.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/resources/test.hint
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/resources/test.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/DeclarativeHintsTestDataObject.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/DeclarativeHintsTestDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/EditorTestPerformer.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/EditorTestPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/HighlightsLayerFactoryImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/HighlightsLayerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestLexer.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestLocatorImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestLocatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestParser.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestPerformer.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestTokenId.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CallOutterMethod.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CallOutterMethod.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CallOutterMethod.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CallOutterMethod.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ChangeFieldType.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ChangeFieldType.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ChangeFieldType.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ChangeFieldType.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CustomConditionTest.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CustomConditionTest.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CustomConditionTest.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/CustomConditionTest.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintLexerTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistryTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParserTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/EmbeddingProviderImplTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/EmbeddingProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/EnhancedForTest.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/EnhancedForTest.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/EnhancedForTest.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/EnhancedForTest.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/FakeBlockWarning.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/FakeBlockWarning.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/FakeBlockWarning.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/FakeBlockWarning.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest1.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest1.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest1.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest1.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest2.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest2.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest2.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/ImportsTest2.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/LambdaInput.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/LambdaInput.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/LambdaInput.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/LambdaInput.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContextTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NameBoundVariablesGetSet.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NameBoundVariablesGetSet.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NameBoundVariablesGetSet.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NameBoundVariablesGetSet.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NegativeInstanceOfTest.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NegativeInstanceOfTest.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NegativeInstanceOfTest.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/NegativeInstanceOfTest.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/PerformDeclarativeTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/PerformDeclarativeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TestParentMatches.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TestParentMatches.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TestParentMatches.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TestParentMatches.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TestUtils.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/annotation-conversion.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/annotation-conversion.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/annotation-conversion.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/annotation-conversion.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/broken-condition-no-exception.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/broken-condition-no-exception.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/broken-condition-no-exception.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/broken-condition-no-exception.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/condition-on-fix.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/condition-on-fix.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/condition-on-fix.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/condition-on-fix.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/ContextTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/ContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/DefaultRuleUtilitiesTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/DefaultRuleUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/MatcherTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/MatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/isAvailable.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/isAvailable.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/isAvailable.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/isAvailable.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/matchWithBind.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/matchWithBind.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/matchWithBind.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/conditionapi/matchWithBind.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/debugging/EvaluationSpanTaskTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/debugging/EvaluationSpanTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/expression-to-expression-statement.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/expression-to-expression-statement.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/expression-to-expression-statement.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/expression-to-expression-statement.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/fqn-rewrite-test.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/fqn-rewrite-test.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/fqn-rewrite-test.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/fqn-rewrite-test.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsTaskTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/otherwise-test.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/otherwise-test.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/otherwise-test.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/otherwise-test.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/remove-from-parent.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/remove-from-parent.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/remove-from-parent.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/remove-from-parent.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/test/TestLexerTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/test/TestLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/test/TestParserTest.java
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/test/TestParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/testfrombundle/display-names-from-bundle.hint
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/testfrombundle/display-names-from-bundle.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/testfrombundle/display-names-from-bundle.test
+++ b/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/testfrombundle/display-names-from-bundle.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/legacy/spi/RulesManager.java
+++ b/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/legacy/spi/RulesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/AbstractHint.java
+++ b/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/AbstractHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/ErrorRule.java
+++ b/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/ErrorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/Rule.java
+++ b/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/TreeRule.java
+++ b/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/TreeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/support/FixFactory.java
+++ b/java.hints.legacy.spi/src/org/netbeans/modules/java/hints/spi/support/FixFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.test/src/org/netbeans/modules/java/hints/test/Utilities.java
+++ b/java.hints.test/src/org/netbeans/modules/java/hints/test/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
+++ b/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.test/src/org/netbeans/modules/parsing/impl/indexing/MimeTypes.java
+++ b/java.hints.test/src/org/netbeans/modules/parsing/impl/indexing/MimeTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.test/test/unit/src/org/netbeans/modules/java/hints/test/api/HintTestTest.java
+++ b/java.hints.test/test/unit/src/org/netbeans/modules/java/hints/test/api/HintTestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/analysis/AnalyzerImpl.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/analysis/AnalyzerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/onsave/OnSaveCustomizer.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/onsave/OnSaveCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/onsave/OnSavePreferencesCustomizer.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/onsave/OnSavePreferencesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/onsave/RemoveUnusedAfterSave.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/onsave/RemoveUnusedAfterSave.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/DepScanningSettings.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/DepScanningSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsOptionsPanelController.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/AbstractApplyHintsRefactoringPlugin.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/AbstractApplyHintsRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ApplyPatternAction.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ApplyPatternAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/Configuration.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationRenderer.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsComboModel.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsComboModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsManager.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/FindDuplicatesRefactoring.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/FindDuplicatesRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/FindDuplicatesRefactoringPlugin.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/FindDuplicatesRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorUI.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndTransformOpenerImpl.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndTransformOpenerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectionComboModel.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectionComboModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectionRenderer.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectionRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/RefactoringPluginFactoryImpl.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/RefactoringPluginFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/Utilities.java
+++ b/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/AddOverrideAnnotation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/AddOverrideAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/AnnotationAsSuperInterface.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/AnnotationAsSuperInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ArithmeticUtilities.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ArithmeticUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/AssignResultToVariable.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/AssignResultToVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/AssignmentIssues.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/AssignmentIssues.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/AssignmentToItself.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/AssignmentToItself.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/Braces.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/Braces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ClassStructure.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ClassStructure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ConvertAnonymousToInner.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ConvertAnonymousToInner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ConvertAnonymousToInnerAction.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ConvertAnonymousToInnerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/DeclarationForInstanceOf.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/DeclarationForInstanceOf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/DoubleCheck.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/DoubleCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/EmptyCancelForCancellableTask.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/EmptyCancelForCancellableTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/EmptyStatements.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/EmptyStatements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/EqualsMethodHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/EqualsMethodHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ExportNonAccessibleElement.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ExportNonAccessibleElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/FieldForUnusedParam.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/FieldForUnusedParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/FieldForUnusedParamCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/FieldForUnusedParamCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/HideField.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/HideField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/HideFieldByVar.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/HideFieldByVar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/IllegalInstanceOf.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/IllegalInstanceOf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/Imports.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/Imports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/IncompatibleMask.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/IncompatibleMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/InitializerCanBeStatic.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/InitializerCanBeStatic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/LeakingThisInConstructor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/LeakingThisInConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/LoggerHintsCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/LoggerHintsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/LoggerNotStaticFinal.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/LoggerNotStaticFinal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/MissingHashCode.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/MissingHashCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/MultipleLoggers.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/MultipleLoggers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/NoLoggers.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/NoLoggers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ObsoleteCollection.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ObsoleteCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/OneCheckboxCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/OneCheckboxCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/OrganizeImports.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/OrganizeImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/OrganizeMembers.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/OrganizeMembers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/OverridableMethodCallInConstructor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/OverridableMethodCallInConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/PointlessBitwiseExpression.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/PointlessBitwiseExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/PrintStackTrace.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/PrintStackTrace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/SerialVersionUID.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/SerialVersionUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ShiftOutOfRange.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ShiftOutOfRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/SideEffectVisitor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/SideEffectVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/StandardJavacWarnings.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/StandardJavacWarnings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/StaticAccess.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/StaticAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/StaticImport.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/StaticImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/StaticNonFinalUsedInInitialization.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/StaticNonFinalUsedInInitialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/StopProcessing.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/StopProcessing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/StringBuilderAppend.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/StringBuilderAppend.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/SuspiciousNamesCombination.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/SuspiciousNamesCombination.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/SuspiciousNamesCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/SuspiciousNamesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/SyncOnNonFinal.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/SyncOnNonFinal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/SystemOut.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/SystemOut.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ThisInAnonymous.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ThisInAnonymous.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ThreadDumpStack.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ThreadDumpStack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/UtilityClass.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/UtilityClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/WrongPackageSuggestion.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/WrongPackageSuggestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparison.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparison.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparisonCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparisonCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/AnalyzeFolder.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/AnalyzeFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/Analyzer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/Analyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ProgressDialog.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ProgressDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/AnalyzerTopComponent.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/AnalyzerTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckRenderer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckTreeView.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/FixDescription.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/FixDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/NextError.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/NextError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/Nodes.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/Nodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/PreviousError.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/PreviousError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/AnnotationsNotRuntime.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/AnnotationsNotRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/ArrayStringConversions.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/ArrayStringConversions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/AssertWithSideEffects.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/AssertWithSideEffects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/BoxedIdentityComparison.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/BoxedIdentityComparison.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/BroadCatchBlock.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/BroadCatchBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/BroadCatchCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/BroadCatchCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/CastVSInstanceOf.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/CastVSInstanceOf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/CheckReturnValueHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/CheckReturnValueHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/CloneAndCloneable.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/CloneAndCloneable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/CollectionRemove.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/CollectionRemove.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/ComparatorParameterNotUsed.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/ComparatorParameterNotUsed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/ConfusingVarargsParameter.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/ConfusingVarargsParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/EqualsHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/EqualsHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/InfiniteRecursion.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/InfiniteRecursion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/MalformedFormatString.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/MalformedFormatString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/MalformedXPathExpression.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/MalformedXPathExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/MathRandomCast.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/MathRandomCast.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/Regexp.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/Regexp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/StringBufferCharConstructor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/StringBufferCharConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/SuspiciousToArray.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/SuspiciousToArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/ThrowableNotThrown.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/ThrowableNotThrown.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/TryCatchFinally.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/TryCatchFinally.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/Unbalanced.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/Unbalanced.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/UnusedAssignmentOrBranch.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/UnusedAssignmentOrBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/control/RedundantConditional.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/control/RedundantConditional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/control/RedundantIf.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/control/RedundantIf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/control/RemoveUnnecessary.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/control/RemoveUnnecessary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ClassEncapsulation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ClassEncapsulation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/encapsulation/FieldEncapsulation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/encapsulation/FieldEncapsulation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ParamEncapsulation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ParamEncapsulation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ReturnEncapsulation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ReturnEncapsulation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AbstractMethodCannotHaveBody.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AbstractMethodCannotHaveBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AccessError.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AccessError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AddCast.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AddCast.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AddCastFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AddCastFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AddCatchFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AddCatchFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AddConstructor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AddConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AddOrRemoveFinalModifier.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AddOrRemoveFinalModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ArrayAccess.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ArrayAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodParameters.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodReturnType.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodReturnType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeParametersFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeParametersFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeType.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeTypeFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeTypeFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ClassNameMismatch.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ClassNameMismatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/CreateClassFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/CreateClassFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/CreateEnumConstant.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/CreateEnumConstant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/CreateFieldFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/CreateFieldFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/CreateMethodFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/CreateMethodFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ErrorFixesFakeHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ErrorFixesFakeHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ExtendsImplements.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ExtendsImplements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ExtraCatch.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ExtraCatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/FinalFieldsFromCtorCustomiser.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/FinalFieldsFromCtorCustomiser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethods.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClass.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClassCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClassCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/LocalVariableFixCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/LocalVariableFixCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/MagicSurroundWithTryCatchFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/MagicSurroundWithTryCatchFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/MissingReturnStatement.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/MissingReturnStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/NotInitializedVariable.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/NotInitializedVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/OrigSurroundWithTryCatchFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/OrigSurroundWithTryCatchFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/OverrideWeakerAccess.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/OverrideWeakerAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveInvalidModifier.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveInvalidModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveOverride.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveOverride.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveUselessCast.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveUselessCast.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/RenameConstructor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/RenameConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/SuppressWarningsFixer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/SuppressWarningsFixer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/TypeErroneous.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/TypeErroneous.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/UncaughtException.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/UncaughtException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/errors/VarArgsCast.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/errors/VarArgsCast.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/finalize/CallFinalize.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/finalize/CallFinalize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/finalize/FinalizeDeclared.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/finalize/FinalizeDeclared.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/finalize/FinalizeDoesNotCallSuper.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/finalize/FinalizeDoesNotCallSuper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/finalize/FinalizeNotProtected.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/finalize/FinalizeNotProtected.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/finalize/Util.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/finalize/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/friendapi/OverrideErrorMessage.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/friendapi/OverrideErrorMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/friendapi/SourceChangeUtils.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/friendapi/SourceChangeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixList.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/EmbeddedHintsCollector.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/EmbeddedHintsCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/EmbeddedLazyHintComputation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/EmbeddedLazyHintComputation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsFactory.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorPositionRefresherHelper.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorPositionRefresherHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/HintAction.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/HintAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaUpToDateStateProvider.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaUpToDateStateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaUpToDateStateProviderFactory.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaUpToDateStateProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputationFactory.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/infrastructure/SuppressWarningsCompletion.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/infrastructure/SuppressWarningsCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/CommonMembersPanel.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/CommonMembersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/CopyFinderService.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/CopyFinderService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/FieldValidator.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/FieldValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/Flow.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/Flow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/InstanceRefFinder.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/InstanceRefFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceAction.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceConstantFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceConstantFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldPanel.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFixBase.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFixBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceHintFactory.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceHintFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceKind.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodPanel.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceParameterFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceParameterFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceVariableFix.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceVariableFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/MemberSearchResult.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/MemberSearchResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/MemberValidator.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/MemberValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/MethodCandidateChooser.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/MethodCandidateChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/MethodValidator.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/MethodValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/NameChangeSupport.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/NameChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/PositionRefresherHelperImpl.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/PositionRefresherHelperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/ReferenceTransformer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/ReferenceTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/ScanStatement.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/ScanStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/TargetDescription.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/TargetDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/introduce/TreeUtils.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/introduce/TreeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/FileToURL.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/FileToURL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/ForbiddenMethod.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/ForbiddenMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/LoggerStringConcat.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/LoggerStringConcat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/AddUnderscores.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/AddUnderscores.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/AddUnderscoresPanel.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/AddUnderscoresPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/AnnotationProcessors.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/AnnotationProcessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToARM.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToARM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHintPanel.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHintPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambda.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaConverter.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaPreconditionChecker.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaPreconditionChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToStringSwitch.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToStringSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/IndexOfToContains.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/IndexOfToContains.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/IteratorToFor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/IteratorToFor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/JoinCatches.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/JoinCatches.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ThrowableInitCause.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ThrowableInitCause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/UnnecessaryBoxing.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/UnnecessaryBoxing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/UnnecessaryUnboxing.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/UnnecessaryUnboxing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/UseSpecificCatch.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/UseSpecificCatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/UseSpecificCatchCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/UseSpecificCatchCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/PreconditionsChecker.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/PreconditionsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/ProspectiveOperation.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/ProspectiveOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/Refactorer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/Refactorer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/TreeUtilities.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/TreeUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/BoxingOfBoxingValue.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/BoxingOfBoxingValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/InitialCapacity.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/InitialCapacity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/ManualArrayCopy.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/ManualArrayCopy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/NoBooleanConstructor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/NoBooleanConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/ReplaceBufferByString.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/ReplaceBufferByString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/SizeEqualsZero.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/SizeEqualsZero.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/StringBuffer2Builder.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/StringBuffer2Builder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/project/IncompleteClassPath.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/project/IncompleteClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/resources/ide.css
+++ b/java.hints/src/org/netbeans/modules/java/hints/resources/ide.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/ConstantNameHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/ConstantNameHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/ConstantNameOptions.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/ConstantNameOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/ConvertIfToSwitch.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/ConvertIfToSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/CreateSubclass.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/CreateSubclass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/ExpandEnhancedForLoop.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/ExpandEnhancedForLoop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/ExpectedTypeResolver.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/ExpectedTypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/FillSwitchCustomizer.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/FillSwitchCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/FlipOperands.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/FlipOperands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/IfToSwitchSupport.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/IfToSwitchSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/Ifs.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/Ifs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/ImplementMethods.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/ImplementMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/Move.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/Move.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/NameAndPackagePanel.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/NameAndPackagePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/Tiny.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/Tiny.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/suggestions/TooStrongCast.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/suggestions/TooStrongCast.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/testing/Tiny.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/testing/Tiny.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/threading/Tiny.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/threading/Tiny.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/threading/UnlockOutsideFinally.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/threading/UnlockOutsideFinally.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ui/ClassNameList.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ui/ClassNameList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ui/InnerPanelSupport.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ui/InnerPanelSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/src/org/netbeans/modules/java/hints/ui/TypeAcceptor.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/ui/TypeAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/data/org/netbeans/test/java/hints/introduce/RefFinderTest/Base.java
+++ b/java.hints/test/unit/data/org/netbeans/test/java/hints/introduce/RefFinderTest/Base.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/data/org/netbeans/test/java/hints/introduce/RefFinderTest/Test.java
+++ b/java.hints/test/unit/data/org/netbeans/test/java/hints/introduce/RefFinderTest/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/editor/codegen/ImplementGeneratorAccessor.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/editor/codegen/ImplementGeneratorAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/AddOverrideAnnotationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/AddOverrideAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/AnnotationAsSuperInterfaceTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/AnnotationAsSuperInterfaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ArithmeticUtilitiesTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ArithmeticUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignResultToVariableTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignResultToVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignmentIssuesTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignmentIssuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignmentToItselfTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignmentToItselfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ClassStructureTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ClassStructureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ConvertAnonymousToInnerTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ConvertAnonymousToInnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/DeclarationForInstanceOfTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/DeclarationForInstanceOfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/DoubleCheckTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/DoubleCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/EmptyCancelForCancellableTaskTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/EmptyCancelForCancellableTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/EqualsMethodHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/EqualsMethodHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ExportNonAccessibleElementTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ExportNonAccessibleElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/FieldForUnusedParamTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/FieldForUnusedParamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/HideFieldByVarTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/HideFieldByVarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/HideFieldTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/HideFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/IllegalInstanceOfTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/IllegalInstanceOfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ImportsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/IncompatibleMaskTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/IncompatibleMaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/LeakingThisInConstructorTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/LeakingThisInConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/LoggerNotStaticFinalTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/LoggerNotStaticFinalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/MissingHashCodeTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/MissingHashCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/MultipleLoggersTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/MultipleLoggersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/NoLoggersTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/NoLoggersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/OrganizeImportsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/OrganizeImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/OverridableMethodCallInConstructorTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/OverridableMethodCallInConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/PointlessBitwiseExpressionTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/PointlessBitwiseExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/PrintStackTraceTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/PrintStackTraceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/RemoveEmptyStatementTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/RemoveEmptyStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/SerialVersionUIDTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/SerialVersionUIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ShiftOutOfRangeTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ShiftOutOfRangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticAccessTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticImportTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticNonFinalUsedInInitializationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticNonFinalUsedInInitializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/StringBuilderAppendTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/StringBuilderAppendTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/SuspiciousNamesCombinationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/SuspiciousNamesCombinationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/SyncOnNonFinalTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/SyncOnNonFinalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/SystemOutTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/SystemOutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ThisInAnonymousTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ThisInAnonymousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/ThreadDumpStackTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/ThreadDumpStackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/UtilityClassTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/UtilityClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/WrongPackageSuggestionTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/WrongPackageSuggestionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/WrongStringComparisonTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/WrongStringComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/AnnotationsNotRuntimeTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/AnnotationsNotRuntimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/ArrayStringOperationsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/ArrayStringOperationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/AssertWithSideEffectsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/AssertWithSideEffectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/BoxedIdentityComparisonTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/BoxedIdentityComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/BroadCatchBlockTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/BroadCatchBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CastVSInstanceOfTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CastVSInstanceOfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CheckReturnValueHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CheckReturnValueHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CloneAndCloneableTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CloneAndCloneableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CollectionRemoveTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CollectionRemoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/EqualsHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/EqualsHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/InfiniteRecursionTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/InfiniteRecursionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/MalformedFormatStringTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/MalformedFormatStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/MathRandomCastTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/MathRandomCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/NPECheckTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/NPECheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/RegexpTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/RegexpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/StringBufferCharConstructorTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/StringBufferCharConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/SuspiciousToArrayTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/SuspiciousToArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/ThrowableNotThrownTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/ThrowableNotThrownTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TryCatchFinallyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TryCatchFinallyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedAssignmentOrBranchTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedAssignmentOrBranchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RedundantConditionalTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RedundantConditionalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RedundantIfTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RedundantIfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RemoveUnnecessaryTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RemoveUnnecessaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/ClassEncapsulationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/ClassEncapsulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/FieldEncapsulationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/FieldEncapsulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/ParamEncapsulationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/ParamEncapsulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/ReturnEncapsulationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/encapsulation/ReturnEncapsulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AbstractMethodCannotHaveBodyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AbstractMethodCannotHaveBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AccessErrorTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AccessErrorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddCastTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddCatchFixTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddCatchFixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddConstructorTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddFinalModifierTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddFinalModifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFixTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ArrayAccessTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ArrayAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeMethodParametersTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeMethodParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeMethodReturnTypeTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeMethodReturnTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeTypeTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ClassNameMismatchTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ClassNameMismatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateClass183980Test.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateClass183980Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateClassTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateElementTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateEnumConstantTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateEnumConstantTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateFieldTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateMethodTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ErrorHintsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ErrorHintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ExtendsImplementsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ExtendsImplementsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ExtraCatchTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ExtraCatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethodsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImportClassTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImportClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/MagicSurroundWithTryCatchFixTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/MagicSurroundWithTryCatchFixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/MissingReturnStatementTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/MissingReturnStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/NewImportClassTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/NewImportClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/NewUncaughtExceptionTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/NewUncaughtExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OrigCreateMethodTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OrigCreateMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OrigSurroundWithTryCatchFixTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OrigSurroundWithTryCatchFixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OrigUncaughtExceptionTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OrigUncaughtExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OverrideWeakerAccessTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/OverrideWeakerAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveFinalModifierFromParameterTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveFinalModifierFromParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveFinalModifierFromVariableTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveFinalModifierFromVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveInvalidModifierTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveInvalidModifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveOverrideTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveOverrideTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveUselessCastTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RemoveUselessCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RenameConstructorTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/RenameConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/SuppressWarningsFixerTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/SuppressWarningsFixerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/UncaughtExceptionTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/UncaughtExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/UtilitiesTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/UtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/VarArgsCastTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/VarArgsCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/CallFinalizeTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/CallFinalizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/FinalizeDeclaredTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/FinalizeDeclaredTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/FinalizeDoesNotCallSuperTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/FinalizeDoesNotCallSuperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/FinalizeNotProtectedTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/finalize/FinalizeNotProtectedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixListTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsTestBase.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/HintsTestBase.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/HintsTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/JavaHintsPositionRefresherTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/JavaHintsPositionRefresherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputationTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/TestPreferencesProvider.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/TestPreferencesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/TreeRuleTestBase.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/TreeRuleTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/FlowTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/FlowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/IntroduceHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/IntroduceHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/RefFinderTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/RefFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/LoggerStringConcatTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/LoggerStringConcatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/AddUnderscoresTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/AddUnderscoresTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/AnnotationProcessorsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/AnnotationProcessorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToARMTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToARMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToStringSwitchTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToStringSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/IndexOfToContainsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/IndexOfToContainsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/IteratorToForTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/IteratorToForTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/JoinCatchesTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/JoinCatchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ThrowableInitCauseTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ThrowableInitCauseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/UnnecessaryBoxingTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/UnnecessaryBoxingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/UnnecessaryUnboxingTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/UnnecessaryUnboxingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/UseSpecificCatchTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/UseSpecificCatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/InitialCapacityTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/InitialCapacityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/ManualArrayCopyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/ManualArrayCopyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/NoBooleanConstructorTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/NoBooleanConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/ReplaceBufferByStringTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/ReplaceBufferByStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/SizeEqualsZeroTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/SizeEqualsZeroTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/StringBuffer2BuilderTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/StringBuffer2BuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/TinyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/TinyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ConvertIfToSwitchTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ConvertIfToSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/CreateSubclassTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/CreateSubclassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ExpandEnhancedForLoopTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ExpandEnhancedForLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/FlipOperandsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/FlipOperandsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/IfsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/IfsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ImplementMethodsTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ImplementMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/LambdaTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/LambdaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/MoveTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/MoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/TinyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/TinyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/TooStrongCastTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/TooStrongCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/testing/TinyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/testing/TinyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/threading/TinyTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/threading/TinyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployActionProvider.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployGeneratedFilesInterceptor.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployGeneratedFilesInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployProjectOpenHook.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployProjectOpenHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployProperties.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/NativeBundleType.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/NativeBundleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/api/J2SEDeployConstants.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/api/J2SEDeployConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/ui/CreateBundleAction.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/ui/CreateBundleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/ui/JSEDeploymentCategoryProvider.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/ui/JSEDeploymentCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/ui/JSEDeploymentPanel.java
+++ b/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/ui/JSEDeploymentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/jreprobe/org/netbeans/modules/java/j2seembedded/wizard/JREProbe.java
+++ b/java.j2seembedded/jreprobe/org/netbeans/modules/java/j2seembedded/wizard/JREProbe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/ConnectionMethod.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/ConnectionMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatform.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatformNode.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatformNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatformProbe.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatformProbe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatformProvider.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/platform/RemotePlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteBuildPropertiesProvider.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteBuildPropertiesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteGeneratedFilesInterceptor.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteGeneratedFilesInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteJavaAntLogger.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteJavaAntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemotePlatformProjectSaver.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemotePlatformProjectSaver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteProjectOpenHook.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteProjectOpenHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteRuntimePlatformProvider.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/RemoteRuntimePlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/Utilities.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/ui/CreateJREPanel.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/ui/CreateJREPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/wizard/RemotePlatformInstall.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/wizard/RemotePlatformInstall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/wizard/RemotePlatformIt.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/wizard/RemotePlatformIt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/wizard/SetUpRemotePlatform.java
+++ b/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/wizard/SetUpRemotePlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/CoSAwareFileBuiltQueryImpl.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/CoSAwareFileBuiltQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularPersistenceProvider.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularPersistenceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularProject.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularProjectGenerator.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularProjectUtil.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularProjectUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/MainClassUpdater.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/MainClassUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ProjectPlatformProviderImpl.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ProjectPlatformProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/UpdateProjectImpl.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/UpdateProjectImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/ModuleNodeFactory.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/ModuleNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/AddAnnotationProcessor.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/AddAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/AddProcessorOption.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/AddProcessorOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerApplication.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerCompile.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerCompile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerJar.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerJar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerJavadoc.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerJavadoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerLibraries.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerLibraries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerProviderImpl.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerRun.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerRun.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerSources.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SECompositePanelProvider.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SECompositePanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/PathsCustomizer.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/PathsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/package-info.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/package-info.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/ModuleTargetChooserPanel.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/ModuleTargetChooserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/ModuleTargetChooserPanelGUI.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/ModuleTargetChooserPanelGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/NewJ2SEModularProjectWizardIterator.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/NewJ2SEModularProjectWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/NewModuleWizardIterator.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/NewModuleWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelConfigureProject.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelConfigureProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelConfigureProjectVisual.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelConfigureProjectVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelOptionsVisual.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelOptionsVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelProjectLocationVisual.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelProjectLocationVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/SettingsPanel.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/SettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/WizardSettings.java
+++ b/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/WizardSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/probesrc/org/netbeans/modules/java/j2seplatform/wizard/SDKProbe.java
+++ b/java.j2seplatform/probesrc/org/netbeans/modules/java/j2seplatform/wizard/SDKProbe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/J2SEInstallImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/J2SEInstallImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/J2SEPlatformModule.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/J2SEPlatformModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/J2SEPlatformWarmUp.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/J2SEPlatformWarmUp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/UpdateLogger.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/UpdateLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/UpdateTask.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/UpdateTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/api/J2SEPlatformCreator.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/api/J2SEPlatformCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryClassPathProvider.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceForBinaryQuery.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceJavadocAttacher.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceJavadocAttacher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceLevelQueryImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryTypeProvider.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizer.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/JavadocForBinaryQueryLibraryImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/JavadocForBinaryQueryLibraryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/VolumeContentModel.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/VolumeContentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/BrokenPlatformCustomizer.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/BrokenPlatformCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultPlatformImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultPlatformImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultPlatformImplBeanInfo.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultPlatformImplBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/FileObjectPropertyEditor.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/FileObjectPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformCustomizer.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultSourcesImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultSourcesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformFactory.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformImplBeanInfo.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformImplBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformNode.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformSourceJavadocAttacher.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformSourceJavadocAttacher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformSourceLevelQueryImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformSourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/PlatformConvertor.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/PlatformConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/Util.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTArchiveRootProvider.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTArchiveRootProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTFileSystem.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTFileSystemProvider.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTFileSystemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTURLMapper.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTURLStreamHandler.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTURLStreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTUtil.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultClassPathProvider.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultJavadocForBinaryQuery.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultJavadocForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceForBinaryQuery.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceJavadocAttacher.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceJavadocAttacher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceLevelQueryImpl.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/QueriesCache.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/QueriesCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SelectRootsPanel.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SelectRootsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/spi/J2SEPlatformDefaultJavadoc.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/spi/J2SEPlatformDefaultJavadoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/spi/J2SEPlatformDefaultSources.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/spi/J2SEPlatformDefaultSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/DetectPanel.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/DetectPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/J2SEWizardIterator.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/J2SEWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/NewJ2SEPlatform.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/NewJ2SEPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataLoader.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataLoaderBeanInfo.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataNode.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataObject.java
+++ b/java.j2seplatform/src/org/netbeans/modules/java/jarloader/JarDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/J2SEPlatformModuleTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/J2SEPlatformModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizerTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/JavadocForBinaryQueryLibraryImplTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/JavadocForBinaryQueryLibraryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/SourceForBinaryQueryLibraryImplTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/SourceForBinaryQueryLibraryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/TestLibraryProviderImpl.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/TestLibraryProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultClassPathProviderTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultClassPathProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultSourceLevelQueryImplTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultSourceLevelQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformJavadocForBinaryQueryTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformJavadocForBinaryQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/JavaPlatformProviderImpl.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/JavaPlatformProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTFileSystemTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTURLMapperTest.java
+++ b/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/jrtfs/NBJRTURLMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seprofiles/src/org/netbeans/modules/java/j2seprofiles/ProfilesAnalyzer.java
+++ b/java.j2seprofiles/src/org/netbeans/modules/java/j2seprofiles/ProfilesAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seprofiles/src/org/netbeans/modules/java/j2seprofiles/ProfilesCustomizer.java
+++ b/java.j2seprofiles/src/org/netbeans/modules/java/j2seprofiles/ProfilesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seprofiles/src/org/netbeans/modules/java/j2seprofiles/ProfilesCustomizerProvider.java
+++ b/java.j2seprofiles/src/org/netbeans/modules/java/j2seprofiles/ProfilesCustomizerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/copylibstask/CopyFiles.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/copylibstask/CopyFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/copylibstask/CopyLibs.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/copylibstask/CopyLibs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/ModuleMainClass.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/ModuleMainClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/Attribute.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/ClassFile.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/ClassFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/ConstantPool.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/ConstantPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/FieldInfo.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/FieldInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/MethodInfo.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/MethodInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/Reader.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/Reader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/Writer.java
+++ b/java.j2seproject/copylibstask/src/org/netbeans/modules/java/j2seproject/moduletask/classfile/Writer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/copylibstask/test/org/netbeans/modules/java/j2seproject/moduletask/ModuleMainClassTest.java
+++ b/java.j2seproject/copylibstask/test/org/netbeans/modules/java/j2seproject/moduletask/ModuleMainClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEActionProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEPersistenceProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEPersistenceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProject.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProjectGenerator.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProjectPlatformImpl.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProjectPlatformImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProjectUtil.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEProjectUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/MainClassUpdater.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/MainClassUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/UpdateProjectImpl.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/UpdateProjectImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEBuildPropertiesProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEBuildPropertiesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SECategoryExtensionProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SECategoryExtensionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SECustomPropertySaver.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SECustomPropertySaver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectBuilder.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectConfigurations.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectConfigurations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectPlatform.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEPropertyEvaluator.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SEPropertyEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SERunConfigProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SERunConfigProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SERuntimePlatformProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/api/J2SERuntimePlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/problems/ModulePathsProblemsProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/problems/ModulePathsProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/problems/ResolveBrokenRuntimePlatform.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/problems/ResolveBrokenRuntimePlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/problems/RuntimePlatformProblemsProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/problems/RuntimePlatformProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/LibrariesNodeFactory.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/LibrariesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/AddAnnotationProcessor.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/AddAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/AddProcessorOption.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/AddProcessorOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerApplication.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerCompile.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerCompile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerJar.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerJar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerJavadoc.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerJavadoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerLibraries.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerLibraries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerProviderImpl.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerRun.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerRun.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerSources.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SECompositePanelProvider.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SECompositePanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/PathsCustomizer.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/PathsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/package-info.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/package-info.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/ImportFoldersPanel.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/ImportFoldersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/J2SEFileWizardIterator.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/J2SEFileWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/MoveToModulePathPanel.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/MoveToModulePathPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/MoveToModulePathPanelGUI.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/MoveToModulePathPanelGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/NewJ2SEProjectWizardIterator.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/NewJ2SEProjectWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelConfigureProject.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelConfigureProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelConfigureProjectVisual.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelConfigureProjectVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelIncludesExcludes.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelIncludesExcludes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelOptionsVisual.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelOptionsVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationExtSrc.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationExtSrc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationVisual.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelSourceFolders.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelSourceFolders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/SettingsPanel.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/SettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/WizardSettings.java
+++ b/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/WizardSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/qa-functional/src/gui/projects/Labels.java
+++ b/java.j2seproject/test/qa-functional/src/gui/projects/Labels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/qa-functional/src/gui/projects/ProjectsBasicsTest.java
+++ b/java.j2seproject/test/qa-functional/src/gui/projects/ProjectsBasicsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/junit/ide/ProjectSupport.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/junit/ide/ProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/junit/ide/ProjectSupportTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/junit/ide/ProjectSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/BuildImplTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/BuildImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEActionProviderTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEActionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEConfigurationProviderTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEConfigurationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEPersistenceProviderTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEPersistenceProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEProjectGeneratorTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEProjectGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEProjectTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SESharabilityQueryTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SESharabilityQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SESourcesTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SESourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ProjectPlatformTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ProjectPlatformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/SourceRootsTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/SourceRootsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SECategoryExtensionProviderTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SECategoryExtensionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SECustomPropertySaverTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SECustomPropertySaverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectConfigurationsTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectConfigurationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectPlatformTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/api/J2SEProjectPlatformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/applet/AppletSupportTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/applet/AppletSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/classpath/BootClassPathImplementationTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/classpath/BootClassPathImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/classpath/J2SEProjectClassPathModifierTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/classpath/J2SEProjectClassPathModifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/classpath/SourcePathImplementationTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/classpath/SourcePathImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/BinaryForSourceQueryImplTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/BinaryForSourceQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/CompiledSourceForBinaryQueryTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/CompiledSourceForBinaryQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/FileEncodingQueryTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/FileEncodingQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/SourceLevelQueryImplTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/SourceLevelQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/UnitTestForSourceQueryImplTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/UnitTestForSourceQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectPropertiesTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelOptionsVisualTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelOptionsVisualTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelSourceFoldersTest.java
+++ b/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelSourceFoldersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.kit/test/qa-functional/src/org/netbeans/test/ide/IDECommitValidationTest.java
+++ b/java.kit/test/qa-functional/src/org/netbeans/test/ide/IDECommitValidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.kit/test/qa-functional/src/org/netbeans/test/ide/IDEValidation.java
+++ b/java.kit/test/qa-functional/src/org/netbeans/test/ide/IDEValidation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.kit/test/qa-functional/src/org/netbeans/test/ide/MemoryValidationTest.java
+++ b/java.kit/test/qa-functional/src/org/netbeans/test/ide/MemoryValidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.kit/test/qa-functional/src/org/netbeans/test/ide/WatchProjects.java
+++ b/java.kit/test/qa-functional/src/org/netbeans/test/ide/WatchProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/src/org/netbeans/api/java/lexer/JavaStringTokenId.java
+++ b/java.lexer/src/org/netbeans/api/java/lexer/JavaStringTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/src/org/netbeans/api/java/lexer/JavaTokenId.java
+++ b/java.lexer/src/org/netbeans/api/java/lexer/JavaTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/src/org/netbeans/api/java/lexer/JavadocTokenId.java
+++ b/java.lexer/src/org/netbeans/api/java/lexer/JavadocTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/src/org/netbeans/lib/java/lexer/JavaCharacterTokenId.java
+++ b/java.lexer/src/org/netbeans/lib/java/lexer/JavaCharacterTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
+++ b/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/src/org/netbeans/lib/java/lexer/JavaStringLexer.java
+++ b/java.lexer/src/org/netbeans/lib/java/lexer/JavaStringLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/src/org/netbeans/lib/java/lexer/JavadocLexer.java
+++ b/java.lexer/src/org/netbeans/lib/java/lexer/JavadocLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaFlyTokensTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaFlyTokensTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLanguageTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLanguageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerPerformanceTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerRandomTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaStringLexerTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaStringLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaTokenDumpTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaTokenDumpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavadocLexerRandomTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavadocLexerRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavadocLexerTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavadocLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/ClassMetrics.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/ClassMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/ComplexArithmeticExpression.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/ComplexArithmeticExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/ComplexLogicalExpression.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/ComplexLogicalExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/CyclomaticComplexityVisitor.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/CyclomaticComplexityVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/DeclaredTypeCollector.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/DeclaredTypeCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/DependencyCollector.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/DependencyCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/DepthVisitor.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/DepthVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/ExpressionVisitor.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/ExpressionVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/MethodMetrics.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/MethodMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/src/org/netbeans/modules/java/metrics/hints/NCLOCVisitor.java
+++ b/java.metrics/src/org/netbeans/modules/java/metrics/hints/NCLOCVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/CoupledEnum.java
+++ b/java.metrics/test/unit/data/hints/metrics/CoupledEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/CoupledException.java
+++ b/java.metrics/test/unit/data/hints/metrics/CoupledException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/FullBranch.java
+++ b/java.metrics/test/unit/data/hints/metrics/FullBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodCount.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodCount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodCountAbstract.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodCountAbstract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodCountLess.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodCountLess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodCoupled.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodCoupled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodLimits.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodLimits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodNoReturn.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodNoReturn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodNotCoupled.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodNotCoupled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodNotTooComplex.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodNotTooComplex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodNotTooDeep.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodNotTooDeep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodReturn.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodReturn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodTooComplex.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodTooComplex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/MethodTooDeep.java
+++ b/java.metrics/test/unit/data/hints/metrics/MethodTooDeep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/NoMethodLimits.java
+++ b/java.metrics/test/unit/data/hints/metrics/NoMethodLimits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/NotTooManyLinesOrCommands.java
+++ b/java.metrics/test/unit/data/hints/metrics/NotTooManyLinesOrCommands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/data/hints/metrics/TooManyLinesOrCommands.java
+++ b/java.metrics/test/unit/data/hints/metrics/TooManyLinesOrCommands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/src/org/netbeans/modules/java/metrics/hints/ClassMetricsTest.java
+++ b/java.metrics/test/unit/src/org/netbeans/modules/java/metrics/hints/ClassMetricsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.metrics/test/unit/src/org/netbeans/modules/java/metrics/hints/MethodMetricsTest.java
+++ b/java.metrics/test/unit/src/org/netbeans/modules/java/metrics/hints/MethodMetricsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.module.graph/src/org/netbeans/modules/java/module/graph/DependencyCalculator.java
+++ b/java.module.graph/src/org/netbeans/modules/java/module/graph/DependencyCalculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.module.graph/src/org/netbeans/modules/java/module/graph/DependencyEdge.java
+++ b/java.module.graph/src/org/netbeans/modules/java/module/graph/DependencyEdge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.module.graph/src/org/netbeans/modules/java/module/graph/GraphMultiViewDescription.java
+++ b/java.module.graph/src/org/netbeans/modules/java/module/graph/GraphMultiViewDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.module.graph/src/org/netbeans/modules/java/module/graph/GraphTopComponent.java
+++ b/java.module.graph/src/org/netbeans/modules/java/module/graph/GraphTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.module.graph/src/org/netbeans/modules/java/module/graph/Install.java
+++ b/java.module.graph/src/org/netbeans/modules/java/module/graph/Install.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.module.graph/src/org/netbeans/modules/java/module/graph/ModuleNode.java
+++ b/java.module.graph/src/org/netbeans/modules/java/module/graph/ModuleNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.module.graph/test/unit/src/org/netbeans/modules/java/module/graph/DependencyCalculatorTest.java
+++ b/java.module.graph/test/unit/src/org/netbeans/modules/java/module/graph/DependencyCalculatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/BreadCrumbsNodeImpl.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/BreadCrumbsNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/BreadCrumbsScanningTask.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/BreadCrumbsScanningTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/CaretListeningFactory.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/CaretListeningFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/CaretListeningTask.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/CaretListeningTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberFilters.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberFilters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberNavigatorJavaSourceFactory.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberNavigatorJavaSourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanel.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/DocumentationScrollPane.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/DocumentationScrollPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/ElementNode.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/ElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/ElementScanningTask.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/ElementScanningTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/HTMLDocView.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/HTMLDocView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/JavadocTopComponent.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/JavadocTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/NoBorderToolBar.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/NoBorderToolBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/ToolTipManagerEx.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/ToolTipManagerEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/AbstractNavigationAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/AbstractNavigationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/FilterSubmenuAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/FilterSubmenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/JavadocAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/JavadocAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/NameActions.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/NameActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/OpenAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/OpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowHierarchyAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowHierarchyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowHierarchyAtCaretAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowHierarchyAtCaretAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowMembersAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowMembersAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowMembersAtCaretAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/ShowMembersAtCaretAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/actions/SortActions.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/actions/SortActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/Filters.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/Filters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/FiltersDescription.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/FiltersDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/FiltersManager.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/FiltersManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/HistorySupport.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/HistorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/Icons.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/Icons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/ModelBusyListener.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/ModelBusyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/Resolvers.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/Resolvers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/SelectJavadocTask.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/SelectJavadocTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/TapPanel.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/TapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/TooltipHack.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/TooltipHack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/TrivialLayout.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/TrivialLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/base/Utils.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/base/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/hierarchy/HierarchyFilters.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/hierarchy/HierarchyFilters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/hierarchy/HierarchyTopComponent.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/hierarchy/HierarchyTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/hierarchy/Nodes.java
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/hierarchy/Nodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/navigation/resources/ide.css
+++ b/java.navigation/src/org/netbeans/modules/java/navigation/resources/ide.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
+++ b/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackAction.java
+++ b/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackTopComponent.java
+++ b/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
+++ b/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/test/unit/src/org/netbeans/modules/java/navigation/BreadCrumbsNodeImplTest.java
+++ b/java.navigation/test/unit/src/org/netbeans/modules/java/navigation/BreadCrumbsNodeImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/test/unit/src/org/netbeans/modules/java/navigation/ElementNodeTest.java
+++ b/java.navigation/test/unit/src/org/netbeans/modules/java/navigation/ElementNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
+++ b/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/api/java/platform/PlatformsCustomizer.java
+++ b/java.platform.ui/src/org/netbeans/api/java/platform/PlatformsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/DefaultJavaPlatformProvider.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/DefaultJavaPlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/InstallerRegistry.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/InstallerRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/PlatformSettings.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/PlatformSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizer.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizerAction.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/LocationChooser.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/LocationChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/PlatformInstallIterator.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/PlatformInstallIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/SelectorPanel.java
+++ b/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/SelectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/spi/java/platform/CustomPlatformInstall.java
+++ b/java.platform.ui/src/org/netbeans/spi/java/platform/CustomPlatformInstall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/spi/java/platform/GeneralPlatformInstall.java
+++ b/java.platform.ui/src/org/netbeans/spi/java/platform/GeneralPlatformInstall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/src/org/netbeans/spi/java/platform/PlatformInstall.java
+++ b/java.platform.ui/src/org/netbeans/spi/java/platform/PlatformInstall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/ConvertAsJavaBeanPlatformTest.java
+++ b/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/ConvertAsJavaBeanPlatformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/DefaultJavaPlatformProviderTest.java
+++ b/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/DefaultJavaPlatformProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/InstallerRegistryAccessor.java
+++ b/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/InstallerRegistryAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/PlatformInstallTest.java
+++ b/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/PlatformInstallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/wizard/PlatformInstallIteratorTest.java
+++ b/java.platform.ui/test/unit/src/org/netbeans/modules/java/platform/wizard/PlatformInstallIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/api/java/platform/JavaPlatform.java
+++ b/java.platform/src/org/netbeans/api/java/platform/JavaPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/api/java/platform/JavaPlatformManager.java
+++ b/java.platform/src/org/netbeans/api/java/platform/JavaPlatformManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/api/java/platform/Profile.java
+++ b/java.platform/src/org/netbeans/api/java/platform/Profile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/api/java/platform/Specification.java
+++ b/java.platform/src/org/netbeans/api/java/platform/Specification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/modules/java/platform/FallbackDefaultJavaPlatform.java
+++ b/java.platform/src/org/netbeans/modules/java/platform/FallbackDefaultJavaPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/modules/java/platform/classpath/PlatformClassPathProvider.java
+++ b/java.platform/src/org/netbeans/modules/java/platform/classpath/PlatformClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/modules/java/platform/implspi/JavaPlatformProvider.java
+++ b/java.platform/src/org/netbeans/modules/java/platform/implspi/JavaPlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/modules/java/platform/implspi/package-info.java
+++ b/java.platform/src/org/netbeans/modules/java/platform/implspi/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformJavadocForBinaryQuery.java
+++ b/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformJavadocForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQuery.java
+++ b/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/modules/java/platform/util/FileNameUtil.java
+++ b/java.platform/src/org/netbeans/modules/java/platform/util/FileNameUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/spi/java/platform/JavaPlatformFactory.java
+++ b/java.platform/src/org/netbeans/spi/java/platform/JavaPlatformFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/src/org/netbeans/spi/java/platform/support/ForwardingJavaPlatform.java
+++ b/java.platform/src/org/netbeans/spi/java/platform/support/ForwardingJavaPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/test/unit/src/org/netbeans/api/java/platform/JavaPlatformManagerTest.java
+++ b/java.platform/test/unit/src/org/netbeans/api/java/platform/JavaPlatformManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/test/unit/src/org/netbeans/api/java/platform/TestJavaPlatformProvider.java
+++ b/java.platform/test/unit/src/org/netbeans/api/java/platform/TestJavaPlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/test/unit/src/org/netbeans/modules/java/platform/queries/PlatformJavadocForBinaryQueryTest.java
+++ b/java.platform/test/unit/src/org/netbeans/modules/java/platform/queries/PlatformJavadocForBinaryQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/test/unit/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQueryTest.java
+++ b/java.platform/test/unit/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.platform/test/unit/src/org/netbeans/modules/java/platform/queries/TestJavaPlatform.java
+++ b/java.platform/test/unit/src/org/netbeans/modules/java/platform/queries/TestJavaPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/JavaSourceUtilImplAccessor.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/JavaSourceUtilImplAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/api/CompileOnSaveActionQuery.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/api/CompileOnSaveActionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/api/JavaSourceUtil.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/api/JavaSourceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/api/ModuleUtilities.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/api/ModuleUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/CompileOnSaveAction.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/CompileOnSaveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/ImportProcessor.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/ImportProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaFileFilterImplementation.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaFileFilterImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaIndexerPlugin.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaIndexerPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaSourceProvider.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaSourceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaSourceUtilImpl.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/JavaSourceUtilImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/VirtualSourceProvider.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/VirtualSourceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/WrapperFactory.java
+++ b/java.preprocessorbridge/src/org/netbeans/modules/java/preprocessorbridge/spi/WrapperFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.preprocessorbridge/test/unit/src/org/netbeans/modules/java/preprocessorbridge/api/CompileOnSaveActionQueryTest.java
+++ b/java.preprocessorbridge/test/unit/src/org/netbeans/modules/java/preprocessorbridge/api/CompileOnSaveActionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/api/java/project/runner/JavaRunner.java
+++ b/java.project.ui/src/org/netbeans/api/java/project/runner/JavaRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/ChangePackageViewTypeAction.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/ChangePackageViewTypeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/FixPlatform.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/FixPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/FixProfile.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/FixProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/FixProjectSourceLevel.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/FixProjectSourceLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaAntLogger.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaAntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaProjectSettings.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaProjectSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanel.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanelGUI.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanelGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/PackageDisplayUtils.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/PackageDisplayUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/ProfileProblemsProviderImpl.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/ProfileProblemsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/modules/java/project/ui/ProjectProblemsProviders.java
+++ b/java.project.ui/src/org/netbeans/modules/java/project/ui/ProjectProblemsProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/runner/JavaRunnerImplementation.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/runner/JavaRunnerImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/BrokenReferencesSupport.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/BrokenReferencesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/EditJarPanel.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/EditJarPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/EditJarSupport.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/EditJarSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/IncludeExcludeVisualizer.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/IncludeExcludeVisualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/IncludeExcludeVisualizerPanel.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/IncludeExcludeVisualizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableVisualPanel1.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableVisualPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableVisualPanel2.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableVisualPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableWizardPanel1.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableWizardPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableWizardPanel2.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/MakeSharableWizardPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageRenameHandler.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageRenameHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageRootNode.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageView.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageViewChildren.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageViewChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/SharableLibrariesUtils.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/SharableLibrariesUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/TreeRootNode.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/TreeRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/templates/JavaFileWizardIteratorFactory.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/templates/JavaFileWizardIteratorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/src/org/netbeans/spi/java/project/support/ui/templates/JavaTemplates.java
+++ b/java.project.ui/src/org/netbeans/spi/java/project/support/ui/templates/JavaTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/data/freeform1/src/org/netbeans/test/FreeFormMain.java
+++ b/java.project.ui/test/qa-functional/data/freeform1/src/org/netbeans/test/FreeFormMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/data/freeform1/test/org/netbeans/test/FreeFormMainTest.java
+++ b/java.project.ui/test/qa-functional/data/freeform1/test/org/netbeans/test/FreeFormMainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/data/srcroot1/examples/texteditor/About.java
+++ b/java.project.ui/test/qa-functional/data/srcroot1/examples/texteditor/About.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/data/srcroot1/examples/texteditor/Finder.java
+++ b/java.project.ui/test/qa-functional/data/srcroot1/examples/texteditor/Finder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/data/srcroot1/examples/texteditor/Ted.java
+++ b/java.project.ui/test/qa-functional/data/srcroot1/examples/texteditor/Ted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/src/projects/LibrariesTest.java
+++ b/java.project.ui/test/qa-functional/src/projects/LibrariesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/src/projects/PlatformsTest.java
+++ b/java.project.ui/test/qa-functional/src/projects/PlatformsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/src/projects/TestProjectUtils.java
+++ b/java.project.ui/test/qa-functional/src/projects/TestProjectUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/src/projects/apitest/CreateProjectTest.java
+++ b/java.project.ui/test/qa-functional/src/projects/apitest/CreateProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/src/projects/apitest/ProjectOpenListener.java
+++ b/java.project.ui/test/qa-functional/src/projects/apitest/ProjectOpenListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/qa-functional/src/projects/apitest/Utilities.java
+++ b/java.project.ui/test/qa-functional/src/projects/apitest/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/data/simple-app/src/simpleapp/Clazz.java
+++ b/java.project.ui/test/unit/data/simple-app/src/simpleapp/Clazz.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/data/simple-app/src/simpleapp/Main.java
+++ b/java.project.ui/test/unit/data/simple-app/src/simpleapp/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/data/simple-app/test/simpleapp/ClazzTest.java
+++ b/java.project.ui/test/unit/data/simple-app/test/simpleapp/ClazzTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/src/org/netbeans/modules/java/project/ui/JavaAntLoggerTest.java
+++ b/java.project.ui/test/unit/src/org/netbeans/modules/java/project/ui/JavaAntLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanelTest.java
+++ b/java.project.ui/test/unit/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/src/org/netbeans/spi/java/project/support/ui/PackageRenameHandlerTest.java
+++ b/java.project.ui/test/unit/src/org/netbeans/spi/java/project/support/ui/PackageRenameHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/src/org/netbeans/spi/java/project/support/ui/PackageViewTest.java
+++ b/java.project.ui/test/unit/src/org/netbeans/spi/java/project/support/ui/PackageViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project.ui/test/unit/src/org/netbeans/spi/java/project/support/ui/templates/JavaTemplatesTest.java
+++ b/java.project.ui/test/unit/src/org/netbeans/spi/java/project/support/ui/templates/JavaTemplatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/api/java/project/JavaProjectConstants.java
+++ b/java.project/src/org/netbeans/api/java/project/JavaProjectConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/api/java/project/classpath/ProjectClassPathModifier.java
+++ b/java.project/src/org/netbeans/api/java/project/classpath/ProjectClassPathModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ExtraProjectJavadocForBinaryQueryImpl.java
+++ b/java.project/src/org/netbeans/modules/java/project/ExtraProjectJavadocForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ExtraProjectSourceForBinaryQueryImpl.java
+++ b/java.project/src/org/netbeans/modules/java/project/ExtraProjectSourceForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/JavadocForBinaryQueryImpl.java
+++ b/java.project/src/org/netbeans/modules/java/project/JavadocForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectAccessibilityQuery.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectAccessibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectAccessibilityQuery2.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectAccessibilityQuery2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectAnnotationProcessingQueryImpl.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectAnnotationProcessingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectBinaryForSourceQuery.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectBinaryForSourceQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectClassPathProvider.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectCompilerOptionsQueryImplementation.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectCompilerOptionsQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectSourceForBinaryQuery.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectSourceForBinaryQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectSourceLevelQueryImpl.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectSourceLevelQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/ProjectSourceLevelQueryImpl2.java
+++ b/java.project/src/org/netbeans/modules/java/project/ProjectSourceLevelQueryImpl2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/UnitTestForSourceQueryImpl.java
+++ b/java.project/src/org/netbeans/modules/java/project/UnitTestForSourceQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/classpath/ClassPathModifierLookupMerger.java
+++ b/java.project/src/org/netbeans/modules/java/project/classpath/ClassPathModifierLookupMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/modules/java/project/classpath/ProjectClassPathModifierAccessor.java
+++ b/java.project/src/org/netbeans/modules/java/project/classpath/ProjectClassPathModifierAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/classpath/ProjectClassPathExtender.java
+++ b/java.project/src/org/netbeans/spi/java/project/classpath/ProjectClassPathExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/classpath/ProjectClassPathModifierImplementation.java
+++ b/java.project/src/org/netbeans/spi/java/project/classpath/ProjectClassPathModifierImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/classpath/ProjectModulesModifier.java
+++ b/java.project/src/org/netbeans/spi/java/project/classpath/ProjectModulesModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/classpath/support/ProjectClassPathImplementation.java
+++ b/java.project/src/org/netbeans/spi/java/project/classpath/support/ProjectClassPathImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/classpath/support/ProjectClassPathSupport.java
+++ b/java.project/src/org/netbeans/spi/java/project/classpath/support/ProjectClassPathSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/support/ClassPathProviderMerger.java
+++ b/java.project/src/org/netbeans/spi/java/project/support/ClassPathProviderMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/support/CompilerOptionsQueryMerger.java
+++ b/java.project/src/org/netbeans/spi/java/project/support/CompilerOptionsQueryMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/support/ExtraSourceJavadocSupport.java
+++ b/java.project/src/org/netbeans/spi/java/project/support/ExtraSourceJavadocSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/support/JavadocAndSourceRootDetection.java
+++ b/java.project/src/org/netbeans/spi/java/project/support/JavadocAndSourceRootDetection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/support/LookupMergerSupport.java
+++ b/java.project/src/org/netbeans/spi/java/project/support/LookupMergerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/support/PreferredProjectPlatform.java
+++ b/java.project/src/org/netbeans/spi/java/project/support/PreferredProjectPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/src/org/netbeans/spi/java/project/support/ProjectPlatform.java
+++ b/java.project/src/org/netbeans/spi/java/project/support/ProjectPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/test/unit/src/org/netbeans/spi/java/project/classpath/support/ProjectClassPathImplementationTest.java
+++ b/java.project/test/unit/src/org/netbeans/spi/java/project/classpath/support/ProjectClassPathImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/test/unit/src/org/netbeans/spi/java/project/support/ClassPathProviderMergerTest.java
+++ b/java.project/test/unit/src/org/netbeans/spi/java/project/support/ClassPathProviderMergerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/test/unit/src/org/netbeans/spi/java/project/support/CompilerOptionsQueryMergerTest.java
+++ b/java.project/test/unit/src/org/netbeans/spi/java/project/support/CompilerOptionsQueryMergerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/test/unit/src/org/netbeans/spi/java/project/support/JavadocAndSourceRootDetectionTest.java
+++ b/java.project/test/unit/src/org/netbeans/spi/java/project/support/JavadocAndSourceRootDetectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.project/test/unit/src/org/netbeans/spi/java/project/support/PreferredProjectPlatformTest.java
+++ b/java.project/test/unit/src/org/netbeans/spi/java/project/support/PreferredProjectPlatformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/CosUpdated.java
+++ b/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/CosUpdated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/DeleteTask.java
+++ b/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/DeleteTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/JavacTask.java
+++ b/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/JavacTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/TranslateClassPath.java
+++ b/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/TranslateClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/UserCancel.java
+++ b/java.source.ant/antsrc/org/netbeans/modules/java/source/ant/UserCancel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/src/org/netbeans/modules/java/source/ant/CheckForCleanBuilds.java
+++ b/java.source.ant/src/org/netbeans/modules/java/source/ant/CheckForCleanBuilds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
+++ b/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.ant/test/unit/src/org/netbeans/modules/java/source/ant/ProjectRunnerImplTest.java
+++ b/java.source.ant/test/unit/src/org/netbeans/modules/java/source/ant/ProjectRunnerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/AssignComments.java
+++ b/java.source.base/src/org/netbeans/api/java/source/AssignComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/BuildArtifactMapper.java
+++ b/java.source.base/src/org/netbeans/api/java/source/BuildArtifactMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/CancellableTask.java
+++ b/java.source.base/src/org/netbeans/api/java/source/CancellableTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/ClassIndexListener.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ClassIndexListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/ClasspathInfo.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ClasspathInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
+++ b/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/CodeStyleUtils.java
+++ b/java.source.base/src/org/netbeans/api/java/source/CodeStyleUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/Comment.java
+++ b/java.source.base/src/org/netbeans/api/java/source/Comment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/CommentCollector.java
+++ b/java.source.base/src/org/netbeans/api/java/source/CommentCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/CompilationController.java
+++ b/java.source.base/src/org/netbeans/api/java/source/CompilationController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/CompilationInfo.java
+++ b/java.source.base/src/org/netbeans/api/java/source/CompilationInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/DocTreePathHandle.java
+++ b/java.source.base/src/org/netbeans/api/java/source/DocTreePathHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/ElementUtilities.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ElementUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/JavaParserResultTask.java
+++ b/java.source.base/src/org/netbeans/api/java/source/JavaParserResultTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
+++ b/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/JavaSourceTaskFactory.java
+++ b/java.source.base/src/org/netbeans/api/java/source/JavaSourceTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/PositionConverter.java
+++ b/java.source.base/src/org/netbeans/api/java/source/PositionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/RootsEvent.java
+++ b/java.source.base/src/org/netbeans/api/java/source/RootsEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/ScanUtils.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ScanUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/Task.java
+++ b/java.source.base/src/org/netbeans/api/java/source/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/TranslateIdentifier.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TranslateIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/TypeMirrorHandle.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TypeMirrorHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/TypesEvent.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TypesEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
+++ b/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/matching/Matcher.java
+++ b/java.source.base/src/org/netbeans/api/java/source/matching/Matcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/matching/Occurrence.java
+++ b/java.source.base/src/org/netbeans/api/java/source/matching/Occurrence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/matching/Pattern.java
+++ b/java.source.base/src/org/netbeans/api/java/source/matching/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreePathScanner.java
+++ b/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreePathScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreeScanner.java
+++ b/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreeScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/support/ProfileSupport.java
+++ b/java.source.base/src/org/netbeans/api/java/source/support/ProfileSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/api/java/source/support/ReferencesCount.java
+++ b/java.source.base/src/org/netbeans/api/java/source/support/ReferencesCount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/ElementHandleAccessor.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/ElementHandleAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/FileObjectFromTemplateCreator.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/FileObjectFromTemplateCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/JavaFileFilterQuery.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/JavaFileFilterQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/JavaSourceAccessor.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/JavaSourceAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/JavaSourceTaskFactoryManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/JavaSourceTaskFactoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/JavaSourceUtilImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/JavaSourceUtilImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/JavadocEnv.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/JavadocEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/JavadocHelper.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/JavadocHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/ModuleNames.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/ModuleNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/PositionRefProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/PositionRefProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/PostFlowAnalysis.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/PostFlowAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/TreeLoader.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/TreeLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/base/Bundle.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/base/Bundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/base/Module.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/base/Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/builder/ASTService.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/builder/ASTService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/builder/CommentHandlerService.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/builder/CommentHandlerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/builder/CommentSetImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/builder/CommentSetImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/builder/ElementsService.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/builder/ElementsService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/builder/QualIdentTree.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/builder/QualIdentTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/AptCacheForSourceQuery.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/AptCacheForSourceQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/AptSourcePath.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/AptSourcePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheClassPath.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheSourceForBinaryQueryImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheSourceForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/Function.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/Function.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/SourcePath.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/SourcePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/SourcePathCheck.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/SourcePathCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/COSSynchronizingIndexer.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/COSSynchronizingIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/CacheAttributesTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/CacheAttributesTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/CheckSums.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/CheckSums.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/CompileWorker.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/CompileWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/DiagnosticListenerImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/DiagnosticListenerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/FQN2Files.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/FQN2Files.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexer.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaFileFilterListener.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaFileFilterListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaIndex.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaIndexerWorker.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaIndexerWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaParsingContext.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaParsingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/MultiPassCompileWorker.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/MultiPassCompileWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/OnePassCompileWorker.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/OnePassCompileWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/SourcePrefetcher.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/SourcePrefetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/SuperOnePassCompileWorker.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/SuperOnePassCompileWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/TransactionContext.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/TransactionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/AbstractPathArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/AbstractPathArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/AbstractSourceFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/AbstractSourceFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/AptSourceFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/AptSourceFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/Archive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/Archive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/BasicSourceFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/BasicSourceFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CTSymArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CTSymArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveClassLoader.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingPathArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingPathArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ClassParser.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ClassParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ClassParserFactory.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ClassParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ClasspathInfoListener.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ClasspathInfoListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ClasspathInfoProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ClasspathInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ClasspathInfoTask.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ClasspathInfoTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CompilationInfoImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CompilationInfoImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/DefaultSourceFileObjectProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/DefaultSourceFileObjectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/DocPositionRegion.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/DocPositionRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/DocumentProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/DocumentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FastJar.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FastJar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FileManagerTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FileManagerTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjectArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjectArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjects.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FindAnonymousVisitor.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FindAnonymousVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FindMethodRegionsVisitor.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FindMethodRegionsVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FolderArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FolderArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingInferableJavaFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingInferableJavaFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingPrefetchableJavaFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingPrefetchableJavaFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/Hacks.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/Hacks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/InferableJavaFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/InferableJavaFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/JavaPathRecognizer.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/JavaPathRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacFlowListener.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacFlowListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParserFactory.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParserResult.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParserResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/MemoryFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/MemoryFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/MimeTask.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/MimeTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleLocation.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleOraculum.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleOraculum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleSourceFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleSourceFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/MultiReleaseJarFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/MultiReleaseJarFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/NewComilerTask.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/NewComilerTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/NullWriter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/NullWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/OutputFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/OutputFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/PathArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/PathArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/PrefetchableJavaFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/PrefetchableJavaFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ProcessorGenerated.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ProcessorGenerated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ProxyArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ProxyArchive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ProxyFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ProxyFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/SiblingProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/SiblingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/SiblingSource.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/SiblingSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/SiblingSupport.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/SiblingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/SourceFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/SourceFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/SourceFileObjectProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/SourceFileObjectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/TranslatePositionsVisitor.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/TranslatePositionsVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/TreeLoaderOutputFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/TreeLoaderOutputFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/pretty/CharBuffer.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/pretty/CharBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/pretty/DanglingElseChecker.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/pretty/DanglingElseChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/pretty/ImportAnalysis2.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/pretty/ImportAnalysis2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/pretty/TrimBufferObserver.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/pretty/TrimBufferObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/pretty/WidthEstimator.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/pretty/WidthEstimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/query/CommentHandler.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/query/CommentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/query/CommentSet.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/query/CommentSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/BlockSequences.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/BlockSequences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/ComputeDiff.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/ComputeDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/DiffContext.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/DiffContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/DiffFacility.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/DiffFacility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/DiffUtilities.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/DiffUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/Difference.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Difference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/ElementOverlay.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/ElementOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/EstimatorFactory.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/EstimatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/ListMatcher.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/ListMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/Measure.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Measure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/PositionEstimator.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/PositionEstimator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/save/Reindenter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Reindenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/tasklist/CompilerSettings.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/tasklist/CompilerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/tasklist/TasklistSettings.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/tasklist/TasklistSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/transform/FieldGroupTree.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/transform/FieldGroupTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/transform/ImmutableDocTreeTranslator.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/transform/ImmutableDocTreeTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/transform/TreeDuplicator.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/transform/TreeDuplicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryAnalyser.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryName.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/BuildArtifactMapperImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/BuildArtifactMapperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/BytecodeDecoder.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/BytecodeDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassFileUtil.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassFileUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexEventsTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexEventsTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexFactory.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexImplEvent.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexImplEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexImplListener.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexImplListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexManagerEvent.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexManagerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexManagerListener.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassIndexManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClassNamesForFileOraculumImpl.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClassNamesForFileOraculumImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ClasspathInfoAccessor.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ClasspathInfoAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/DocumentUtil.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/DocumentUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndex.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/LongHashMap.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/LongHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/PersistentClassIndex.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/PersistentClassIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/PersistentIndexTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/PersistentIndexTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/QueryUtil.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/QueryUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/SourceAnalyzerFactory.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/SourceAnalyzerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/TermCollector.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/TermCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/UsagesData.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/UsagesData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/VirtualSourceProviderQuery.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/VirtualSourceProviderQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/fcs/FileChangeSupport.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/fcs/FileChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/fcs/FileChangeSupportEvent.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/fcs/FileChangeSupportEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/usages/fcs/FileChangeSupportListener.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/usages/fcs/FileChangeSupportListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/util/Factory.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/util/Factory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/util/Iterators.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/util/Iterators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/source/util/Models.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/util/Models.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/ui/FmtOptions.java
+++ b/java.source.base/src/org/netbeans/modules/java/ui/FmtOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/src/org/netbeans/modules/java/ui/UIProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/ui/UIProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/ImportAnalysisDefaultPackage1.java
+++ b/java.source.base/test/unit/data/ImportAnalysisDefaultPackage1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/ImportAnalysisDefaultPackage2.java
+++ b/java.source.base/test/unit/data/ImportAnalysisDefaultPackage2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/ImportAnalysisDefaultPackage3.java
+++ b/java.source.base/test/unit/data/ImportAnalysisDefaultPackage3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationAttributeValueTest/testChangeAttributeName_AnnotationAttributeValueTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationAttributeValueTest/testChangeAttributeName_AnnotationAttributeValueTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationAttributeValueTest/testChangeAttributeValue_AnnotationAttributeValueTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationAttributeValueTest/testChangeAttributeValue_AnnotationAttributeValueTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnLocVarTest/testAddAnnToLocVar_AnnotationOnLocVarTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnLocVarTest/testAddAnnToLocVar_AnnotationOnLocVarTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnLocVarTest/testAddLocVarWithAnn_AnnotationOnLocVarTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnLocVarTest/testAddLocVarWithAnn_AnnotationOnLocVarTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAddFeatureWithAnnOnPar_AnnOnParam.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAddFeatureWithAnnOnPar_AnnOnParam.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar11_AnnOnParam.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar11_AnnOnParam.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar1_AnnOnParam.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar1_AnnOnParam.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar2_AnnOnParam.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar2_AnnOnParam.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar3_AnnOnParam.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar3_AnnOnParam.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar4_AnnOnParam.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationOnParamTest/testAnnOnPar4_AnnOnParam.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTest/testAddAnnWithConstr_AnnotationClass.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTest/testAddAnnWithConstr_AnnotationClass.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTest/testAddAnnWithField_AnnotationClass.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTest/testAddAnnWithField_AnnotationClass.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTest/testAddAnnotation_AnnotationClass.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTest/testAddAnnotation_AnnotationClass.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAddAttribute_AnnotationType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAddAttribute_AnnotationType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeDefaultValue2Change_AnnotationType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeDefaultValue2Change_AnnotationType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeDefaultValue3Change_AnnotationType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeDefaultValue3Change_AnnotationType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeDefaultValueChange_AnnotationType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeDefaultValueChange_AnnotationType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeNameChange_AnnotationType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeNameChange_AnnotationType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeTypeChange_AnnotationType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testAttributeTypeChange_AnnotationType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testRemoveAttribute_AnnotationType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnnotationTypeTest/testRemoveAttribute_AnnotationType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnonClassTest/AnonClass1.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnonClassTest/AnonClass1.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnonClassTest/AnonClass2.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/AnonClassTest/AnonClass2.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ArrayAttrValueTest/testAddAnnotationWithoutAttrName_ArrayAttrValueClass.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ArrayAttrValueTest/testAddAnnotationWithoutAttrName_ArrayAttrValueClass.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ArrayAttrValueTest/testAddAnnotation_ArrayAttrValueClass.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ArrayAttrValueTest/testAddAnnotation_ArrayAttrValueClass.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ClashingImportsTest/testAddClashingImport2.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ClashingImportsTest/testAddClashingImport2.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ClashingImportsTest/testAddClashingImport_ClashingImports.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ClashingImportsTest/testAddClashingImport_ClashingImports.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ClashingImportsTest/testAddImport_ClashingImports.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ClashingImportsTest/testAddImport_ClashingImports.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ConstructorTest/ConstructorTest/testAddConstructor.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ConstructorTest/ConstructorTest/testAddConstructor.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ConstructorTest/ConstructorTest/testAddConstructor2.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ConstructorTest/ConstructorTest/testAddConstructor2.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumFacilityTest/testAddConst_EnumFacilityName.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumFacilityTest/testAddConst_EnumFacilityName.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumFacilityTest/testReorder_EnumFacilityName.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumFacilityTest/testReorder_EnumFacilityName.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/EnumTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/EnumTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/testAddConstantToEmptyEnum_EnumTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/testAddConstantToEmptyEnum_EnumTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/testNewEmptyEnum_EnumTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/testNewEmptyEnum_EnumTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/testNewEnum_EnumTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/EnumTest/testNewEnum_EnumTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldChangeInInitValue.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldChangeInInitValue.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldInitialValue.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldInitialValue.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldInitialValueRemoval.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldInitialValueRemoval.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldInitialValueText.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldInitialValueText.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldModifiers.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldModifiers.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldName.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldName.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest1/FieldTest1/testFieldType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest2/FieldTest2.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest2/FieldTest2.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest3/testGroupInitValues_FieldTest3.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest3/testGroupInitValues_FieldTest3.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest3/testGroupSeparation_FieldTest3.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest3/testGroupSeparation_FieldTest3.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest4/testAddField_FieldTest4.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FieldTest4/testAddField_FieldTest4.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ForEachTest1/testForCreation_ForEachTest1.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ForEachTest1/testForCreation_ForEachTest1.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FormatterTest/FormattedClass.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/FormatterTest/FormattedClass.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GenericsTest/GenericMethod.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GenericsTest/GenericMethod.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GenericsTest/Generics.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GenericsTest/Generics.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest/GroupTestClass.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest/GroupTestClass.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest2/testGroupCreation_GroupTest2Class.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest2/testGroupCreation_GroupTest2Class.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest2/testGroupSplit1_GroupTest2Class.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest2/testGroupSplit1_GroupTest2Class.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest2/testGroupSplit2_GroupTest2Class.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/GroupTest2/testGroupSplit2_GroupTest2Class.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport1.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport1.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport10.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport10.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport12.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport12.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport2.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport2.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport3.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport3.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport4.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport4.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport5.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport5.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport6.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport6.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport7.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport7.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport8.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport8.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport9.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImport9.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod1.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod1.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod2.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod2.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod3.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod3.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod4.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ImportAnalysisTest/testAddImportThroughMethod4.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testAddJavaDocText2_JavaDocTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testAddJavaDocText2_JavaDocTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testAddJavaDocText_JavaDocTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testAddJavaDocText_JavaDocTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testChangeJavaDocText_JavaDocTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testChangeJavaDocText_JavaDocTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testRemoveJavaDocText_JavaDocTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/JavaDocTest/testRemoveJavaDocText_JavaDocTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/LabelsTest/testIdentifiers.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/LabelsTest/testIdentifiers.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testAddRemoveInOneTrans.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testAddRemoveInOneTrans.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testCreateNewMethod.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testCreateNewMethod.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodBody.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodBody.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodModifiers.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodModifiers.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodName.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodName.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodParameterChange.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodParameterChange.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodParameters.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodParameters.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodReturnType.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodReturnType.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testMethodThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testParameterizedMethod.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest1/MethodTest1/testParameterizedMethod.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest2/MethodTest2/testMethodAdd.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest2/MethodTest2/testMethodAdd.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest3/MethodTest3/testMethodThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest3/MethodTest3/testMethodThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddFirstThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddFirstThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddSecondThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddSecondThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddThirdThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddThirdThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddTypeParam.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAddTypeParam.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAnnotationAndThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testAnnotationAndThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveAllThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveAllThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveAnnAndAddThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveAnnAndAddThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveFirstThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveFirstThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveLastThrows.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/MethodTest4/testRemoveLastThrows.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/NewClassWithAnnTest/testAddBody_NewClassWithAnn.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/NewClassWithAnnTest/testAddBody_NewClassWithAnn.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParDimCountTest/testCreateDimPar_ParDimCountTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParDimCountTest/testCreateDimPar_ParDimCountTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParDimCountTest/testParDim1To0_ParDimCountTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParDimCountTest/testParDim1To0_ParDimCountTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParDimCountTest/testParDim1To2_ParDimCountTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParDimCountTest/testParDim1To2_ParDimCountTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParametersTest/testAddChng_ParametersTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParametersTest/testAddChng_ParametersTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParametersTest/testCreation_ParametersTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParametersTest/testCreation_ParametersTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParametersTest/testSwapTypeChng_ParametersTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/ParametersTest/testSwapTypeChng_ParametersTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/RenameTests/RenameTestClass/testRename.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/RenameTests/RenameTestClass/testRename.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/RenameTests/RenameTestField/testRename.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/RenameTests/RenameTestField/testRename.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/RenameTests/RenameTestMethod/testRename.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/RenameTests/RenameTestMethod/testRename.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/StaticImportTest/testCreation2_StaticImport.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/StaticImportTest/testCreation2_StaticImport.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/StaticImportTest/testCreation_StaticImport.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/StaticImportTest/testCreation_StaticImport.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/StaticImportTest/testSetStatic_StaticImport.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/StaticImportTest/testSetStatic_StaticImport.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/SuperClassTest/testAddClass_SuperClassTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/SuperClassTest/testAddClass_SuperClassTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/SuperClassTest/testAddSuper_SuperClassTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/SuperClassTest/testAddSuper_SuperClassTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/SuperClassTest/testChange_SuperClassTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/SuperClassTest/testChange_SuperClassTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/VarArgsTest/testCreation_VarArgsTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/VarArgsTest/testCreation_VarArgsTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/VarArgsTest/testParAdd_VarArgsTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/VarArgsTest/testParAdd_VarArgsTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/VarArgsTest/testParChange_VarArgsTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/VarArgsTest/testParChange_VarArgsTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotationWithClass_AnnIndentTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotationWithClass_AnnIndentTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotationWithMethod_AnnIndentTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotationWithMethod_AnnIndentTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotationsToClass_AnnIndentTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotationsToClass_AnnIndentTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotations_AnnIndentTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest/testAddAnnotations_AnnIndentTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest2/testAddAnns_AnnIndentTest2.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/AnnIndentTest2/testAddAnns_AnnIndentTest2.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/BlenderTest/testMixStatements_BlenderTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/BlenderTest/testMixStatements_BlenderTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testAddFirstImport_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testAddFirstImport_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testAddLastImport_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testAddLastImport_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testAddSeveral_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testAddSeveral_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testFirstAddition_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testFirstAddition_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testMoveFirst_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testMoveFirst_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testMoveLast_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testMoveLast_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveAllRemaning_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveAllRemaning_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveFirstImport_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveFirstImport_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveInnerImport_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveInnerImport_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveInside_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveInside_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveLastImport_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testRemoveLastImport_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testReplaceLine_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testReplaceLine_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testSort_ImportFormatTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/ImportFormatTest/testSort_ImportFormatTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/Indent1Test/testIndentTryBlock_Indent1Test.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/Indent1Test/testIndentTryBlock_Indent1Test.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/Indent1Test/testThrowStatement_Indent1Test.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/Indent1Test/testThrowStatement_Indent1Test.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MethodBodyTextTest/testCreateWithBodyText_MethodBodyTextTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MethodBodyTextTest/testCreateWithBodyText_MethodBodyTextTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MethodBodyTextTest/testModifyBodyText_MethodBodyTextTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MethodBodyTextTest/testModifyBodyText_MethodBodyTextTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MethodBodyTextTest/testSetBodyText_MethodBodyTextTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MethodBodyTextTest/testSetBodyText_MethodBodyTextTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveAlois_MoveElementsTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveAlois_MoveElementsTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveCall_MoveElementsTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveCall_MoveElementsTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveGianluigi_MoveElementsTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveGianluigi_MoveElementsTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveLojza_MoveElementsTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/MoveElementsTest/testMoveLojza_MoveElementsTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/SurroundExistingBodyTest/SurroundExistingBody_SurroundExistingBodyTest.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/indent/SurroundExistingBodyTest/SurroundExistingBody_SurroundExistingBodyTest.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/trywrapper/TryWrapper1Test/testWrapMoreVars.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/trywrapper/TryWrapper1Test/testWrapMoreVars.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/trywrapper/TryWrapper1Test/testWrapSingle1.pass
+++ b/java.source.base/test/unit/data/goldenfiles/org/netbeans/jmi/javamodel/codegen/trywrapper/TryWrapper1Test/testWrapSingle1.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/indexing/files/ConstructorTest.java
+++ b/java.source.base/test/unit/data/indexing/files/ConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/indexing/files/EmptyClass.java
+++ b/java.source.base/test/unit/data/indexing/files/EmptyClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/indexing/root1/org/netbeans/parsing/source1/ClassWithInnerClass.java
+++ b/java.source.base/test/unit/data/indexing/root1/org/netbeans/parsing/source1/ClassWithInnerClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/indexing/root1/org/netbeans/parsing/source1/TestFile.java
+++ b/java.source.base/test/unit/data/indexing/root1/org/netbeans/parsing/source1/TestFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/indexing/root2/org/netbeans/parsing/source2/SuperClass.java
+++ b/java.source.base/test/unit/data/indexing/root2/org/netbeans/parsing/source2/SuperClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnOnLocalVar.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnOnLocalVar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnOnParam.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnOnParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnotationAttributeValueTest.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnotationAttributeValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnotationClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnotationClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnotationType.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/AnnotationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/AnonClassTestClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/AnonClassTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ArrayAttrValueClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ArrayAttrValueClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ClashingImports.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ClashingImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ClashingImports2.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ClashingImports2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ClashingImports3.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ClashingImports3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ClassImplementingList.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ClassImplementingList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ClassPositionTest.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ClassPositionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ClassWithInnerClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ClassWithInnerClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ConstructorTest.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ConstructorTest2.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ConstructorTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/EmptyClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/EmptyClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/EnumFacilityName.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/EnumFacilityName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/EnumTest.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/EnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/FeatureListTestClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/FeatureListTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest1.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest2.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest3.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest4.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/FieldTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ForEachTest1.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ForEachTest1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/FormattedClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/FormattedClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/GenericMethod.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/GenericMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/Generics.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/Generics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/GroupTest2Class.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/GroupTest2Class.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/GroupTestClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/GroupTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest1.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest127486.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest127486.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest130479.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest130479.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest2.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest3.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest4.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest5.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest6.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest7.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest8.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest9.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTest9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTesta.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ImportsTesta.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/InputStream.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/InputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/InterfacePositionTest.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/InterfacePositionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/JavaDocTestClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/JavaDocTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest1.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest2.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest3.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest4.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTypeClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/MethodTypeClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/NewClassWithAnn.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/NewClassWithAnn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ParDimCount.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ParDimCount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/ParametersTestClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/ParametersTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/RenameTestClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/RenameTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/RenameTestField.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/RenameTestField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/RenameTestMethod.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/RenameTestMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/StaticImport.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/StaticImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/SuperClassTest.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/SuperClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/SynteticDefaultConstructor.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/SynteticDefaultConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/Tutorial1.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/Tutorial1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/Tutorial2.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/Tutorial2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/VarArgsClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/VarArgsClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/VariableAccessTypeClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/VariableAccessTypeClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157162/foo/Bar.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157162/foo/Bar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157162/foo/Foo.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157162/foo/Foo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157162/test/Test.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157162/test/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/a/C.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/a/C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/C.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Character.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Character.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/String.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/String.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Test.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Testd.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Testd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Teste.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/imports157566/b/Teste.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/indent/MethodBodyText.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/indent/MethodBodyText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/indent/imports/ImportClass1.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/indent/imports/ImportClass1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/org/netbeans/test/codegen/labels/SetLabelTestClass.java
+++ b/java.source.base/test/unit/data/org/netbeans/test/codegen/labels/SetLabelTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/samples1/EmptyClass.java
+++ b/java.source.base/test/unit/data/samples1/EmptyClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestDollarSourceName.java
+++ b/java.source.base/test/unit/data/sourceutils/TestDollarSourceName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestGetEnclosingTypeElement.java
+++ b/java.source.base/test/unit/data/sourceutils/TestGetEnclosingTypeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestGetFQNsForSimpleName.java
+++ b/java.source.base/test/unit/data/sourceutils/TestGetFQNsForSimpleName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestGetOutermostEnclosingTypeElement.java
+++ b/java.source.base/test/unit/data/sourceutils/TestGetOutermostEnclosingTypeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestInnerClassName$InnerClass.java
+++ b/java.source.base/test/unit/data/sourceutils/TestInnerClassName$InnerClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestInnerClassName.java
+++ b/java.source.base/test/unit/data/sourceutils/TestInnerClassName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestIsDeprecated1.java
+++ b/java.source.base/test/unit/data/sourceutils/TestIsDeprecated1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/data/sourceutils/TestIsDeprecated2.java
+++ b/java.source.base/test/unit/data/sourceutils/TestIsDeprecated2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/APIIsSelfContainedTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/APIIsSelfContainedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/CodeStyleUtilsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/CodeStyleUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/CommentCollectorTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/CommentCollectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/CompilationInfoTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/CompilationInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementHandleTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementUtilitiesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceInvalidationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceInvalidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceTaskFactoryTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceTaskFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/ModificationResultTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/ModificationResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/ScanUtilsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/ScanUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTestUtil.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTestUtil2.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTestUtil2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilities.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilitiesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TranslateIdentifierTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TranslateIdentifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TreePathHandleTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TreePathHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeMirrorHandleTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeMirrorHandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeUtilitiesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/WorkingCopyTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/WorkingCopyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AddCastTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AddCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AddMethodToInterfaceTemplateTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AddMethodToInterfaceTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnnotationOnLocVarTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnnotationOnLocVarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnnotationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnonymousClassTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnonymousClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ArraysTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ArraysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BlockTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BodyStatementTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BodyStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BreakContinueTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BreakContinueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BrokenSourceTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/BrokenSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClashingImportsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClashingImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClassExtendsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClassExtendsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClassImplementsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClassImplementsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClassMemberTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ClassMemberTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CommanAndWhitespaceTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CommanAndWhitespaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CommentsManipulationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CommentsManipulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CommentsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CommentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CompareTreeTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CompareTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CompilationUnitTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CompilationUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ConstructorRenameTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ConstructorRenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ConstructorTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/DoctreeTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/DoctreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/DuplicatedCommentsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/DuplicatedCommentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/EnumTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/EnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FeatureAddingTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FeatureAddingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Field5Test.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Field5Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Field6Test.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Field6Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldGroupTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest1.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest2.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest3.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest4.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FieldTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ForLoopTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ForLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FormRegressionTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/FormRegressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/GeneratorTestBase.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/GeneratorTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/GeneratorTestMDRCompat.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/GeneratorTestMDRCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/GuardedBlockTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/GuardedBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/IfTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/IfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportAnalysis2Test.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportAnalysis2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportAnalysisTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportFormatTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/IndentAddedElemTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/IndentAddedElemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/InterfaceExtendsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/InterfaceExtendsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/InterfaceTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/InterfaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LabelsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LabelsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LambdaTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LambdaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ListMatcherTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ListMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LiteralTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LiteralTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MemberAdditionTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MemberAdditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Method1Test.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Method1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodBodyTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodBodyTextTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodBodyTextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodCreationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodCreationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodParametersTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTest2.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTest3.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTest4.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodThrowsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodThrowsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTypeParametersTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MethodTypeParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ModifiersTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ModifiersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ModuleInfoTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ModuleInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MoveTreeTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MoveTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MultiCatchTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MultiCatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MultipleRewritesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/MultipleRewritesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/NewClassTreeTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/NewClassTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/OperatorsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/OperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/PackageTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/PackageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ParallelModificationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ParallelModificationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ParameterizedTypeTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/ParameterizedTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RefactoringRegressionsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RefactoringRegressionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteInCommentTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteInCommentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteMultipleExpressionsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteMultipleExpressionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteOccasionalStatements.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteOccasionalStatements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SeparatorTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SeparatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SwitchTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SyntetickejTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SyntetickejTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TopLevelTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TopLevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeChecker.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeMakerDemo.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeMakerDemo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeManipulationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeManipulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeTaggingTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeTaggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TryTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TutorialTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TutorialTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TwoModificationsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TwoModificationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TypeAnnotationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TypeAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TypeParameterTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TypeParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Utils.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/VarArgsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/VarArgsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/WhitespaceIgnoringDiff.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/WhitespaceIgnoringDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/WrappingTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/WrappingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/matching/MatchingTestAccessor.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/matching/MatchingTestAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/performance/Utilities.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/performance/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ProfileSupportTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ProfileSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ReferencesCountTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ReferencesCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/test/support/MemoryValidator.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/test/support/MemoryValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/builder/CommentHandlerServiceTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/builder/CommentHandlerServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/BasicPerformanceTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/BasicPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/ClassIndexTestCase.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/ClassIndexTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/JavaSourceUtilImplTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/JavaSourceUtilImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/ModuleNamesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/ModuleNamesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/PostFlowAnalysisTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/PostFlowAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/StopWatch.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/StopWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/TestUtil.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/TestUtilTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/TestUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/TreeLoaderTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/TreeLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/CacheSourceForBinaryQueryImplTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/CacheSourceForBinaryQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/JShellSourcePathTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/JShellSourcePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/SourcePathTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/SourcePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/APTUtilsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/APTUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CheckSumsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CheckSumsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/MultiPassCompileWorkerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/MultiPassCompileWorkerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/OnePassCompileWorkerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/OnePassCompileWorkerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/SourcePrefetcherTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/SourcePrefetcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/SuperOnePassCompileWorkerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/SuperOnePassCompileWorkerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingFileManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingPathArchiveTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingPathArchiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ClassParserTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ClassParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ClasspathInfoTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ClasspathInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CtSymArchiveTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CtSymArchiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FastJarTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FastJarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectArchiveTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectArchiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectsTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/IndexerTransactionTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/IndexerTransactionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARCachingFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARCachingFileManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARModuleFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARModuleFileManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MemoryFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MemoryFileManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ModuleOraculumTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ModuleOraculumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MutableCp.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MutableCp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/OutputFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/OutputFileManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PathArchiveTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PathArchiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfBatchCompilationTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfBatchCompilationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfJavacIntefaceGCTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfJavacIntefaceGCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfResolveTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfResolveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfZipJarOpenTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PerfZipJarOpenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ProxyFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ProxyFileManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/SourceFileObjectTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/SourceFileObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/TestJavaPlatformProviderImpl.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/TestJavaPlatformProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/DiffFacilityTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/DiffFacilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/ReindenterTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/ReindenterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/transform/Transformer.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/transform/Transformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryAnalyserTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryAnalyserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryNameTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryUsagesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryUsagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ClassIndexManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ClassIndexManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ClassNamesForFileOraculumImplTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ClassNamesForFileOraculumImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/CompromiseSATest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/CompromiseSATest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndexTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/IndexUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/LucenePerformanceTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/LucenePerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/NeverEndingScanTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/NeverEndingScanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/PersistentClassIndexScopesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/PersistentClassIndexScopesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ScanInProgressTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ScanInProgressTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/SourceAnalyzerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/SourceAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/TestSupport.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/TestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/VirtualSourceProviderQueryTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/VirtualSourceProviderQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/util/IteratorTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/util/IteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.base/test/unit/src/org/netbeans/modules/parsing/lucene/support/LowMemoryWatcherAccessor.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/parsing/lucene/support/LowMemoryWatcherAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.compat8/src/org/netbeans/modules/java/source/compat8/ModificationResult8.java
+++ b/java.source.compat8/src/org/netbeans/modules/java/source/compat8/ModificationResult8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.compat8/test/unit/src/org/netbeans/modules/java/source/compat8/ModificationResult8Test.java
+++ b/java.source.compat8/test/unit/src/org/netbeans/modules/java/source/compat8/ModificationResult8Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/APIAccessor.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/APIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/SPIAccessor.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/api/Function.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/api/Function.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/api/Queries.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/api/Queries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/api/QueryException.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/api/QueryException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/api/TemplateWizardFactory.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/api/TemplateWizardFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/api/Updates.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/api/Updates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/spi/ModelOperations.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/spi/ModelOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/spi/QueriesController.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/spi/QueriesController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/src/org/netbeans/modules/java/source/queries/spi/TemplateWizardProvider.java
+++ b/java.source.queries/src/org/netbeans/modules/java/source/queries/spi/TemplateWizardProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queries/test/unit/src/org/netbeans/modules/java/source/queries/spi/QueryOperationsTestBase.java
+++ b/java.source.queries/test/unit/src/org/netbeans/modules/java/source/queries/spi/QueryOperationsTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/JavaOperationsImpl.java
+++ b/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/JavaOperationsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/NbTemplateWizardProviderImpl.java
+++ b/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/NbTemplateWizardProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/QueriesControllerImpl.java
+++ b/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/QueriesControllerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
+++ b/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source.queriesimpl/test/unit/src/org/netbeans/modules/java/source/queriesimpl/JavaOperationsImplTest.java
+++ b/java.source.queriesimpl/test/unit/src/org/netbeans/modules/java/source/queriesimpl/JavaOperationsImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/META-INF/upgrade/org.netbeans.api.java.source.PositionConverter.hint
+++ b/java.source/src/META-INF/upgrade/org.netbeans.api.java.source.PositionConverter.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/api/java/loaders/JavaDataSupport.java
+++ b/java.source/src/org/netbeans/api/java/loaders/JavaDataSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/api/java/source/UiUtils.java
+++ b/java.source/src/org/netbeans/api/java/source/UiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/api/java/source/support/CaretAwareJavaSourceTaskFactory.java
+++ b/java.source/src/org/netbeans/api/java/source/support/CaretAwareJavaSourceTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/api/java/source/support/EditorAwareJavaSourceTaskFactory.java
+++ b/java.source/src/org/netbeans/api/java/source/support/EditorAwareJavaSourceTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/api/java/source/support/LookupBasedJavaSourceTaskFactory.java
+++ b/java.source/src/org/netbeans/api/java/source/support/LookupBasedJavaSourceTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/api/java/source/support/OpenedEditors.java
+++ b/java.source/src/org/netbeans/api/java/source/support/OpenedEditors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/api/java/source/support/SelectionAwareJavaSourceTaskFactory.java
+++ b/java.source/src/org/netbeans/api/java/source/support/SelectionAwareJavaSourceTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/BinaryElementOpen.java
+++ b/java.source/src/org/netbeans/modules/java/BinaryElementOpen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ClassDataLoader.java
+++ b/java.source/src/org/netbeans/modules/java/ClassDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ClassDataObject.java
+++ b/java.source/src/org/netbeans/modules/java/ClassDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/IndentFileEntry.java
+++ b/java.source/src/org/netbeans/modules/java/IndentFileEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/JMapFormat.java
+++ b/java.source/src/org/netbeans/modules/java/JMapFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/JavaDataLoader.java
+++ b/java.source/src/org/netbeans/modules/java/JavaDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/JavaDataLoaderBeanInfo.java
+++ b/java.source/src/org/netbeans/modules/java/JavaDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/JavaDataObject.java
+++ b/java.source/src/org/netbeans/modules/java/JavaDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/JavaNode.java
+++ b/java.source/src/org/netbeans/modules/java/JavaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/JavaTemplateAttributesProvider.java
+++ b/java.source/src/org/netbeans/modules/java/JavaTemplateAttributesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.java
+++ b/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/classfile/BinaryElementOpenImpl.java
+++ b/java.source/src/org/netbeans/modules/java/classfile/BinaryElementOpenImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
+++ b/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/classfile/SideBarFactoryImpl.java
+++ b/java.source/src/org/netbeans/modules/java/classfile/SideBarFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/DefaultFileObjectFromTemplateCreator.java
+++ b/java.source/src/org/netbeans/modules/java/source/DefaultFileObjectFromTemplateCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/DefaultPositionRefProvider.java
+++ b/java.source/src/org/netbeans/modules/java/source/DefaultPositionRefProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
+++ b/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/JavaSourceSupportAccessor.java
+++ b/java.source/src/org/netbeans/modules/java/source/JavaSourceSupportAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/package-info.java
+++ b/java.source/src/org/netbeans/modules/java/source/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/parsing/SourceFileObject.java
+++ b/java.source/src/org/netbeans/modules/java/source/parsing/SourceFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/parsing/SourceFileObjectProviderImpl.java
+++ b/java.source/src/org/netbeans/modules/java/source/parsing/SourceFileObjectProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/save/OverlayTemplateAttributesProvider.java
+++ b/java.source/src/org/netbeans/modules/java/source/save/OverlayTemplateAttributesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/tasklist/IncorrectErrorBadges.java
+++ b/java.source/src/org/netbeans/modules/java/source/tasklist/IncorrectErrorBadges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/source/usages/AllRefactoringsPluginFactory.java
+++ b/java.source/src/org/netbeans/modules/java/source/usages/AllRefactoringsPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/CategorySupport.java
+++ b/java.source/src/org/netbeans/modules/java/ui/CategorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/ContainsErrorsWarning.java
+++ b/java.source/src/org/netbeans/modules/java/ui/ContainsErrorsWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/ElementHeaderFormater.java
+++ b/java.source/src/org/netbeans/modules/java/ui/ElementHeaderFormater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtAlignment.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtAlignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtBlankLines.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtBlankLines.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtBraces.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtBraces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtCodeGeneration.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtCodeGeneration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtComments.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtImports.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtNaming.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtNaming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtSpaces.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtSpaces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtTabsIndents.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtTabsIndents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/FmtWrapping.java
+++ b/java.source/src/org/netbeans/modules/java/ui/FmtWrapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/Icons.java
+++ b/java.source/src/org/netbeans/modules/java/ui/Icons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/LazyListModel.java
+++ b/java.source/src/org/netbeans/modules/java/ui/LazyListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/NumericKeyListener.java
+++ b/java.source/src/org/netbeans/modules/java/ui/NumericKeyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/Renderers.java
+++ b/java.source/src/org/netbeans/modules/java/ui/Renderers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/modules/java/ui/UIProviderImpl.java
+++ b/java.source/src/org/netbeans/modules/java/ui/UIProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/src/org/netbeans/spi/java/loaders/RenameHandler.java
+++ b/java.source/src/org/netbeans/spi/java/loaders/RenameHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCopyPaste.pass
+++ b/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCopyPaste.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCopyPasteInterface.pass
+++ b/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCopyPasteInterface.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCutPaste.pass
+++ b/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCutPaste.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCutPasteInterface.pass
+++ b/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/copypaste/ClassNodeTest/testCutPasteInterface.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/fiximports/FixImportsTest/testFixImports.pass
+++ b/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/fiximports/FixImportsTest/testFixImports.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/fiximports/FixImportsTest/testFixImportsComplex.pass
+++ b/java.source/test/qa-functional/data/goldenfiles/org/netbeans/test/java/gui/fiximports/FixImportsTest/testFixImportsComplex.pass
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/TopLevelClassDefaultPackage.java
+++ b/java.source/test/qa-functional/data/projects/default/src/TopLevelClassDefaultPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/generating/javadoc/TestFile.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/generating/javadoc/TestFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/copypaste/test/TestClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/copypaste/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/copypaste/test/TestInterface.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/copypaste/test/TestInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/ClassCustomizer.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/ClassCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/ConstructorCustomizer.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/ConstructorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/FieldCustomizer.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/FieldCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/MethodCustomizer.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/customizers/test/MethodCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/errorannotations/test/TestClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/errorannotations/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/fiximports/test/TestClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/fiximports/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/overridemethods/test/TestClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/overridemethods/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateConstructor.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateField.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateInnerClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateInnerClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateInnerInterface.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateInnerInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateMethod.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateOuterClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateOuterClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateOuterInterface.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/parser/ParserTest/testCreateOuterInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/synchronization/test/TestClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/synchronization/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/wizards/test/TestClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/gui/wizards/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/AllAbs.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/AllAbs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/AllAbs2.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/AllAbs2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Element1.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Element1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Element2.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Element2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Imports.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Imports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Inline.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Inline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/RemoveImport.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/RemoveImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Surround.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/Surround.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/addHint.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/addHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/castHint.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/hints/HintsTest/castHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/parsing/javadoc/TestFile.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/parsing/javadoc/TestFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/rename/Rename.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/rename/Rename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/GetClassTest.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/GetClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/GetDeclaringClassTest.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/GetDeclaringClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/InTestFS.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/InTestFS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/Remover.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/Remover.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/TopLevelClass.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/TopLevelClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/WalkThrough.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/WalkThrough.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface1.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface2.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface3.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface4.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/Interface4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/OtherInterface.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/OtherInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/RootInterface.java
+++ b/java.source/test/qa-functional/data/projects/default/src/org/netbeans/test/java/testsources/ifaces/RootInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/jellytools/modules/java/FixAllImports.java
+++ b/java.source/test/qa-functional/src/org/netbeans/jellytools/modules/java/FixAllImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/jellytools/modules/java/SimpleCopyAction.java
+++ b/java.source/test/qa-functional/src/org/netbeans/jellytools/modules/java/SimpleCopyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/jellytools/modules/java/SimpleMoveAction.java
+++ b/java.source/test/qa-functional/src/org/netbeans/jellytools/modules/java/SimpleMoveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/Common.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/Common.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/Go.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/Go.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/JavaTestCase.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/JavaTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/LogTestCase.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/LogTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/Utilities.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/XGUIRunner.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/XGUIRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/XRunner.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/XRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/ConstructorElem.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/ConstructorElem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/FieldElem.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/FieldElem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/InitializerElem.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/InitializerElem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/InnerClasses.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/InnerClasses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/MethodElem.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/MethodElem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/SourceElem.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/SourceElem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/SourceGenerator.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/SourceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/generating/SuperClassInterfaces.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/generating/SuperClassInterfaces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/GuiUtilities.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/GuiUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/copypaste/ClassNodeTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/copypaste/ClassNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/copypaste/PackageNodeTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/copypaste/PackageNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/errorannotations/ErrorAnnotations.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/errorannotations/ErrorAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/fiximports/FixImportsTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/fiximports/FixImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/parser/ElementVisitor.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/parser/ElementVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/parser/ParserTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/parser/ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/gui/wizards/NewFileWizardTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/gui/wizards/NewFileWizardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/hints/AddElementHintTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/hints/AddElementHintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/hints/AddImportTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/hints/AddImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/hints/HintsTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/hints/HintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/hints/HintsTestCase.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/hints/HintsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/hints/ImplAllAbstractTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/hints/ImplAllAbstractTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/hints/IntroduceInlineTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/hints/IntroduceInlineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/hints/SurroundTest.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/hints/SurroundTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/rename/InstantRename.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/rename/InstantRename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/suites/GuiSuite.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/suites/GuiSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/suites/HintsSuite.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/suites/HintsSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/suites/SourceGeneratingSuite.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/suites/SourceGeneratingSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/qa-functional/src/org/netbeans/test/java/suites/StableSuite.java
+++ b/java.source/test/qa-functional/src/org/netbeans/test/java/suites/StableSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/api/java/source/UiUtilsTest.java
+++ b/java.source/test/unit/src/org/netbeans/api/java/source/UiUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/api/java/source/gen/LambdaTest.java
+++ b/java.source/test/unit/src/org/netbeans/api/java/source/gen/LambdaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/api/java/source/support/LookupBasedJavaSourceTaskFactoryTest.java
+++ b/java.source/test/unit/src/org/netbeans/api/java/source/support/LookupBasedJavaSourceTaskFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/modules/java/FileToURLTest.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/FileToURLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/modules/java/JavaDataLoaderTest.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/JavaDataLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/modules/java/JavaDataObjectTest.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/JavaDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/modules/java/JavaNodeTest.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/JavaNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/modules/java/JavaTemplateAttributesProviderTest.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/JavaTemplateAttributesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/modules/java/TestJavaPlatformProviderImpl.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/TestJavaPlatformProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.source/test/unit/src/org/netbeans/modules/java/classfile/CodeGeneratorTest.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/classfile/CodeGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/DialogBinding.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/DialogBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/ElementHeaders.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/ElementHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/ElementIcons.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/ElementIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/HTMLJavadocParser.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/HTMLJavadocParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/ScanDialog.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/ScanDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/api/java/source/ui/TypeElementFinder.java
+++ b/java.sourceui/src/org/netbeans/api/java/source/ui/TypeElementFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/AsyncJavaSymbolDescriptor.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/AsyncJavaSymbolDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/FastTypeProvider.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/FastTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaSourceUIModule.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaSourceUIModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaSymbolDescriptorBase.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaSymbolDescriptorBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaSymbolProvider.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaSymbolProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaTypeDescription.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaTypeDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaTypeProvider.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/src/org/netbeans/modules/java/source/ui/ResolvedJavaSymbolDescriptor.java
+++ b/java.sourceui/src/org/netbeans/modules/java/source/ui/ResolvedJavaSymbolDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
+++ b/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/HTMLJavadocParserTest.java
+++ b/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/HTMLJavadocParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/test/unit/src/org/netbeans/modules/java/source/ui/FastIndexTest.java
+++ b/java.sourceui/test/unit/src/org/netbeans/modules/java/source/ui/FastIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/test/unit/src/org/netbeans/modules/java/source/ui/JavaTypeProviderTest.java
+++ b/java.sourceui/test/unit/src/org/netbeans/modules/java/source/ui/JavaTypeProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.sourceui/test/unit/src/org/netbeans/spi/jumpto/type/JumptoAccessor.java
+++ b/java.sourceui/test/unit/src/org/netbeans/spi/jumpto/type/JumptoAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/AntLoggerUtils.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/AntLoggerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/AntProject.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/AntProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/BatchTest.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/BatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/FileSet.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/FileSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/FileSetScanner.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/FileSetScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/FileUtils.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/PatternSet.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/PatternSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/TestCounter.java
+++ b/java.testrunner.ant/src/org/netbeans/modules/java/testrunner/ant/utils/TestCounter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ant/test/unit/src/org/netbeans/modules/java/testrunner/ant/utils/FileSetScannerTest.java
+++ b/java.testrunner.ant/test/unit/src/org/netbeans/modules/java/testrunner/ant/utils/FileSetScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/JavaTestCreatorConfiguration.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/JavaTestCreatorConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/JavaTestCreatorConfigurationProvider.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/JavaTestCreatorConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/NodeOpenerProcessor.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/NodeOpenerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/JavaManager.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/JavaManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/JumpAction.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/JumpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/NodeOpener.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/NodeOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/UIJavaUtils.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/UIJavaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/CreateTestClassHint.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/CreateTestClassHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/CreateTestMethodsHint.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/CreateTestMethodsHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/Utils.java
+++ b/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/CommonSettings.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/CommonSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/CommonTestUtil.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/CommonTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/GuiUtils.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/GuiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/JavaRegexpPatterns.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/JavaRegexpPatterns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/JavaRegexpUtils.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/JavaRegexpUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/JavaUtils.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/JavaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/OutputUtils.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/OutputUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaCommonSettingsProvider.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaCommonSettingsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaCommonTestUtilProvider.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaCommonTestUtilProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaGuiUtilsProvider.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaGuiUtilsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaRootsProvider.java
+++ b/java.testrunner/src/org/netbeans/modules/java/testrunner/providers/JavaRootsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/java.testrunner/test/unit/src/org/netbeans/modules/java/testrunner/CommonTestUtilTest.java
+++ b/java.testrunner/test/unit/src/org/netbeans/modules/java/testrunner/CommonTestUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/JavadocBracesMatcher.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/JavadocBracesMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/JavadocModule.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/JavadocModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/highlighting/Factory.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/highlighting/Factory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/highlighting/Highlighting.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/highlighting/Highlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/Access.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/Access.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/AddTagFix.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/AddTagFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/Analyzer.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/Analyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/Cancel.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/Cancel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/FixAll.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/FixAll.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/GenerateJavadocAction.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/GenerateJavadocAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/GenerateJavadocFix.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/GenerateJavadocFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocGenerator.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocHint.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocUtilities.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/hints/RemoveTagFix.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/hints/RemoveTagFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/DocIndexItem.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/DocIndexItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/DocSearchIcons.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/DocSearchIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/GetJavaWord.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/GetJavaWord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/IndexBuilder.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/IndexBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/IndexListCellRenderer.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/IndexListCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/IndexOverviewAction.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/IndexOverviewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/IndexSearch.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/IndexSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/IndexSearchThread.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/IndexSearchThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/JapanJavadocEncodings.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/JapanJavadocEncodings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/JavadocRegistry.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/JavadocRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/JavadocSearchEngine.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/JavadocSearchEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/JavadocSearchEngineImpl.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/JavadocSearchEngineImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/JavadocSearchType.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/JavadocSearchType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/Jdk12SearchType.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/Jdk12SearchType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/Jdk12SearchType_japan.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/Jdk12SearchType_japan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/NoJavadocException.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/NoJavadocException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/ReferencesPanel.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/ReferencesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/SearchDocAction.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/SearchDocAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/SearchThreadJdk12.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/SearchThreadJdk12.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/SearchThreadJdk12_japan.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/SearchThreadJdk12_japan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/SrcFinder.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/SrcFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/search/URLUtils.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/search/URLUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/src/org/netbeans/modules/javadoc/settings/DocumentationSettings.java
+++ b/javadoc/src/org/netbeans/modules/javadoc/settings/DocumentationSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/AddTagFixTest.java
+++ b/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/AddTagFixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/Analyzer2Test.java
+++ b/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/Analyzer2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/GenerateJavadocFixTest.java
+++ b/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/GenerateJavadocFixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/RemoveTagFixTest.java
+++ b/javadoc/test/unit/src/org/netbeans/modules/javadoc/hints/RemoveTagFixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/test/unit/src/org/netbeans/modules/javadoc/search/IndexBuilderTest.java
+++ b/javadoc/test/unit/src/org/netbeans/modules/javadoc/search/IndexBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javadoc/test/unit/src/org/netbeans/modules/javadoc/search/SearchThreadJdk12Test.java
+++ b/javadoc/test/unit/src/org/netbeans/modules/javadoc/search/SearchThreadJdk12Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javaee.injection/src/org/netbeans/modules/javaee/injection/api/InjectionTargetQuery.java
+++ b/javaee.injection/src/org/netbeans/modules/javaee/injection/api/InjectionTargetQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javaee.injection/src/org/netbeans/modules/javaee/injection/spi/InjectionTargetQueryImplementation.java
+++ b/javaee.injection/src/org/netbeans/modules/javaee/injection/spi/InjectionTargetQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/ErrorHintProvider.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/ErrorHintProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/ErrorMark.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/ErrorMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/ErrorReporter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/ErrorReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/FXMLCompletion2.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/FXMLCompletion2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/FXMLCompletionItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/FXMLCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/JavaFXEditorUtils.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/JavaFXEditorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerFileMaker.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerFileMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerGenerator.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/FieldsWithTypeParams.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/FieldsWithTypeParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/GenerateControllerAction.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/GenerateControllerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddFxPropertyConfig.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddFxPropertyConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyCodeGenerator.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyMaker.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddPropertyPanel.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddPropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/GeneratorUtils.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/GeneratorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilder.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BuilderResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BuilderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FSBuilderResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FSBuilderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBean.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBeanCache.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBeanCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBeanProvider.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBeanProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxDefinition.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxDefinitionKind.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxDefinitionKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxEvent.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxProperty.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/SimpleBuilderResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/SimpleBuilderResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/AbstractCompletionItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/AbstractCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/AttachedPropertyItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/AttachedPropertyItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassItemFactory.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassItemFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassItemFactoryBase.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassItemFactoryBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/Completer.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/Completer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionContext.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionUtils.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ConstantCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ConstantCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/EnumValueCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/EnumValueCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/EventCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/EventCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/EventCompletionItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/EventCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxCopyReferenceCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxCopyReferenceCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxIdCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxIdCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxIncludeCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxIncludeCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxInstructionItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/FxInstructionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/HandlerMethodCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/HandlerMethodCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/IdReferenceCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/IdReferenceCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ImportCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ImportCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/InstanceCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/InstanceCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PackageItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PackageItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyElementItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyElementItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ResourcePathCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ResourcePathCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ResourcePathItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ResourcePathItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/SimpleClassItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/SimpleClassItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/StaticPropertyCompleter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/StaticPropertyCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ValueClassItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ValueClassItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ValueItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/ValueItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/CompoundCharSequence.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/CompoundCharSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/Dummy.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/Dummy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/EventHandler.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/EventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxClassUtils.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxClassUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxInclude.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxInclude.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxInstance.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxInstanceCopy.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxInstanceCopy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxModel.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxNewInstance.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxNewInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxNode.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxNodeVisitor.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxObjectBase.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxObjectBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxReference.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxScriptFragment.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxScriptFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxTreeUtilities.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxTreeUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxXmlSymbols.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxXmlSymbols.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxmlParserResult.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/FxmlParserResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/HasContent.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/HasContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/HasResource.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/HasResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/ImportDecl.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/ImportDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/LanguageDecl.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/LanguageDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/MapProperty.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/MapProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/PropertySetter.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/PropertySetter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/PropertyValue.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/PropertyValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/StaticProperty.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/StaticProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/TextPositions.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/TextPositions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/XmlNode.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/XmlNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/XmlTreeNode.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/model/XmlTreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/css/JavaFXCSSCompletionItem.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/css/JavaFXCSSCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/css/JavaFXCSSModule.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/css/JavaFXCSSModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLDataObject.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLEditAction.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLEditAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLHyperlinkProvider.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLMultiViewHelper.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLMultiViewHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLOpenAction.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FXMLOpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FxmlSchemaCatalog.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/fxml/FxmlSchemaCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/BuildEnvironment.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/BuildEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxModelBuilder.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxParserTask.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxParserTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxmlParser.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxmlParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxmlParserFactory.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/FxmlParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/ModelAccessor.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/ModelAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/ModelBuilderStep.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/ModelBuilderStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/NodeInfo.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/NodeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/ScriptEmbeddingProvider.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/ScriptEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/EventResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/EventResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ImportProcessor.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ImportProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/IncludeResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/IncludeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/NamedInstancesCollector.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/NamedInstancesCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/PropertyResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/PropertyResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ReferenceResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ReferenceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ScriptResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ScriptResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/TypeResolver.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/TypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ValueChecker.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/parser/processors/ValueChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/sax/ContentLocator.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/sax/ContentLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/sax/SequenceContentHandler.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/sax/SequenceContentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/sax/XmlLexerParser.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/sax/XmlLexerParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/src/org/netbeans/modules/javafx2/editor/spi/FXMLOpener.java
+++ b/javafx2.editor/src/org/netbeans/modules/javafx2/editor/spi/FXMLOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/data/org/netbeans/modules/javafx2/editor/actions/FieldsWithTypeParams.java
+++ b/javafx2.editor/test/unit/data/org/netbeans/modules/javafx2/editor/actions/FieldsWithTypeParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/FXMLCompletionTestBase.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/FXMLCompletionTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/GoldenFileTestBase.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/GoldenFileTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/actions/ControllerGeneratorTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/actions/ControllerGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyCodeGeneratorTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyCodeGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilderTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassCompleterTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/ClassCompleterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionContextTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/ImportCompleterTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/ImportCompleterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyCompleterTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyCompleterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/css/JavaFXCSSModuleTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/css/JavaFXCSSModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/parser/FxmlBuilderTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/parser/FxmlBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/parser/FxmlParserTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/parser/FxmlParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/parser/PrintVisitor.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/parser/PrintVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/sax/XMLLexerParserTest.java
+++ b/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/sax/XMLLexerParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.platform/src/org/netbeans/modules/javafx2/platform/JavaFXPlatformJavadoc.java
+++ b/javafx2.platform/src/org/netbeans/modules/javafx2/platform/JavaFXPlatformJavadoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.platform/src/org/netbeans/modules/javafx2/platform/JavaFxDefaultJavadocImpl.java
+++ b/javafx2.platform/src/org/netbeans/modules/javafx2/platform/JavaFxDefaultJavadocImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.platform/src/org/netbeans/modules/javafx2/platform/JavaFxDefaultSourcesImpl.java
+++ b/javafx2.platform/src/org/netbeans/modules/javafx2/platform/JavaFxDefaultSourcesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.platform/src/org/netbeans/modules/javafx2/platform/PlatformPropertiesHandler.java
+++ b/javafx2.platform/src/org/netbeans/modules/javafx2/platform/PlatformPropertiesHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.platform/src/org/netbeans/modules/javafx2/platform/Utils.java
+++ b/javafx2.platform/src/org/netbeans/modules/javafx2/platform/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.platform/src/org/netbeans/modules/javafx2/platform/api/JavaFXPlatformUtils.java
+++ b/javafx2.platform/src/org/netbeans/modules/javafx2/platform/api/JavaFXPlatformUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.platform/src/org/netbeans/modules/javafx2/platform/api/JavaFxRuntimeInclusion.java
+++ b/javafx2.platform/src/org/netbeans/modules/javafx2/platform/api/JavaFxRuntimeInclusion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ChooseOtherPlatformPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ChooseOtherPlatformPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/J2SEProjectType.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/J2SEProjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXActionProvider.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXGeneratedFilesHelper.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXGeneratedFilesHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXGeneratedFilesInterceptor.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXGeneratedFilesInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXPlatformUpdater.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXPlatformUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectConfigurations.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectConfigurations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectGenerator.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectIconAnnotator.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectIconAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectOpenedHook.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectOpenedHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectPlatformFilter.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectPlatformFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectProblems.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectProblems.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectProperties.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectUtils.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXRecommendedTemplates.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXRecommendedTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/JavaFXProjectWizardIterator.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/JavaFXProjectWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelConfigureProject.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelConfigureProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelConfigureProjectVisual.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelConfigureProjectVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelIncludesExcludes.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelIncludesExcludes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelOptionsVisual.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelOptionsVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationExtSrc.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationExtSrc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationVisual.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelSourceFolders.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelSourceFolders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/SettingsPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/SettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/WizardSettings.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/WizardSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/api/JavaFXProjectUtils.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/api/JavaFXProjectUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLCSSPanelVisual.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLCSSPanelVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLControllerPanelVisual.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLControllerPanelVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLPanelVisual.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLPanelVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/FXMLTemplateAttributesProvider.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/FXMLTemplateAttributesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/FXMLTemplateWizardIterator.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/FXMLTemplateWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/SourceGroupSupport.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/SourceGroupSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationCategoryProvider.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationClassChooser.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationClassChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationMultiPropertyPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationMultiPropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXDeploymentCategoryProvider.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXDeploymentCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXDeploymentPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXDeploymentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXDownloadModePanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXDownloadModePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXIconsPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXIconsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXJavaScriptCallbacksPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXJavaScriptCallbacksPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPackagingCategoryProvider.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPackagingCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPackagingPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPackagingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserVisualPanel1.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserVisualPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizard.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizardIterator.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizardPanel1.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizardPanel1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizardPanel2.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXPreloaderChooserWizardPanel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRequestRuntimePanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRequestRuntimePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRunCategoryProvider.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRunCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRunPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRunPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXSigningPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXSigningPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JSEApplicationClassChooser.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JSEApplicationClassChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JSEDeploymentCategoryExtender.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JSEDeploymentCategoryExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JSEDeploymentPanel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JSEDeploymentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/PlatformsComboBoxModel.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/PlatformsComboBoxModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/RuntimeComboBox.java
+++ b/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/RuntimeComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/qa-functional/src/org/netbeans/modules/javafx2/project/NewJavaFX2FilesTest.java
+++ b/javafx2.project/test/qa-functional/src/org/netbeans/modules/javafx2/project/NewJavaFX2FilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/qa-functional/src/org/netbeans/modules/javafx2/project/NewJavaFX2ProjectTest.java
+++ b/javafx2.project/test/qa-functional/src/org/netbeans/modules/javafx2/project/NewJavaFX2ProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/qa-functional/src/org/netbeans/modules/javafx2/project/TestUtils.java
+++ b/javafx2.project/test/qa-functional/src/org/netbeans/modules/javafx2/project/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/unit/src/org/netbeans/junit/ide/FXProjectSupport.java
+++ b/javafx2.project/test/unit/src/org/netbeans/junit/ide/FXProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/unit/src/org/netbeans/junit/ide/FXProjectSupportTest.java
+++ b/javafx2.project/test/unit/src/org/netbeans/junit/ide/FXProjectSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/unit/src/org/netbeans/junit/ide/JDKSetupTest.java
+++ b/javafx2.project/test/unit/src/org/netbeans/junit/ide/JDKSetupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/JFXConfigsTest.java
+++ b/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/JFXConfigsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/ProjectTypeTest.java
+++ b/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/ProjectTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/UpdateJFXImplTest.java
+++ b/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/UpdateJFXImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationClassChooserTest.java
+++ b/javafx2.project/test/unit/src/org/netbeans/modules/javafx2/project/ui/JFXApplicationClassChooserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/AdvancedMedia/src/advancedmedia/AdvancedMedia.java
+++ b/javafx2.samples/AdvancedMedia/src/advancedmedia/AdvancedMedia.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/AudioVisualizer3D/src/audiovisualizer3d/AudioVisualizer3D.java
+++ b/javafx2.samples/AudioVisualizer3D/src/audiovisualizer3d/AudioVisualizer3D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Ball.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Ball.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Bat.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Bat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Bonus.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Bonus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Brick.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Brick.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Config.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Config.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Level.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Level.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/LevelData.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/LevelData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Main.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Splash.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Splash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/BrickBreaker/src/brickbreaker/Utils.java
+++ b/javafx2.samples/BrickBreaker/src/brickbreaker/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChangeListener/src/changelistener/ChangeListener.java
+++ b/javafx2.samples/ChangeListener/src/changelistener/ChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAdvancedArea/src/chartadvancedarea/ChartAdvancedArea.java
+++ b/javafx2.samples/ChartAdvancedArea/src/chartadvancedarea/ChartAdvancedArea.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAdvancedBar/src/chartadvancedbar/ChartAdvancedBar.java
+++ b/javafx2.samples/ChartAdvancedBar/src/chartadvancedbar/ChartAdvancedBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAdvancedPie/src/chartadvancedpie/ChartAdvancedPie.java
+++ b/javafx2.samples/ChartAdvancedPie/src/chartadvancedpie/ChartAdvancedPie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAdvancedScatter/src/chartadvancedscatter/ChartAdvancedScatter.java
+++ b/javafx2.samples/ChartAdvancedScatter/src/chartadvancedscatter/ChartAdvancedScatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAdvancedScatterLive/src/chartadvancedscatterlive/ChartAdvancedScatterLive.java
+++ b/javafx2.samples/ChartAdvancedScatterLive/src/chartadvancedscatterlive/ChartAdvancedScatterLive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAdvancedStockLine/src/chartadvancedstockline/ChartAdvancedStockLine.java
+++ b/javafx2.samples/ChartAdvancedStockLine/src/chartadvancedstockline/ChartAdvancedStockLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAudioArea/src/chartaudioarea/ChartAudioArea.java
+++ b/javafx2.samples/ChartAudioArea/src/chartaudioarea/ChartAudioArea.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartAudioBar/src/chartaudiobar/ChartAudioBar.java
+++ b/javafx2.samples/ChartAudioBar/src/chartaudiobar/ChartAudioBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ChartLine/src/chartline/ChartLine.java
+++ b/javafx2.samples/ChartLine/src/chartline/ChartLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ColorPicker/src/colorpicker/ColorPickerDemo.java
+++ b/javafx2.samples/ColorPicker/src/colorpicker/ColorPickerDemo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/ColorfulCircles/src/colorfulcircles/ColorfulCircles.java
+++ b/javafx2.samples/ColorfulCircles/src/colorfulcircles/ColorfulCircles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/CreateAdvancedStage/src/createadvancedstage/CreateAdvancedStage.java
+++ b/javafx2.samples/CreateAdvancedStage/src/createadvancedstage/CreateAdvancedStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/Cube3D/src/cube3d/Cube3D.java
+++ b/javafx2.samples/Cube3D/src/cube3d/Cube3D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/CubeSystem3D/src/cubesystem3d/CubeSystem3D.java
+++ b/javafx2.samples/CubeSystem3D/src/cubesystem3d/CubeSystem3D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/DigitalClock/src/digitalclock/DigitalClock.java
+++ b/javafx2.samples/DigitalClock/src/digitalclock/DigitalClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/DisplayShelf/src/displayshelf/DisplayShelf.java
+++ b/javafx2.samples/DisplayShelf/src/displayshelf/DisplayShelf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/FXML-LoginDemo/src/demo/Login.css
+++ b/javafx2.samples/FXML-LoginDemo/src/demo/Login.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/FXML-LoginDemo/src/demo/LoginController.java
+++ b/javafx2.samples/FXML-LoginDemo/src/demo/LoginController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/FXML-LoginDemo/src/demo/Main.java
+++ b/javafx2.samples/FXML-LoginDemo/src/demo/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/FXML-LoginDemo/src/demo/ProfileController.java
+++ b/javafx2.samples/FXML-LoginDemo/src/demo/ProfileController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/FXML-LoginDemo/src/demo/model/User.java
+++ b/javafx2.samples/FXML-LoginDemo/src/demo/model/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/FXML-LoginDemo/src/demo/security/Authenticator.java
+++ b/javafx2.samples/FXML-LoginDemo/src/demo/security/Authenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/Fireworks/src/Fireworks/Fireworks.java
+++ b/javafx2.samples/Fireworks/src/Fireworks/Fireworks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/HTMLEditorApp/src/htmleditorapp/HTMLEditorApp.java
+++ b/javafx2.samples/HTMLEditorApp/src/htmleditorapp/HTMLEditorApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/KeyStrokeMotion/src/keystrokemotion/KeyStrokeMotion.java
+++ b/javafx2.samples/KeyStrokeMotion/src/keystrokemotion/KeyStrokeMotion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/MouseEvents/src/mouseevents/MouseEvents.java
+++ b/javafx2.samples/MouseEvents/src/mouseevents/MouseEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/PaginationDemo/src/paginationdemo/PaginationDemo.java
+++ b/javafx2.samples/PaginationDemo/src/paginationdemo/PaginationDemo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/PuzzlePieces/src/puzzlepieces/PuzzlePieces.java
+++ b/javafx2.samples/PuzzlePieces/src/puzzlepieces/PuzzlePieces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/StopWatch/src/stopwatch/StopWatch.java
+++ b/javafx2.samples/StopWatch/src/stopwatch/StopWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/SwingInterop/src/swinginterop/SampleTableModel.java
+++ b/javafx2.samples/SwingInterop/src/swinginterop/SampleTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/SwingInterop/src/swinginterop/SwingInterop.java
+++ b/javafx2.samples/SwingInterop/src/swinginterop/SwingInterop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/TimelineEvents/src/timelineevents/TimelineEvents.java
+++ b/javafx2.samples/TimelineEvents/src/timelineevents/TimelineEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/TimelineInterpolator/src/timelineinterpolator/TimelineInterpolator.java
+++ b/javafx2.samples/TimelineInterpolator/src/timelineinterpolator/TimelineInterpolator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/TransitionPath/src/transitionpath/TransitionPath.java
+++ b/javafx2.samples/TransitionPath/src/transitionpath/TransitionPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/TransitionRotate/src/transitionrotate/TransitionRotate.java
+++ b/javafx2.samples/TransitionRotate/src/transitionrotate/TransitionRotate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/WebViewBrowser/src/webviewbrowser/WebViewBrowser.java
+++ b/javafx2.samples/WebViewBrowser/src/webviewbrowser/WebViewBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/Xylophone/src/xylophone/Xylophone.java
+++ b/javafx2.samples/Xylophone/src/xylophone/Xylophone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/src/org/netbeans/modules/javafx2/samples/JavaFXSampleProjectGenerator.java
+++ b/javafx2.samples/src/org/netbeans/modules/javafx2/samples/JavaFXSampleProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/src/org/netbeans/modules/javafx2/samples/JavaFXSampleProjectIterator.java
+++ b/javafx2.samples/src/org/netbeans/modules/javafx2/samples/JavaFXSampleProjectIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelConfigureProject.java
+++ b/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelConfigureProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelConfigureProjectVisual.java
+++ b/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelConfigureProjectVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelOptionsVisual.java
+++ b/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelOptionsVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelProjectLocationVisual.java
+++ b/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelProjectLocationVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.samples/src/org/netbeans/modules/javafx2/samples/WizardProperties.java
+++ b/javafx2.samples/src/org/netbeans/modules/javafx2/samples/WizardProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/Home.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/Home.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/HomeFactory.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/HomeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/SceneBuilderFXMLOpener.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/SceneBuilderFXMLOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/Settings.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/impl/SBHomeFactory.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/impl/SBHomeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/GrowingComboBox.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/GrowingComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/SBOptionsPanel.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/SBOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/SBOptionsPanelController.java
+++ b/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/SBOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/META-INF/upgrade/Help.hint
+++ b/javahelp/src/META-INF/upgrade/Help.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/api/javahelp/Help.java
+++ b/javahelp/src/org/netbeans/api/javahelp/Help.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/api/javahelp/HelpSetRegistration.java
+++ b/javahelp/src/org/netbeans/api/javahelp/HelpSetRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/api/javahelp/HelpUtils.java
+++ b/javahelp/src/org/netbeans/api/javahelp/HelpUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/AbstractHelp.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/AbstractHelp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/BrowserDisplayer.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/BrowserDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/BrowserDisplayerBeanInfo.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/BrowserDisplayerBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/CopyLinkLocationAction.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/CopyLinkLocationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/HelpAction.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HelpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/HelpConstants.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HelpConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/HelpSetProcessor.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HelpSetProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/HyperlinkEventProcessor.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/HyperlinkEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/Installer.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/JavaHelp.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/JavaHelp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuery.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuickSearchProviderImpl.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuickSearchProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/NbDocsStreamHandler.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/NbDocsStreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/src/org/netbeans/modules/javahelp/Utils.java
+++ b/javahelp/src/org/netbeans/modules/javahelp/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/test/qa-functional/src/javahelp/gui/JavaHelpDialogStableTest.java
+++ b/javahelp/test/qa-functional/src/javahelp/gui/JavaHelpDialogStableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/test/qa-functional/src/javahelp/gui/JavaHelpDialogTest.java
+++ b/javahelp/test/qa-functional/src/javahelp/gui/JavaHelpDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/test/unit/src/org/netbeans/api/javahelp/HelpUtilsTest.java
+++ b/javahelp/test/unit/src/org/netbeans/api/javahelp/HelpUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/test/unit/src/org/netbeans/modules/javahelp/HelpCtxProcessorTest.java
+++ b/javahelp/test/unit/src/org/netbeans/modules/javahelp/HelpCtxProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/test/unit/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessorTest.java
+++ b/javahelp/test/unit/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javahelp/test/unit/src/org/netbeans/modules/javahelp/JavaHelpGetContentViewerTest.java
+++ b/javahelp/test/unit/src/org/netbeans/modules/javahelp/JavaHelpGetContentViewerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/EditorContextSetter.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/EditorContextSetter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/JSUtils.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/JSUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/TextLineHandler.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/TextLineHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/BreakpointAnnotationListener.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/BreakpointAnnotationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/BreakpointAnnotationManager.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/BreakpointAnnotationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/LineBreakpointAnnotation.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/LineBreakpointAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/ControllerProvider.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/ControllerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/JSLineBreakpointCustomizer.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/JSLineBreakpointCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/JSLineBreakpointCustomizerPanel.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/JSLineBreakpointCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/JSLineBreakpointType.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/JSLineBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/ToggleBreakpointActionProvider.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/breakpoints/ToggleBreakpointActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/editor/EditorLineHandlerFactoryImpl.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/editor/EditorLineHandlerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/editor/FutureLine.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/editor/FutureLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/editor/LineDelegate.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/editor/LineDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/ViewModelSupport.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/ViewModelSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/breakpoints/BreakpointNodeActionProvider.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/breakpoints/BreakpointNodeActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/breakpoints/BreakpointNodeModel.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/breakpoints/BreakpointNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/tooltip/AbstractJSToolTipAnnotation.java
+++ b/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/tooltip/AbstractJSToolTipAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/EditorLineHandler.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/EditorLineHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/EditorLineHandlerFactory.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/EditorLineHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/NamesTranslator.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/NamesTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSBreakpointStatus.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSBreakpointStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSBreakpointsInfo.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSBreakpointsInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSBreakpointsInfoManager.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSBreakpointsInfoManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSLineBreakpoint.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSLineBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSLineBreakpointBeanInfo.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/JSLineBreakpointBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/BreakpointsFromGroup.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/BreakpointsFromGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/JSBreakpointReader.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/JSBreakpointReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/PersistenceManager.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/PersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceConnection.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceContent.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceFS.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceFS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceFilesCache.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceFilesCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceURLMapper.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/src/org/netbeans/modules/javascript2/debug/spi/SourceElementsQuery.java
+++ b/javascript2.debug/src/org/netbeans/modules/javascript2/debug/spi/SourceElementsQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javascript2.debug/test/unit/src/org/netbeans/modules/javascript2/debug/sources/SourceFSTest.java
+++ b/javascript2.debug/test/unit/src/org/netbeans/modules/javascript2/debug/sources/SourceFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/SignJarsTask.java
+++ b/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/SignJarsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/anttasks/CopyTemplatePageTask.java
+++ b/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/anttasks/CopyTemplatePageTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/anttasks/GenerateJnlpFileTask.java
+++ b/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/anttasks/GenerateJnlpFileTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/anttasks/SignJarsTask.java
+++ b/javawebstart/AntTasks/src/org/netbeans/modules/javawebstart/anttasks/SignJarsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/CustomizerRunComponent.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/CustomizerRunComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/J2SERunConfigProviderImpl.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/J2SERunConfigProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/JWSGeneratedFilesInterceptor.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/JWSGeneratedFilesInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/JWSProjectOpenHook.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/JWSProjectOpenHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataLoader.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataLoaderBeanInfo.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataNode.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataObject.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/JnlpDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/RunJavaws.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/RunJavaws.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/package-info.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/AppletParametersPanel.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/AppletParametersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/ExtensionResourcesPanel.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/ExtensionResourcesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSCompositeCategoryProvider.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSCompositeCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSCustomizerPanel.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectProperties.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectPropertiesUtils.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectPropertiesUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/ResourcesCustomizer.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/ResourcesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/SigningPanel.java
+++ b/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/SigningPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/javawebstart/test/unit/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectPropertiesTest.java
+++ b/javawebstart/test/unit/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/DocumentsDialogOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/DocumentsDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/EditorOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/EditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/EditorWindowOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/EditorWindowOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/FilesTabOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/FilesTabOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/FindInFilesOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/FindInFilesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/NavigatorOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/NavigatorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/NewFileWizardOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/NewFileWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/NewProjectWizardOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/NewProjectWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/PaletteOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/PaletteOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/ProjectsTabOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/ProjectsTabOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/RuntimeTabOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/RuntimeTabOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/SearchResultsOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/SearchResultsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/DebugProjectAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/DebugProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/FilesViewAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/FilesViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/FindInFilesAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/FindInFilesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/NewFileAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/NewFileAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/NewProjectAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/NewProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/PaletteViewAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/PaletteViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/ProjectViewAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/ProjectViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/actions/RuntimeViewAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/actions/RuntimeViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/AddJDBCDriverOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/AddJDBCDriverOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/AddDriverAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/AddDriverAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/ConnectAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/ConnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/ConnectUsingAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/ConnectUsingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/DisconnectAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/DisconnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/ExecuteCommandAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/actions/ExecuteCommandAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/CreateJavaDBDatabaseOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/CreateJavaDBDatabaseOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/CreateDatabaseAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/CreateDatabaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/SettingsAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/SettingsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/StartServerAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/StartServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/StopServerAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/derby/actions/StopServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/ConnectionNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/ConnectionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/DatabasesNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/DatabasesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/DriverNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/DriverNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/DriversNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/db/nodes/DriversNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/BreakpointsWindowOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/BreakpointsWindowOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/SessionsOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/SessionsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/ApplyCodeChangesAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/ApplyCodeChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/AttachDebuggerAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/AttachDebuggerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/BreakpointsWindowAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/BreakpointsWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/ContinueAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/ContinueAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/DebugProjectAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/DebugProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/DeleteAllBreakpointsAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/DeleteAllBreakpointsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/FinishAllAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/FinishAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/FinishDebuggerAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/FinishDebuggerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/MakeCurrentAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/MakeCurrentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/NewBreakpointAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/NewBreakpointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/PauseAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/PauseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/RunToCursorAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/RunToCursorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/SessionsAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/SessionsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/SourcesAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/SourcesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepIntoAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepIntoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepOutAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepOutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepOverAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepOverAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepOverExpressionAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/StepOverExpressionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/TakeGUISnapshotAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/TakeGUISnapshotAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/ToggleBreakpointAction.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/ToggleBreakpointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/modules/editor/CompletionJListOperator.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/modules/editor/CompletionJListOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/nodes/FolderNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/nodes/FolderNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/nodes/ImageNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/nodes/ImageNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/nodes/ProjectRootNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/nodes/ProjectRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/nodes/PropertiesNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/nodes/PropertiesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/nodes/URLNode.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/nodes/URLNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/src/org/netbeans/jellytools/testutils/NodeUtils.java
+++ b/jellytools.ide/src/org/netbeans/jellytools/testutils/NodeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/data/SampleProject/src/sample1/JFrameSample.java
+++ b/jellytools.ide/test/qa-functional/data/SampleProject/src/sample1/JFrameSample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
+++ b/jellytools.ide/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
+++ b/jellytools.ide/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/data/SampleProject/test/Dummy.java
+++ b/jellytools.ide/test/qa-functional/data/SampleProject/test/Dummy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/CollectBundleKeys.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/CollectBundleKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/DocumentsDialogOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/DocumentsDialogOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/EditorOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/EditorOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/EditorWindowOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/EditorWindowOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/FilesTabOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/FilesTabOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/FindInFilesOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/FindInFilesOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/IDEBundleKeysTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/IDEBundleKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/JellytoolsIDESuite.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/JellytoolsIDESuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/NavigatorOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/NavigatorOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/ProjectsTabOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/ProjectsTabOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/RuntimeTabOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/RuntimeTabOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/SearchResultsOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/SearchResultsOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/actions/FindInFilesActionTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/actions/FindInFilesActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/db/actions/DbActionsTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/db/actions/DbActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/db/nodes/DatabasesNodeTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/db/nodes/DatabasesNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/BreakpointsWindowOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/BreakpointsWindowOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/actions/BreakpointsWindowActionTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/actions/BreakpointsWindowActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/actions/DeleteAllBreakpointsActionTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/actions/DeleteAllBreakpointsActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/editor/CompletionJListOperatorTest.java
+++ b/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/modules/editor/CompletionJListOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/BuildAndRunActionsStepOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/BuildAndRunActionsStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/ClasspathStepOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/ClasspathStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/JavaProjectsTabOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/JavaProjectsTabOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/NewJavaFileNameLocationStepOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/NewJavaFileNameLocationStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/NewJavaFileWizardOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/NewJavaFileWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/NewJavaProjectNameLocationStepOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/NewJavaProjectNameLocationStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/SourcePackageFoldersStepOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/SourcePackageFoldersStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/actions/BuildJavaProjectAction.java
+++ b/jellytools.java/src/org/netbeans/jellytools/actions/BuildJavaProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/actions/CleanJavaProjectAction.java
+++ b/jellytools.java/src/org/netbeans/jellytools/actions/CleanJavaProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/actions/CompileJavaAction.java
+++ b/jellytools.java/src/org/netbeans/jellytools/actions/CompileJavaAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/debugger/AttachDialogOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/debugger/AttachDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/debugger/SourcesOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/debugger/SourcesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/debugger/actions/DebugJavaFileAction.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/debugger/actions/DebugJavaFileAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/ComponentInspectorOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/ComponentInspectorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/ComponentPaletteOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/ComponentPaletteOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/FormDesignerOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/FormDesignerOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/actions/InspectorAction.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/actions/InspectorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/FormCustomEditorOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/FormCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/MethodPickerOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/MethodPickerOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/ParametersPickerOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/ParametersPickerOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/PropertyPickerOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/PropertyPickerOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/freeform/actions/RedeployFreeformAction.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/freeform/actions/RedeployFreeformAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/freeform/actions/RunFreeformAction.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/freeform/actions/RunFreeformAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/freeform/nodes/FreeformProjectNode.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/freeform/nodes/FreeformProjectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/modules/java/editor/GenerateCodeOperator.java
+++ b/jellytools.java/src/org/netbeans/jellytools/modules/java/editor/GenerateCodeOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/nodes/ClassNode.java
+++ b/jellytools.java/src/org/netbeans/jellytools/nodes/ClassNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/nodes/FormNode.java
+++ b/jellytools.java/src/org/netbeans/jellytools/nodes/FormNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/nodes/JavaNode.java
+++ b/jellytools.java/src/org/netbeans/jellytools/nodes/JavaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/nodes/JavaProjectRootNode.java
+++ b/jellytools.java/src/org/netbeans/jellytools/nodes/JavaProjectRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/nodes/SourcePackagesNode.java
+++ b/jellytools.java/src/org/netbeans/jellytools/nodes/SourcePackagesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/src/org/netbeans/jellytools/testutils/JavaNodeUtils.java
+++ b/jellytools.java/src/org/netbeans/jellytools/testutils/JavaNodeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/JFrameSample.java
+++ b/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/JFrameSample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
+++ b/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/outline/TestOutline.java
+++ b/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/outline/TestOutline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
+++ b/jellytools.java/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/data/SampleProject/test/Dummy.java
+++ b/jellytools.java/test/qa-functional/data/SampleProject/test/Dummy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/ActionsTest.java
+++ b/jellytools.java/test/qa-functional/src/examples/ActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/EmptyTest.java
+++ b/jellytools.java/test/qa-functional/src/examples/EmptyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/ExamplesSuite.java
+++ b/jellytools.java/test/qa-functional/src/examples/ExamplesSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/NodesTest.java
+++ b/jellytools.java/test/qa-functional/src/examples/NodesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/OperatorsTest.java
+++ b/jellytools.java/test/qa-functional/src/examples/OperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/OverallTest.java
+++ b/jellytools.java/test/qa-functional/src/examples/OverallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/PropertiesTest.java
+++ b/jellytools.java/test/qa-functional/src/examples/PropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/examples/WizardsTest.java
+++ b/jellytools.java/test/qa-functional/src/examples/WizardsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/JavaBundleKeysTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/JavaBundleKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/JellytoolsJavaSuite.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/JellytoolsJavaSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewFileWizardOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewFileWizardOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewJavaFileNameLocationStepOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewJavaFileNameLocationStepOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewJavaProjectNameLocationStepOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewJavaProjectNameLocationStepOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewProjectWizardOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/NewProjectWizardOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/OutlineOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/OutlineOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/TopComponentOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/TopComponentOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ActionNoBlockTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ActionNoBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ActionsSuite.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ActionsSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/AddLocaleActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/AddLocaleActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/AttachWindowActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/AttachWindowActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/BuildJavaProjectActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/BuildJavaProjectActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CleanJavaProjectActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CleanJavaProjectActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CompileJavaActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CompileJavaActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CopyActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CopyActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CustomizeActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CustomizeActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CutActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/CutActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/DebugProjectActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/DebugProjectActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/DeleteActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/DeleteActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/EditActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/EditActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/FindActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/FindActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/HelpActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/HelpActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/MaximizeWindowActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/MaximizeWindowActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/NewFileActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/NewFileActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/OpenActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/OpenActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/OutputWindowViewActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/OutputWindowViewActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/PaletteViewActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/PaletteViewActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/PasteActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/PasteActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ProjectViewActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ProjectViewActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/PropertiesActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/PropertiesActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/RenameActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/RenameActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ReplaceActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ReplaceActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/RuntimeViewActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/RuntimeViewActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SaveActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SaveActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SaveAllActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SaveAllActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SaveAsTemplateActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SaveAsTemplateActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ShowDescriptionAreaActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/ShowDescriptionAreaActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SortByCategoryActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SortByCategoryActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SortByNameActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/actions/SortByNameActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/actions/DebugJavaFileActionTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/debugger/actions/DebugJavaFileActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/FormEditorOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/FormEditorOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/FormPropertiesEditorsTestCase.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/FormPropertiesEditorsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/MethodPickerOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/MethodPickerOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/ParametersPickerOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/ParametersPickerOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/PropertyPickerOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/modules/form/properties/editors/PropertyPickerOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/ClassNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/ClassNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/FolderNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/FolderNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/FormNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/FormNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/HTMLNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/HTMLNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/ImageNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/ImageNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/JavaNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/JavaNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/JavaProjectRootNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/JavaProjectRootNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/NodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/NodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/NodesSuite.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/NodesSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/ProjectRootNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/ProjectRootNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/PropertiesNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/PropertiesNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/URLNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/URLNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/UnrecognizedNodeTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/nodes/UnrecognizedNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/CustomPropertiesTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/CustomPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/PropertiesSuite.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/PropertiesSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/PropertySheetOperatorTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/PropertySheetOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/PropertyTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/PropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/TestNode.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/TestNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/editors/CustomEditorOperatorsTest.java
+++ b/jellytools.java/test/qa-functional/src/org/netbeans/jellytools/properties/editors/CustomEditorOperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/Bundle.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/Bundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/FavoritesOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/FavoritesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/HelpOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/HelpOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/JellyTestCase.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/JellyTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/JellyVersion.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/JellyVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/MainWindowOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/MainWindowOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/NbDialogOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/NbDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/OptionsOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/OptionsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/OutlineOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/OutlineOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/OutputOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/OutputOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/OutputTabOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/OutputTabOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/PluginsOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/PluginsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/QuestionDialogOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/QuestionDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/SaveAsTemplateOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/SaveAsTemplateOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/TestBundleKeys.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/TestBundleKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/TopComponentOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/TopComponentOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/TreeTableOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/TreeTableOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/WizardOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/WizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/Action.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/ActionNoBlock.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/ActionNoBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/AddLocaleAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/AddLocaleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/AttachWindowAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/AttachWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/CloneViewAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/CloneViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/CloseAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/CloseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/CloseAllDocumentsAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/CloseAllDocumentsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/CloseViewAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/CloseViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/CopyAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/CopyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/CustomizeAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/CustomizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/CutAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/CutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/DeleteAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/DeleteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/DockWindowAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/DockWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/DocumentsAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/DocumentsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/EditAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/EditAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/ExploreFromHereAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/ExploreFromHereAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/FavoritesAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/FavoritesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/FindAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/FindAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/HelpAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/HelpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/MaximizeWindowAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/MaximizeWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/OpenAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/OpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/OptionsViewAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/OptionsViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/OutputWindowViewAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/OutputWindowViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/PasteAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/PasteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/PasteActionNoBlock.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/PasteActionNoBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/PropertiesAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/PropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/RenameAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/RenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/ReplaceAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/ReplaceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/RestoreWindowAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/RestoreWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/SaveAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/SaveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/SaveAllAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/SaveAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/SaveAsTemplateAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/SaveAsTemplateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/ShowDescriptionAreaAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/ShowDescriptionAreaAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/SortByCategoryAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/SortByCategoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/SortByNameAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/SortByNameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/UndockWindowAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/UndockWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/actions/ViewAction.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/actions/ViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/nodes/HTMLNode.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/nodes/HTMLNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/nodes/Node.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/nodes/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/nodes/OutlineNode.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/nodes/OutlineNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/nodes/UnrecognizedNode.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/nodes/UnrecognizedNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/ClasspathProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/ClasspathProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/ColorProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/ColorProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/DimensionProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/DimensionProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/FileProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/FileProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/FontProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/FontProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/PointProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/PointProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/ProcessDescriptorProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/ProcessDescriptorProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/Property.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/Property.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/PropertySheetOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/PropertySheetOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/RectangleProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/RectangleProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/StringArrayProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/StringArrayProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/StringProperty.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/StringProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ClasspathCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ClasspathCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ColorCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ColorCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/DimensionCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/DimensionCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/FileCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/FileCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/FontCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/FontCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/IconCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/IconCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/PointCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/PointCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ProcessDescriptorCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ProcessDescriptorCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/RectangleCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/RectangleCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/StringArrayCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/StringArrayCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/StringCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/StringCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/properties/editors/TreeViewCustomEditorOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/properties/editors/TreeViewCustomEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/util/FolderContext.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/util/FolderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/util/StringFilter.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/util/StringFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/widgets/ConnectionWidgetOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/widgets/ConnectionWidgetOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/widgets/LabelWidgetOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/widgets/LabelWidgetOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/src/org/netbeans/jellytools/widgets/WidgetOperator.java
+++ b/jellytools.platform/src/org/netbeans/jellytools/widgets/WidgetOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/data/SampleProject/src/sample1/JFrameSample.java
+++ b/jellytools.platform/test/qa-functional/data/SampleProject/src/sample1/JFrameSample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
+++ b/jellytools.platform/test/qa-functional/data/SampleProject/src/sample1/SampleClass1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
+++ b/jellytools.platform/test/qa-functional/data/SampleProject/src/sample1/sample2/SampleClass2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/data/SampleProject/test/Dummy.java
+++ b/jellytools.platform/test/qa-functional/data/SampleProject/test/Dummy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/BundleTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/BundleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/FavoritesOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/FavoritesOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/HelpOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/HelpOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/JellytoolsPlatformSuite.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/JellytoolsPlatformSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/MainWindowOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/MainWindowOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/NbDialogOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/NbDialogOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/OptionsOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/OptionsOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/OutputOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/OutputOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/OutputTabOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/OutputTabOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/PlatformBundleKeysTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/PlatformBundleKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/PluginsOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/PluginsOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/QuestionDialogOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/QuestionDialogOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/SaveAsTemplateOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/SaveAsTemplateOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/Utils.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/WizardOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/WizardOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/widgets/Utils.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/widgets/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/widgets/WidgetOperatorTest.java
+++ b/jellytools.platform/test/qa-functional/src/org/netbeans/jellytools/widgets/WidgetOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/lib/nbjshell/JShellAccessor.java
+++ b/jshell.support/src/org/netbeans/lib/nbjshell/JShellAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/lib/nbjshell/LaunchJDIAgent.java
+++ b/jshell.support/src/org/netbeans/lib/nbjshell/LaunchJDIAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/lib/nbjshell/NbExecutionControl.java
+++ b/jshell.support/src/org/netbeans/lib/nbjshell/NbExecutionControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/lib/nbjshell/NbExecutionControlBase.java
+++ b/jshell.support/src/org/netbeans/lib/nbjshell/NbExecutionControlBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/lib/nbjshell/PipeInputStream.java
+++ b/jshell.support/src/org/netbeans/lib/nbjshell/PipeInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/lib/nbjshell/RemoteJShellService.java
+++ b/jshell.support/src/org/netbeans/lib/nbjshell/RemoteJShellService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/lib/nbjshell/SnippetWrapping.java
+++ b/jshell.support/src/org/netbeans/lib/nbjshell/SnippetWrapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/ClassNamePanel.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/ClassNamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/CommandCompletionProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/CommandCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/CompletionFilter.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/CompletionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleEditor.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleFoldManager.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleFoldsProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleFoldsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/DropSnippetAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/DropSnippetAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/ExecutingGlassPanel.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/ExecutingGlassPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/GenerateClassAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/GenerateClassAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/GuardedBlockSuppressLayer.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/GuardedBlockSuppressLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/HistoryCompletionProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/HistoryCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/JShellImports.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/JShellImports.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/OverrideEditorActions.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/OverrideEditorActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/REPLEditorKit.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/REPLEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/ResetAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/ResetAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/RunScriptAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/RunScriptAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/ShellActionBase.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/ShellActionBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/SnippetClassGenerator.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/SnippetClassGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/editor/StopExecutionAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/editor/StopExecutionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/CompilerOptionsProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/CompilerOptionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/ConfigurableClasspath.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/ConfigurableClasspath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/GlobalShellHistory.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/GlobalShellHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/JShellDataObject.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/JShellDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/JShellEnvironment.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/JShellEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/JShellLoader.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/JShellLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/ShellClasspathProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/ShellClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/ShellEvent.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/ShellEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/ShellListener.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/ShellListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/ShellOwnerQueryImpl.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/ShellOwnerQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/ShellRegistry.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/ShellRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/ShellStatus.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/ShellStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/SourceLevelProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/SourceLevelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/env/WriterOutputStream.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/WriterOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/j2se/JShellRunProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/j2se/JShellRunProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/j2se/JShellStartupExtender.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/j2se/JShellStartupExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/j2se/LaunchAntListener.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/j2se/LaunchAntListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/j2se/NbProjectShellHistory.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/j2se/NbProjectShellHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/AgentGenerator.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/AgentGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/BrokenExecutionControl.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/BrokenExecutionControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/DebugExecutionEnvironment.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/DebugExecutionEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/JShellConnection.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/JShellConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/JShellOptionsController.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/JShellOptionsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/JShellOptionsPanel.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/JShellOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/NIOStreams.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/NIOStreams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/PlatformShellAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/PlatformShellAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/PropertyNames.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/PropertyNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/RemoteJShellAccessor.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/RemoteJShellAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/RunExecutionEnvironment.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/RunExecutionEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/ShellAgent.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/ShellAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/ShellDebuggerUtils.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/ShellDebuggerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/ShellLaunchEvent.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/ShellLaunchEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/ShellLaunchListener.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/ShellLaunchListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/ShellLaunchManager.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/ShellLaunchManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/launch/ShellOptions.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/launch/ShellOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/maven/JShellCategoryProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/maven/JShellCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/maven/MavenRunOptions.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/maven/MavenRunOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/maven/MavenShellLauncher.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/maven/MavenShellLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/maven/MavenSnippetStorage.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/maven/MavenSnippetStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/maven/MvnProjectShellHistory.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/maven/MvnProjectShellHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleContents.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleContents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleEvent.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleListener.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleModel.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleSection.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/ConsoleSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/JShellToken.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/JShellToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/Rng.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/Rng.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/SnippetHandle.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/SnippetHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/model/SnippetListener.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/model/SnippetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/navigation/DropAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/navigation/DropAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/navigation/NavigationTask.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/navigation/NavigationTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/navigation/OpenAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/navigation/OpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetNavigationPanel.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetNavigationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetNodes.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetNodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetPanelUI.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetPanelUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/ConsoleEmbeddingProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/ConsoleEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/ConsoleMainParser.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/ConsoleMainParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/EmbeddingProcessor.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/EmbeddingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/JShellLexer.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/JShellLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/JShellParser.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/JShellParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/JShellParser2.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/JShellParser2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/LexerEmbeddingAdapter.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/LexerEmbeddingAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/ModelAccessor.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/ModelAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/ShellAccessBridge.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/ShellAccessBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/parsing/SnippetRegistry.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/parsing/SnippetRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions2.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/LaunchedProjectOpener.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/LaunchedProjectOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/OpenRunningShellAction.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/OpenRunningShellAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/ProjectShellEnv.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/ProjectShellEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/REPLAction2.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/REPLAction2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/RunOptionsModel.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/RunOptionsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/project/ShellProjectUtils.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/project/ShellProjectUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/FileHistory.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/FileHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/J2SESnippetStorage.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/J2SESnippetStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/JShellGenerator.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/JShellGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/LocationSuppressRule.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/LocationSuppressRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/PersistentSnippets.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/PersistentSnippets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/PersistentSnippetsSupport.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/PersistentSnippetsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/SemicolonMissingRule.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/SemicolonMissingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/ShellHistory.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/ShellHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/ShellSession.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/ShellSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/SnippetCollector.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/SnippetCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/SnippetFileSystem.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/SnippetFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/SnippetStorage.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/SnippetStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/SnippetsFolder.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/SnippetsFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/support/SwitchingJavaFileManger.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/support/SwitchingJavaFileManger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/tool/ArgTokenizer.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/tool/ArgTokenizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/tool/ContinuousCompletionProvider.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/tool/ContinuousCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/tool/Feedback.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/tool/Feedback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/tool/IOContext.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/tool/IOContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/tool/JShellLauncher.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/tool/JShellLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/tool/JShellTool.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/tool/JShellTool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/src/org/netbeans/modules/jshell/tool/MessageHandler.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/tool/MessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/ContentParserTest.java
+++ b/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/ContentParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/api/jumpto/type/TypeBrowser.java
+++ b/jumpto/src/org/netbeans/api/jumpto/type/TypeBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/EntityComparator.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/EntityComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/SearchHistory.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/SearchHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/AbstractModelFilter.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/AbstractModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/CurrentSearch.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/CurrentSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/DescriptorAccessor.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/DescriptorAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/Factory.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/Factory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/HighlightingNameFormatter.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/HighlightingNameFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/ItemRenderer.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/ItemRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/Models.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/Models.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/StateFullComparator.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/StateFullComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/UiUtils.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/UiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/common/Utils.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/common/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/FileComarator.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/FileComarator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/FileDescription.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/FileDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/FileIndexer.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/FileIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/FileProviderAccessor.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/FileProviderAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchAction.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchOptions.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchPanel.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/file/Worker.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/file/Worker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToSymbolProvider.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToSymbolProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToSymbolWorker.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToSymbolWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToTypeWorker.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToTypeWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/quicksearch/JavaTypeSearchProvider.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/quicksearch/JavaTypeSearchProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/settings/GoToSettings.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/settings/GoToSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/settings/JumpToOptionsPanelController.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/settings/JumpToOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/settings/JumpToPanel.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/settings/JumpToPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/symbol/ContentProviderImpl.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/symbol/ContentProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/symbol/DialogFactory.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/symbol/DialogFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/symbol/GoToPanel.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/symbol/GoToPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/symbol/GoToPanelImpl.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/symbol/GoToPanelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/symbol/GoToSymbolAction.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/symbol/GoToSymbolAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/symbol/SymbolComparator.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/symbol/SymbolComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/symbol/SymbolProviderAccessor.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/symbol/SymbolProviderAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/type/FilteredListModel.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/type/FilteredListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/type/GoToPanel.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/type/GoToPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/type/GoToTypeAction.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/type/GoToTypeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/type/TypeComparator.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/type/TypeComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/type/TypeProviderAccessor.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/type/TypeProviderAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/modules/jumpto/type/UiOptions.java
+++ b/jumpto/src/org/netbeans/modules/jumpto/type/UiOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/file/FileDescriptor.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/file/FileDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/file/FileProvider.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/file/FileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/file/FileProviderFactory.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/file/FileProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/support/AsyncDescriptor.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/support/AsyncDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/support/Descriptor.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/support/Descriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/support/DescriptorChangeEvent.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/support/DescriptorChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/support/DescriptorChangeListener.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/support/DescriptorChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/support/NameMatcher.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/support/NameMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/support/NameMatcherFactory.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/support/NameMatcherFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/symbol/SymbolDescriptor.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/symbol/SymbolDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/symbol/SymbolProvider.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/symbol/SymbolProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/type/SearchType.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/type/SearchType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/type/TypeDescriptor.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/type/TypeDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/src/org/netbeans/spi/jumpto/type/TypeProvider.java
+++ b/jumpto/src/org/netbeans/spi/jumpto/type/TypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/test/unit/src/org/netbeans/modules/jumpto/common/HighlightingNameFormatterTest.java
+++ b/jumpto/test/unit/src/org/netbeans/modules/jumpto/common/HighlightingNameFormatterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/test/unit/src/org/netbeans/modules/jumpto/symbol/ContentProviderImplTest.java
+++ b/jumpto/test/unit/src/org/netbeans/modules/jumpto/symbol/ContentProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/test/unit/src/org/netbeans/modules/jumpto/type/GoToTypeActionTest.java
+++ b/jumpto/test/unit/src/org/netbeans/modules/jumpto/type/GoToTypeActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/test/unit/src/org/netbeans/modules/jumpto/type/TypeComparatorTest.java
+++ b/jumpto/test/unit/src/org/netbeans/modules/jumpto/type/TypeComparatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jumpto/test/unit/src/org/netbeans/spi/jumpto/file/FileProviderTest.java
+++ b/jumpto/test/unit/src/org/netbeans/spi/jumpto/file/FileProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitManagerProvider.java
+++ b/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitManagerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestMethodNode.java
+++ b/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestRunnerNodeFactory.java
+++ b/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestRunnerNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestsuiteNode.java
+++ b/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestsuiteNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/JUnitProjectOpenedHook.java
+++ b/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/JUnitProjectOpenedHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant.ui/test/unit/src/org/netbeans/modules/junit/ant/ui/AntJUnitManagerProviderTest.java
+++ b/junit.ant.ui/test/unit/src/org/netbeans/modules/junit/ant/ui/AntJUnitManagerProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant/src/org/netbeans/modules/junit/ant/AntSessionInfo.java
+++ b/junit.ant/src/org/netbeans/modules/junit/ant/AntSessionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant/src/org/netbeans/modules/junit/ant/JUnitAntLogger.java
+++ b/junit.ant/src/org/netbeans/modules/junit/ant/JUnitAntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant/src/org/netbeans/modules/junit/ant/JUnitExecutionManager.java
+++ b/junit.ant/src/org/netbeans/modules/junit/ant/JUnitExecutionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
+++ b/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant/src/org/netbeans/modules/junit/ant/JUnitTestSession.java
+++ b/junit.ant/src/org/netbeans/modules/junit/ant/JUnitTestSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ant/src/org/netbeans/modules/junit/ant/XmlOutputParser.java
+++ b/junit.ant/src/org/netbeans/modules/junit/ant/XmlOutputParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/JUnitTestCreatorProvider.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/JUnitTestCreatorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/OpenTestAction.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/OpenTestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/TestAction.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/TestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/actions/JUnitMethodDebuggerProvider.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/actions/JUnitMethodDebuggerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/actions/JUnitMethodRunnerProvider.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/actions/JUnitMethodRunnerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestClassInfoTask.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestClassInfoTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestSingleMethodSupport.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestSingleMethodSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitCallstackFrameNode.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitCallstackFrameNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitTestMethodNode.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitTestMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitTestsuiteNode.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitTestsuiteNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/ClassChooserPanel.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/ClassChooserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/EmptyTestCaseWizard.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/EmptyTestCaseWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/EmptyTestCaseWizardIterator.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/EmptyTestCaseWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/EmptyTestStepLocation.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/EmptyTestStepLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/JavaChildren.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/JavaChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SettingsPanel.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SimpleTestCaseWizard.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SimpleTestCaseWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SimpleTestCaseWizardIterator.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SimpleTestCaseWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SimpleTestStepLocation.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/SimpleTestStepLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/StepProblemMessage.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/StepProblemMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/TestSuiteStepLocation.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/TestSuiteStepLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit.ui/src/org/netbeans/modules/junit/ui/wizards/TestSuiteWizardIterator.java
+++ b/junit.ui/src/org/netbeans/modules/junit/ui/wizards/TestSuiteWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
+++ b/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/ClassMap.java
+++ b/junit/src/org/netbeans/modules/junit/ClassMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/DefaultITPlugin.java
+++ b/junit/src/org/netbeans/modules/junit/DefaultITPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/DefaultPlugin.java
+++ b/junit/src/org/netbeans/modules/junit/DefaultPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/GoToOppositeAction.java
+++ b/junit/src/org/netbeans/modules/junit/GoToOppositeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/JUnit3TestGenerator.java
+++ b/junit/src/org/netbeans/modules/junit/JUnit3TestGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/JUnit4TestGenerator.java
+++ b/junit/src/org/netbeans/modules/junit/JUnit4TestGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/JUnitLibraryComparator.java
+++ b/junit/src/org/netbeans/modules/junit/JUnitLibraryComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/JUnitPluginTrampoline.java
+++ b/junit/src/org/netbeans/modules/junit/JUnitPluginTrampoline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/JUnitVersion.java
+++ b/junit/src/org/netbeans/modules/junit/JUnitVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/ProgressIndicator.java
+++ b/junit/src/org/netbeans/modules/junit/ProgressIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/TestCreator.java
+++ b/junit/src/org/netbeans/modules/junit/TestCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/TestGeneratorSetup.java
+++ b/junit/src/org/netbeans/modules/junit/TestGeneratorSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/TestMethodNameGenerator.java
+++ b/junit/src/org/netbeans/modules/junit/TestMethodNameGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/TestabilityJudge.java
+++ b/junit/src/org/netbeans/modules/junit/TestabilityJudge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/TestabilityResult.java
+++ b/junit/src/org/netbeans/modules/junit/TestabilityResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/TopClassFinder.java
+++ b/junit/src/org/netbeans/modules/junit/TopClassFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/TypeNameIdGenerator.java
+++ b/junit/src/org/netbeans/modules/junit/TypeNameIdGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/api/JUnitSettings.java
+++ b/junit/src/org/netbeans/modules/junit/api/JUnitSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/api/JUnitTestSuite.java
+++ b/junit/src/org/netbeans/modules/junit/api/JUnitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
+++ b/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/api/JUnitTestcase.java
+++ b/junit/src/org/netbeans/modules/junit/api/JUnitTestcase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/api/JUnitUtils.java
+++ b/junit/src/org/netbeans/modules/junit/api/JUnitUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/src/org/netbeans/modules/junit/plugin/JUnitPlugin.java
+++ b/junit/src/org/netbeans/modules/junit/plugin/JUnitPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/go/Alfa.java
+++ b/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/go/Alfa.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/pkgtestcreation/test/TestClass.java
+++ b/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/pkgtestcreation/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/pkgtestcreation/test/TestClass2.java
+++ b/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/pkgtestcreation/test/TestClass2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/testcreation/test/TestClass.java
+++ b/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/testcreation/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/testresults/test/TestClass.java
+++ b/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/testresults/test/TestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/testresults/test/TestSuccess.java
+++ b/junit/test/qa-functional/data/JunitTestProject/src/org/netbeans/test/junit/testresults/test/TestSuccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/go/AlfaTest.java
+++ b/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/go/AlfaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/go/GoSuite.java
+++ b/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/go/GoSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/EmptyJUnitTest.java
+++ b/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/EmptyJUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/ResultTestSuite.java
+++ b/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/ResultTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/TestClassTest.java
+++ b/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/TestClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/TestSuccessTest.java
+++ b/junit/test/qa-functional/data/JunitTestProject/test/org/netbeans/test/junit/testresults/test/TestSuccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/CreateTestsAction.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/CreateTestsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/ExecuteTestAction.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/ExecuteTestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/OpenTestAction.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/OpenTestAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/ResultWindowViewAction.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/actions/ResultWindowViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/dialogs/CreateTestsDialogOperator.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/dialogs/CreateTestsDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/nodes/JUnitNode.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/nodes/JUnitNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/testcases/ExtJellyTestCaseForJunit3.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/testcases/ExtJellyTestCaseForJunit3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/testcases/ExtJellyTestCaseForJunit4.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/testcases/ExtJellyTestCaseForJunit4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/testcases/JunitTestCase.java
+++ b/junit/test/qa-functional/src/org/netbeans/jellytools/modules/junit/testcases/JunitTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/creation/CreateTestTest.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/creation/CreateTestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/creation/GotoTest.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/creation/GotoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/creation/TestCreationTestSuite.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/creation/TestCreationTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/junit3/CreateProjectTest.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/junit3/CreateProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/junit3/Junit3TestSuitx.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/junit3/Junit3TestSuitx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/junit4/CreateProjectTest.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/junit4/CreateProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/junit4/Junit4TestSuite.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/junit4/Junit4TestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/results/ResultsWindowTest.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/results/ResultsWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/results/TestResultsTestSuite.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/results/TestResultsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/utils/ResultWindowOperator.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/utils/ResultWindowOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/utils/StatisticsPanelOperator.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/utils/StatisticsPanelOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/qa-functional/src/org/netbeans/test/junit/utils/Utilities.java
+++ b/junit/test/qa-functional/src/org/netbeans/test/junit/utils/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/junit/test/unit/src/org/netbeans/modules/junit/api/RegexpUtilsTest.java
+++ b/junit/test/unit/src/org/netbeans/modules/junit/api/RegexpUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.fallback/src/org/netbeans/modules/keyring/fallback/FallbackProvider.java
+++ b/keyring.fallback/src/org/netbeans/modules/keyring/fallback/FallbackProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.fallback/src/org/netbeans/modules/keyring/fallback/MasterPasswordEncryption.java
+++ b/keyring.fallback/src/org/netbeans/modules/keyring/fallback/MasterPasswordEncryption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.fallback/src/org/netbeans/modules/keyring/fallback/MasterPasswordPanel.java
+++ b/keyring.fallback/src/org/netbeans/modules/keyring/fallback/MasterPasswordPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.fallback/src/org/netbeans/modules/keyring/spi/EncryptionProvider.java
+++ b/keyring.fallback/src/org/netbeans/modules/keyring/spi/EncryptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.fallback/src/org/netbeans/modules/keyring/utils/Utils.java
+++ b/keyring.fallback/src/org/netbeans/modules/keyring/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.fallback/test/unit/src/org/netbeans/modules/keyring/fallback/FallbackProviderTest.java
+++ b/keyring.fallback/test/unit/src/org/netbeans/modules/keyring/fallback/FallbackProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.fallback/test/unit/src/org/netbeans/modules/keyring/fallback/MasterPasswordEncryptionTest.java
+++ b/keyring.fallback/test/unit/src/org/netbeans/modules/keyring/fallback/MasterPasswordEncryptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeKeyringLibrary.java
+++ b/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeKeyringLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeProvider.java
+++ b/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/src/org/netbeans/modules/keyring/kde/CommonKWalletProvider.java
+++ b/keyring.impl/src/org/netbeans/modules/keyring/kde/CommonKWalletProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/src/org/netbeans/modules/keyring/kde/KWalletProvider.java
+++ b/keyring.impl/src/org/netbeans/modules/keyring/kde/KWalletProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/src/org/netbeans/modules/keyring/mac/MacProvider.java
+++ b/keyring.impl/src/org/netbeans/modules/keyring/mac/MacProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/src/org/netbeans/modules/keyring/mac/SecurityLibrary.java
+++ b/keyring.impl/src/org/netbeans/modules/keyring/mac/SecurityLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/src/org/netbeans/modules/keyring/win32/Win32Protect.java
+++ b/keyring.impl/src/org/netbeans/modules/keyring/win32/Win32Protect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/test/unit/src/org/netbeans/modules/keyring/KeyringProviderTestBase.java
+++ b/keyring.impl/test/unit/src/org/netbeans/modules/keyring/KeyringProviderTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/test/unit/src/org/netbeans/modules/keyring/gnome/GnomeProviderTest.java
+++ b/keyring.impl/test/unit/src/org/netbeans/modules/keyring/gnome/GnomeProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/test/unit/src/org/netbeans/modules/keyring/kde/KWalletProviderTest.java
+++ b/keyring.impl/test/unit/src/org/netbeans/modules/keyring/kde/KWalletProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/test/unit/src/org/netbeans/modules/keyring/mac/MacProviderTest.java
+++ b/keyring.impl/test/unit/src/org/netbeans/modules/keyring/mac/MacProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring.impl/test/unit/src/org/netbeans/modules/keyring/win32/Win32ProtectTest.java
+++ b/keyring.impl/test/unit/src/org/netbeans/modules/keyring/win32/Win32ProtectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring/src/org/netbeans/api/keyring/Keyring.java
+++ b/keyring/src/org/netbeans/api/keyring/Keyring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring/src/org/netbeans/api/keyring/package-info.java
+++ b/keyring/src/org/netbeans/api/keyring/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring/src/org/netbeans/spi/keyring/KeyringProvider.java
+++ b/keyring/src/org/netbeans/spi/keyring/KeyringProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/keyring/src/org/netbeans/spi/keyring/package-info.java
+++ b/keyring/src/org/netbeans/spi/keyring/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.diff/src/org/netbeans/modules/languages/diff/DiffDataObject.java
+++ b/languages.diff/src/org/netbeans/modules/languages/diff/DiffDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.diff/src/org/netbeans/modules/languages/diff/DiffLanguageHierarchy.java
+++ b/languages.diff/src/org/netbeans/modules/languages/diff/DiffLanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.diff/src/org/netbeans/modules/languages/diff/DiffLanguageProvider.java
+++ b/languages.diff/src/org/netbeans/modules/languages/diff/DiffLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.diff/src/org/netbeans/modules/languages/diff/DiffLexer.java
+++ b/languages.diff/src/org/netbeans/modules/languages/diff/DiffLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.diff/src/org/netbeans/modules/languages/diff/DiffTokenId.java
+++ b/languages.diff/src/org/netbeans/modules/languages/diff/DiffTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.manifest/src/org/netbeans/modules/languages/manifest/MfDataObject.java
+++ b/languages.manifest/src/org/netbeans/modules/languages/manifest/MfDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.manifest/src/org/netbeans/modules/languages/manifest/MfLanguageHierarchy.java
+++ b/languages.manifest/src/org/netbeans/modules/languages/manifest/MfLanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.manifest/src/org/netbeans/modules/languages/manifest/MfLanguageProvider.java
+++ b/languages.manifest/src/org/netbeans/modules/languages/manifest/MfLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.manifest/src/org/netbeans/modules/languages/manifest/MfLexer.java
+++ b/languages.manifest/src/org/netbeans/modules/languages/manifest/MfLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.manifest/src/org/netbeans/modules/languages/manifest/MfTokenId.java
+++ b/languages.manifest/src/org/netbeans/modules/languages/manifest/MfTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/EmbeddedSectionsHighlighting.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/EmbeddedSectionsHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/IndentUtils.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/IndentUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/InsertTabAction.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/InsertTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlCompletion.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlDataObject.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandler.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlLanguage.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlLexer.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlParser.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlParserResult.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlParserResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlScanner.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlSemanticAnalyzer.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlSemanticAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlTokenId.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/src/org/netbeans/modules/languages/yaml/ruby/RubyEmbeddingProvider.java
+++ b/languages.yaml/src/org/netbeans/modules/languages/yaml/ruby/RubyEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlCompletionTest.java
+++ b/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlCompletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandlerTest.java
+++ b/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlLexerTest.java
+++ b/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlParserTest.java
+++ b/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlScannerTest.java
+++ b/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlSemanticAnalyzerTest.java
+++ b/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlSemanticAnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlTestBase.java
+++ b/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ASTEvaluator.java
+++ b/languages/src/org/netbeans/api/languages/ASTEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ASTItem.java
+++ b/languages/src/org/netbeans/api/languages/ASTItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ASTNode.java
+++ b/languages/src/org/netbeans/api/languages/ASTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ASTPath.java
+++ b/languages/src/org/netbeans/api/languages/ASTPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ASTToken.java
+++ b/languages/src/org/netbeans/api/languages/ASTToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/CharInput.java
+++ b/languages/src/org/netbeans/api/languages/CharInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/CompletionItem.java
+++ b/languages/src/org/netbeans/api/languages/CompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/Context.java
+++ b/languages/src/org/netbeans/api/languages/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/Highlighting.java
+++ b/languages/src/org/netbeans/api/languages/Highlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/Language.java
+++ b/languages/src/org/netbeans/api/languages/Language.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/LanguageDefinitionNotFoundException.java
+++ b/languages/src/org/netbeans/api/languages/LanguageDefinitionNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/LanguagesManager.java
+++ b/languages/src/org/netbeans/api/languages/LanguagesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/LibrarySupport.java
+++ b/languages/src/org/netbeans/api/languages/LibrarySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ParseException.java
+++ b/languages/src/org/netbeans/api/languages/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ParserManager.java
+++ b/languages/src/org/netbeans/api/languages/ParserManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/ParserManagerListener.java
+++ b/languages/src/org/netbeans/api/languages/ParserManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/SyntaxContext.java
+++ b/languages/src/org/netbeans/api/languages/SyntaxContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/TokenInput.java
+++ b/languages/src/org/netbeans/api/languages/TokenInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/database/DatabaseContext.java
+++ b/languages/src/org/netbeans/api/languages/database/DatabaseContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/database/DatabaseDefinition.java
+++ b/languages/src/org/netbeans/api/languages/database/DatabaseDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/database/DatabaseItem.java
+++ b/languages/src/org/netbeans/api/languages/database/DatabaseItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/database/DatabaseManager.java
+++ b/languages/src/org/netbeans/api/languages/database/DatabaseManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/api/languages/database/DatabaseUsage.java
+++ b/languages/src/org/netbeans/api/languages/database/DatabaseUsage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/Feature.java
+++ b/languages/src/org/netbeans/modules/languages/Feature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/FeatureList.java
+++ b/languages/src/org/netbeans/modules/languages/FeatureList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/Language.java
+++ b/languages/src/org/netbeans/modules/languages/Language.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/LanguageImpl.java
+++ b/languages/src/org/netbeans/modules/languages/LanguageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/LanguagesManager.java
+++ b/languages/src/org/netbeans/modules/languages/LanguagesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/NBSLanguage.java
+++ b/languages/src/org/netbeans/modules/languages/NBSLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/NBSLanguageReader.java
+++ b/languages/src/org/netbeans/modules/languages/NBSLanguageReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/ParserManagerImpl.java
+++ b/languages/src/org/netbeans/modules/languages/ParserManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/Rule.java
+++ b/languages/src/org/netbeans/modules/languages/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/Selector.java
+++ b/languages/src/org/netbeans/modules/languages/Selector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/TokenType.java
+++ b/languages/src/org/netbeans/modules/languages/TokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/Utils.java
+++ b/languages/src/org/netbeans/modules/languages/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/GLFFilesCustomEditor.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/GLFFilesCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/Install.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/Install.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataLoader.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataLoaderBeanInfo.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataNode.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataObject.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/LanguagesDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/LanguagesEditorKit.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/LanguagesEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/dataobject/MimeLookupInitializerImpl.java
+++ b/languages/src/org/netbeans/modules/languages/dataobject/MimeLookupInitializerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/ext/NBS.java
+++ b/languages/src/org/netbeans/modules/languages/ext/NBS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ASTBrowserAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/ASTBrowserAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ASTBrowserTopComponent.java
+++ b/languages/src/org/netbeans/modules/languages/features/ASTBrowserTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ActionCreator.java
+++ b/languages/src/org/netbeans/modules/languages/features/ActionCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/AnnotationManager.java
+++ b/languages/src/org/netbeans/modules/languages/features/AnnotationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/BraceCompletionDeleteAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/BraceCompletionDeleteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/BraceCompletionInsertAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/BraceCompletionInsertAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/BraceHighlighting.java
+++ b/languages/src/org/netbeans/modules/languages/features/BraceHighlighting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/CodeCommentAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/CodeCommentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/CodeFoldingSideBarFactory.java
+++ b/languages/src/org/netbeans/modules/languages/features/CodeFoldingSideBarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/CodeUncommentAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/CodeUncommentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/CollapseFoldTypeAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/CollapseFoldTypeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ColorsASTEvaluator.java
+++ b/languages/src/org/netbeans/modules/languages/features/ColorsASTEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ColorsManager.java
+++ b/languages/src/org/netbeans/modules/languages/features/ColorsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/CompletionProviderImpl.java
+++ b/languages/src/org/netbeans/modules/languages/features/CompletionProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/CompletionSupport.java
+++ b/languages/src/org/netbeans/modules/languages/features/CompletionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ContextASTEvaluator.java
+++ b/languages/src/org/netbeans/modules/languages/features/ContextASTEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/DatabaseManager.java
+++ b/languages/src/org/netbeans/modules/languages/features/DatabaseManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/DeclarationASTEvaluator.java
+++ b/languages/src/org/netbeans/modules/languages/features/DeclarationASTEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/EditorTokenInput.java
+++ b/languages/src/org/netbeans/modules/languages/features/EditorTokenInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ExpandFoldTypeAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/ExpandFoldTypeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/FileNotParsedException.java
+++ b/languages/src/org/netbeans/modules/languages/features/FileNotParsedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/Folds.java
+++ b/languages/src/org/netbeans/modules/languages/features/Folds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/FormatAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/FormatAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/GLFHighlightsLayerFactory.java
+++ b/languages/src/org/netbeans/modules/languages/features/GLFHighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/GenericAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/GenericAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/GoToDeclarationAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/GoToDeclarationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/HighlighterSupport.java
+++ b/languages/src/org/netbeans/modules/languages/features/HighlighterSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/HyperlinkListener.java
+++ b/languages/src/org/netbeans/modules/languages/features/HyperlinkListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/IndentAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/IndentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/IndentFactory.java
+++ b/languages/src/org/netbeans/modules/languages/features/IndentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/Index.java
+++ b/languages/src/org/netbeans/modules/languages/features/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/InstantRenameAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/InstantRenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/LanguagesFoldManager.java
+++ b/languages/src/org/netbeans/modules/languages/features/LanguagesFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/LanguagesGenerateFoldPopupAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/LanguagesGenerateFoldPopupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/LanguagesHighlightsLayer.java
+++ b/languages/src/org/netbeans/modules/languages/features/LanguagesHighlightsLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/LanguagesNavigator.java
+++ b/languages/src/org/netbeans/modules/languages/features/LanguagesNavigator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/LanguagesNavigatorModel.java
+++ b/languages/src/org/netbeans/modules/languages/features/LanguagesNavigatorModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/LocalizationSupport.java
+++ b/languages/src/org/netbeans/modules/languages/features/LocalizationSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/MarkOccurrencesSupport.java
+++ b/languages/src/org/netbeans/modules/languages/features/MarkOccurrencesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/SemanticHighlightsLayer.java
+++ b/languages/src/org/netbeans/modules/languages/features/SemanticHighlightsLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/SyntaxErrorHighlighter.java
+++ b/languages/src/org/netbeans/modules/languages/features/SyntaxErrorHighlighter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ToggleCommentAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/ToggleCommentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/TokenHighlightsLayer.java
+++ b/languages/src/org/netbeans/modules/languages/features/TokenHighlightsLayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/TokensBrowserAction.java
+++ b/languages/src/org/netbeans/modules/languages/features/TokensBrowserAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/TokensBrowserTopComponent.java
+++ b/languages/src/org/netbeans/modules/languages/features/TokensBrowserTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/ToolTipAnnotation.java
+++ b/languages/src/org/netbeans/modules/languages/features/ToolTipAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/UpToDateStatusProviderFactoryImpl.java
+++ b/languages/src/org/netbeans/modules/languages/features/UpToDateStatusProviderFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/features/UsagesASTEvaluator.java
+++ b/languages/src/org/netbeans/modules/languages/features/UsagesASTEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/lexer/DelegatingInputBridge.java
+++ b/languages/src/org/netbeans/modules/languages/lexer/DelegatingInputBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/lexer/InputBridge.java
+++ b/languages/src/org/netbeans/modules/languages/lexer/InputBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/lexer/SLanguageHierarchy.java
+++ b/languages/src/org/netbeans/modules/languages/lexer/SLanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/lexer/SLanguageProvider.java
+++ b/languages/src/org/netbeans/modules/languages/lexer/SLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/lexer/SLexer.java
+++ b/languages/src/org/netbeans/modules/languages/lexer/SLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/lexer/STokenId.java
+++ b/languages/src/org/netbeans/modules/languages/lexer/STokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/ASTFeatures.java
+++ b/languages/src/org/netbeans/modules/languages/parser/ASTFeatures.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/AnalyserAnalyser.java
+++ b/languages/src/org/netbeans/modules/languages/parser/AnalyserAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/DG.java
+++ b/languages/src/org/netbeans/modules/languages/parser/DG.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/DGUtils.java
+++ b/languages/src/org/netbeans/modules/languages/parser/DGUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/First.java
+++ b/languages/src/org/netbeans/modules/languages/parser/First.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/LLSyntaxAnalyser.java
+++ b/languages/src/org/netbeans/modules/languages/parser/LLSyntaxAnalyser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/NodeFactory.java
+++ b/languages/src/org/netbeans/modules/languages/parser/NodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/Parser.java
+++ b/languages/src/org/netbeans/modules/languages/parser/Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/Pattern.java
+++ b/languages/src/org/netbeans/modules/languages/parser/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/StringInput.java
+++ b/languages/src/org/netbeans/modules/languages/parser/StringInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/SyntaxError.java
+++ b/languages/src/org/netbeans/modules/languages/parser/SyntaxError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java
+++ b/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/qa-functional/src/org/netbeans/test/languages/OpenProjectFileTest.java
+++ b/languages/test/qa-functional/src/org/netbeans/test/languages/OpenProjectFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/qa-functional/src/org/netbeans/test/languages/OpenStandaloneFileTest.java
+++ b/languages/test/qa-functional/src/org/netbeans/test/languages/OpenStandaloneFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/qa-functional/src/org/netbeans/test/languages/TokensTest.java
+++ b/languages/test/qa-functional/src/org/netbeans/test/languages/TokensTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/qa-functional/src/org/netbeans/test/lib/BasicOpenFileTest.java
+++ b/languages/test/qa-functional/src/org/netbeans/test/lib/BasicOpenFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/qa-functional/src/org/netbeans/test/lib/BasicTokensTest.java
+++ b/languages/test/qa-functional/src/org/netbeans/test/lib/BasicTokensTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/qa-functional/src/org/netbeans/test/lib/DumpTokens.java
+++ b/languages/test/qa-functional/src/org/netbeans/test/lib/DumpTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/api/languages/ASTTest.java
+++ b/languages/test/unit/src/org/netbeans/api/languages/ASTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/LanguageTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/LanguageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/NBSLanguageReaderTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/NBSLanguageReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/TestLanguage.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/TestLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/TestUtils.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/parser/AnalyserTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/parser/AnalyserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/parser/DGUtilsTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/parser/DGUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/parser/FirstTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/parser/FirstTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/parser/Grammar1.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/parser/Grammar1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/parser/NBSTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/parser/NBSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/parser/ParserTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/parser/ParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/languages/test/unit/src/org/netbeans/modules/languages/parser/PatternTest.java
+++ b/languages/test/unit/src/org/netbeans/modules/languages/parser/PatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/src/org/netbeans/modules/lexer/nbbridge/LanguagesEmbeddingMap.java
+++ b/lexer.nbbridge/src/org/netbeans/modules/lexer/nbbridge/LanguagesEmbeddingMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/src/org/netbeans/modules/lexer/nbbridge/MimeLookupFolderInfo.java
+++ b/lexer.nbbridge/src/org/netbeans/modules/lexer/nbbridge/MimeLookupFolderInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/src/org/netbeans/modules/lexer/nbbridge/MimeLookupLanguageProvider.java
+++ b/lexer.nbbridge/src/org/netbeans/modules/lexer/nbbridge/MimeLookupLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/MimeLookupLanguageProviderTest.java
+++ b/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/MimeLookupLanguageProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimpleCharLexer.java
+++ b/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimpleCharLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimpleCharTokenId.java
+++ b/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimpleCharTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimplePlainLexer.java
+++ b/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimplePlainLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimplePlainTokenId.java
+++ b/lexer.nbbridge/test/unit/src/org/netbeans/modules/lexer/nbbridge/test/simple/SimplePlainTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/DemoSampleToken.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/DemoSampleToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/DemoToken.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/DemoToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/DemoTokenUpdater.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/DemoTokenUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/EditorPaneDemo.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/EditorPaneDemo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/LexerRandomTest.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/LexerRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/StringLexerInput.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/StringLexerInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/StringToken.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/StringToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/Calc.g
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/Calc.g
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcLanguage.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcLanguageUtilities.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcLanguageUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcLexer.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcScanner.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcScannerTokenTypes.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcScannerTokenTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcTestDescription.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/antlr/CalcTestDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkLanguage.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkLanguageUtilities.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkLanguageUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkLexer.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkTestDescription.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/link/LinkTestDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/plain/PlainLanguage.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/plain/PlainLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/plain/PlainLexer.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/plain/PlainLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/plain/PlainTestDescription.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/handcoded/plain/PlainTestDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/Calc.jj
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/Calc.jj
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcConstants.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcLanguage.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcLanguageUtilities.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcLanguageUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcLexer.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcTestDescription.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcTestDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcTokenManager.java
+++ b/lexer/demo/src/org/netbeans/modules/lexer/demo/javacc/CalcTokenManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/AntlrGenerateLanguageDescription.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/AntlrGenerateLanguageDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/AntlrGenerateLanguageSource.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/AntlrGenerateLanguageSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/GenerateLanguageDescription.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/GenerateLanguageDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/GenerateLanguageSource.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/GenerateLanguageSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/HandcodedGenerateLanguageSource.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/HandcodedGenerateLanguageSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/JavaCCGenerateLanguageDescription.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/JavaCCGenerateLanguageDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/JavaCCGenerateLanguageSource.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/JavaCCGenerateLanguageSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/antsrc/org/netbeans/lexer/gen/StringReplace.java
+++ b/lexer/gen/antsrc/org/netbeans/lexer/gen/StringReplace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/DescriptionReader.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/DescriptionReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/LanguageData.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/LanguageData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/LanguageGenerator.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/LanguageGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/MutableTokenId.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/MutableTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/TokenTypes.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/TokenTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrLanguageDescriptionGenerator.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrLanguageDescriptionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrLanguageGenerator.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrLanguageGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrTokenTypes.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrTokenTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrUnicodeRanges.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/antlr/AntlrUnicodeRanges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/handcoded/HandcodedLanguageGenerator.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/handcoded/HandcodedLanguageGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCLanguageDescriptionGenerator.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCLanguageDescriptionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCLanguageGenerator.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCLanguageGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCTokenTypes.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCTokenTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCUnicodeRanges.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/javacc/JavaCCUnicodeRanges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/util/LexerGenUtilities.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/util/LexerGenUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/util/LexerGenUtilitiesImpl.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/util/LexerGenUtilitiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/gen/src/org/netbeans/modules/lexer/gen/util/UnicodeRanges.java
+++ b/lexer/gen/src/org/netbeans/modules/lexer/gen/util/UnicodeRanges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/InputAttributes.java
+++ b/lexer/src/org/netbeans/api/lexer/InputAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/Language.java
+++ b/lexer/src/org/netbeans/api/lexer/Language.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/LanguagePath.java
+++ b/lexer/src/org/netbeans/api/lexer/LanguagePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/PartType.java
+++ b/lexer/src/org/netbeans/api/lexer/PartType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/Token.java
+++ b/lexer/src/org/netbeans/api/lexer/Token.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenChange.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenHierarchy.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenHierarchyEvent.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenHierarchyEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenHierarchyEventType.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenHierarchyEventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenHierarchyListener.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenHierarchyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenId.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenSequence.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/api/lexer/TokenUtilities.java
+++ b/lexer/src/org/netbeans/api/lexer/TokenUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/BatchTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/BatchTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/CharPreprocessor.java
+++ b/lexer/src/org/netbeans/lib/lexer/CharPreprocessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/CharPreprocessorError.java
+++ b/lexer/src/org/netbeans/lib/lexer/CharPreprocessorError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/CharPreprocessorOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/CharPreprocessorOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/CharProvider.java
+++ b/lexer/src/org/netbeans/lib/lexer/CharProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/EmbeddedJoinInfo.java
+++ b/lexer/src/org/netbeans/lib/lexer/EmbeddedJoinInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/EmbeddedTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/EmbeddedTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/EmbeddingOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/EmbeddingOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/IntegerCache.java
+++ b/lexer/src/org/netbeans/lib/lexer/IntegerCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/JoinLexerInputOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/JoinLexerInputOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/JoinTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/JoinTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LAState.java
+++ b/lexer/src/org/netbeans/lib/lexer/LAState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LanguageIds.java
+++ b/lexer/src/org/netbeans/lib/lexer/LanguageIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LanguageManager.java
+++ b/lexer/src/org/netbeans/lib/lexer/LanguageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LanguageOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/LanguageOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LexerApiPackageAccessor.java
+++ b/lexer/src/org/netbeans/lib/lexer/LexerApiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LexerInputOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/LexerInputOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LexerSpiPackageAccessor.java
+++ b/lexer/src/org/netbeans/lib/lexer/LexerSpiPackageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/LexerUtilsConstants.java
+++ b/lexer/src/org/netbeans/lib/lexer/LexerUtilsConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/PreprocessedTextLexerInputOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/PreprocessedTextLexerInputOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/PreprocessedTextStorage.java
+++ b/lexer/src/org/netbeans/lib/lexer/PreprocessedTextStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/StackElementArray.java
+++ b/lexer/src/org/netbeans/lib/lexer/StackElementArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/SubSequenceTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/SubSequenceTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TextLexerInputOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/TextLexerInputOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TokenHierarchyOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/TokenHierarchyOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TokenIdImpl.java
+++ b/lexer/src/org/netbeans/lib/lexer/TokenIdImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TokenIdSet.java
+++ b/lexer/src/org/netbeans/lib/lexer/TokenIdSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/TokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TokenListList.java
+++ b/lexer/src/org/netbeans/lib/lexer/TokenListList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TokenOrEmbedding.java
+++ b/lexer/src/org/netbeans/lib/lexer/TokenOrEmbedding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/TokenSequenceList.java
+++ b/lexer/src/org/netbeans/lib/lexer/TokenSequenceList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/UnicodeEscapesPreprocessor.java
+++ b/lexer/src/org/netbeans/lib/lexer/UnicodeEscapesPreprocessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/WrapTokenId.java
+++ b/lexer/src/org/netbeans/lib/lexer/WrapTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/WrapTokenIdCache.java
+++ b/lexer/src/org/netbeans/lib/lexer/WrapTokenIdCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/DocumentInput.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/DocumentInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/FilterSnapshotTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/FilterSnapshotTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/IncTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/IncTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/JoinTokenListChange.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/JoinTokenListChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/MutableJoinLexerInputOperation.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/MutableJoinLexerInputOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/MutableTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/MutableTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/OriginalText.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/OriginalText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/RemovedTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/RemovedTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/SnapshotTokenList.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/SnapshotTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/TokenChangeInfo.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/TokenChangeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/TokenHierarchyEventInfo.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/TokenHierarchyEventInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/TokenHierarchyUpdate.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/TokenHierarchyUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/TokenListChange.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/TokenListChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/TokenListListUpdate.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/TokenListListUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/inc/TokenListUpdater.java
+++ b/lexer/src/org/netbeans/lib/lexer/inc/TokenListUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/AbstractToken.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/AbstractToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/CustomTextToken.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/CustomTextToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/DefaultToken.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/DefaultToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/JoinToken.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/JoinToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/JoinTokenText.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/JoinTokenText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/PartToken.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/PartToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/PartTypePropertyProvider.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/PartTypePropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/PropertyToken.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/PropertyToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/lib/lexer/token/TextToken.java
+++ b/lexer/src/org/netbeans/lib/lexer/token/TextToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/EmbeddingPresence.java
+++ b/lexer/src/org/netbeans/spi/lexer/EmbeddingPresence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/LanguageEmbedding.java
+++ b/lexer/src/org/netbeans/spi/lexer/LanguageEmbedding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/LanguageHierarchy.java
+++ b/lexer/src/org/netbeans/spi/lexer/LanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/LanguageProvider.java
+++ b/lexer/src/org/netbeans/spi/lexer/LanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/Lexer.java
+++ b/lexer/src/org/netbeans/spi/lexer/Lexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/LexerInput.java
+++ b/lexer/src/org/netbeans/spi/lexer/LexerInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/LexerRestartInfo.java
+++ b/lexer/src/org/netbeans/spi/lexer/LexerRestartInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/MutableTextInput.java
+++ b/lexer/src/org/netbeans/spi/lexer/MutableTextInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/TokenFactory.java
+++ b/lexer/src/org/netbeans/spi/lexer/TokenFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/TokenHierarchyControl.java
+++ b/lexer/src/org/netbeans/spi/lexer/TokenHierarchyControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/TokenPropertyProvider.java
+++ b/lexer/src/org/netbeans/spi/lexer/TokenPropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/src/org/netbeans/spi/lexer/TokenValidator.java
+++ b/lexer/src/org/netbeans/spi/lexer/TokenValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/api/lexer/CustomTokenClassTest.java
+++ b/lexer/test/unit/src/org/netbeans/api/lexer/CustomTokenClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/api/lexer/InputAttributesTest.java
+++ b/lexer/test/unit/src/org/netbeans/api/lexer/InputAttributesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/api/lexer/LanguagePathTest.java
+++ b/lexer/test/unit/src/org/netbeans/api/lexer/LanguagePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/api/lexer/LanguageTest.java
+++ b/lexer/test/unit/src/org/netbeans/api/lexer/LanguageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/api/lexer/TokenHierarchyTest.java
+++ b/lexer/test/unit/src/org/netbeans/api/lexer/TokenHierarchyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/api/lexer/TokenSequenceTest.java
+++ b/lexer/test/unit/src/org/netbeans/api/lexer/TokenSequenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/CharRangesTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/CharRangesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/EmbeddedTokenListTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/EmbeddedTokenListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/LAStateTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/LAStateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/LanguageIdsTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/LanguageIdsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/LanguageManagerTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/LanguageManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/TokenSequenceListTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/TokenSequenceListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/WrapTokenIdCacheTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/WrapTokenIdCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/inc/EmbeddingUpdateTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/inc/EmbeddingUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/inc/SnapshotTokenListTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/inc/SnapshotTokenListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/inc/TokenHierarchyEventTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/inc/TokenHierarchyEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestChangingTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestChangingTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestCharLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestCharLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestCharTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestCharTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestEmbeddingTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestEmbeddingTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestGenLanguage.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestGenLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestHTMLTagLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestHTMLTagLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestHTMLTagTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestHTMLTagTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJavadocLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJavadocLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJavadocTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJavadocTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTagLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTagLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTagTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTagTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTextLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTextLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTextTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinMixTextTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTextLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTextLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTextTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTextTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTopLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTopLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTopTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestJoinTopTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestLineLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestLineLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestLineTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestLineTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestPlainLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestPlainLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestPlainTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestPlainTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestSaveTokensInLATokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestSaveTokensInLATokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestStringLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestStringLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestStringTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestStringTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/lang/TestTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/CharRangesDump.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/CharRangesDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/FixedTextDescriptor.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/FixedTextDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/LexerTestUtilities.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/LexerTestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/ModificationTextDocument.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/ModificationTextDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/RandomCharDescriptor.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/RandomCharDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/RandomModifyDescriptor.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/RandomModifyDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/RandomTextProvider.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/RandomTextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/TestLanguageProvider.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/TestLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/TestRandomModify.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/TestRandomModify.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TextAsSingleTokenLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TextAsSingleTokenLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TextAsSingleTokenTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TextAsSingleTokenTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpCheck.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/dump/TokenDumpTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/DocumentUpdateTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/DocumentUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/OriginalTextTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/OriginalTextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenHierarchyRebuildTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenHierarchyRebuildTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenHierarchySnapshotTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenHierarchySnapshotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenListUpdaterExtraTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenListUpdaterExtraTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenListUpdaterTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/inc/TokenListUpdaterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinMixTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinMixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinRandomTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinSectionsMod1Test.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinSectionsMod1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinSectionsMod2Test.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinSectionsMod2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinSectionsPositioningTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinSectionsPositioningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/CharPreprocessingTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/CharPreprocessingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/CustomEmbeddingTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/CustomEmbeddingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/FlyTokensTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/FlyTokensTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/GenLanguageTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/GenLanguageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLanguageProvider.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLanguageTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLanguageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerBatchTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerBatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerIncTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerIncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerRandomTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerRandomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/InvalidLexerOperationTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/InvalidLexerOperationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/StateLexer.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/StateLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/StateLexerIncTest.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/StateLexerIncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/StateTokenId.java
+++ b/lexer/test/unit/src/org/netbeans/lib/lexer/test/state/StateTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lexer/test/unit/src/org/netbeans/spi/lexer/LexerInputTest.java
+++ b/lexer/test/unit/src/org/netbeans/spi/lexer/LexerInputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/AgentWorker.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/AgentWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/LoaderDelegator.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/LoaderDelegator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbRemoteLoader.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbRemoteLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteAgent.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteClassLoader.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteCodes.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteCodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteResolutionException.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteResolutionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/SwingExecutor.java
+++ b/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/SwingExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/CancelAbort.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/CancelAbort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/CancelService.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/CancelService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBAttr.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBAttr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassReader.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassWriter.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBEnter.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBEnter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavacTrees.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavacTrees.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavadocEnter.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavadocEnter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavadocMemberEnter.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavadocMemberEnter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBMemberEnter.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBMemberEnter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBMessager.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBMessager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBNames.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBResolve.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBResolve.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBTreeMaker.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBTreeMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/PartialReparser.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/PartialReparser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/AnonymousNumberingTest.java
+++ b/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/AnonymousNumberingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/CouplingTest.java
+++ b/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/CouplingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
+++ b/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/Utilities.java
+++ b/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartComponent.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartConfigurationListener.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartConfigurationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartContext.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartDecorator.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartItem.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartItemChange.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartItemChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartItemListener.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartItemListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartOverlay.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartSelectionListener.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartSelectionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartSelectionManager.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartSelectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartSelectionModel.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ChartSelectionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/CompoundItemPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/CompoundItemPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemSelection.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemSelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemsListener.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemsModel.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/ItemsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/PaintersListener.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/PaintersListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/PaintersModel.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/PaintersModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/Timeline.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/Timeline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisComponent.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisMark.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisMarksComputer.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisMarksComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisMarksPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/AxisMarksPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/BytesAxisUtils.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/BytesAxisUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/BytesMark.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/BytesMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/BytesMarksPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/BytesMarksPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/DecimalAxisUtils.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/DecimalAxisUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/LongMark.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/LongMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/PercentLongMarksPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/PercentLongMarksPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/SimpleLongMarksPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/SimpleLongMarksPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimeAxisUtils.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimeAxisUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimeMark.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimeMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimeMarksPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimeMarksPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimelineMarksComputer.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/axis/TimelineMarksComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/canvas/BufferedCanvasComponent.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/canvas/BufferedCanvasComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/canvas/InteractiveCanvasComponent.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/canvas/InteractiveCanvasComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/canvas/TransformableCanvasComponent.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/canvas/TransformableCanvasComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/CrossBorderLayout.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/CrossBorderLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/LongRect.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/LongRect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/RoundBorder.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/RoundBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/Utils.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/swing/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/BytesXYItemMarksComputer.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/BytesXYItemMarksComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/CompoundXYItemPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/CompoundXYItemPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/DecimalXYItemMarksComputer.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/DecimalXYItemMarksComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItem.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemChange.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemMarksComputer.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemMarksComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemSelection.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/XYItemSelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYChart.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYChartContext.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYChartContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItem.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItemMarker.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItemMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItemPainter.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItemPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItemsModel.java
+++ b/lib.profiler.charts/src/org/netbeans/lib/profiler/charts/xy/synchronous/SynchronousXYItemsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/AttachSettings.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/AttachSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/CommonUtils.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/CommonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/GlobalProfilingSettings.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/GlobalProfilingSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/Profiler.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/Profiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/ProfilingSettings.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/ProfilingSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/ProfilingSettingsPresets.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/ProfilingSettingsPresets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/SessionSettings.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/SessionSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/ProfilingStateAdapter.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/ProfilingStateAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/ProfilingStateEvent.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/ProfilingStateEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/ProfilingStateListener.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/ProfilingStateListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/SimpleProfilingStateAdapter.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/event/SimpleProfilingStateAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/integration/IntegrationUtils.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/integration/IntegrationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/Formatters.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/Formatters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/LiveResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/LiveResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/LiveResultsWindowContributor.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/LiveResultsWindowContributor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/ResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/ResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/ResultsView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/ResultsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/StringDecorator.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/StringDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/SwingWorker.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/SwingWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIConstants.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIUtils.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/AbstractBarChartModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/AbstractBarChartModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/AbstractPieChartModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/AbstractPieChartModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/BarChart.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/BarChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/BarChartModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/BarChartModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/ChartActionListener.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/ChartActionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/ChartModelListener.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/ChartModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/DateTimeAxisUtils.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/DateTimeAxisUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/DecimalAxisUtils.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/DecimalAxisUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/DynamicPieChartModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/DynamicPieChartModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/PieChart.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/PieChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/PieChartModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/PieChartModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerGCXYItem.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerGCXYItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerGCXYItemPainter.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerGCXYItemPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYChart.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYItemPainter.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYItemPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYSelectionOverlay.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYSelectionOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYTooltipModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYTooltipModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYTooltipOverlay.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYTooltipOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYTooltipPainter.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/charts/xy/ProfilerXYTooltipPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/AnimatedContainer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/AnimatedContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/AnimationLayout.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/AnimationLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/Animator.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/Animator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CellTipAware.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CellTipAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CellTipManager.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CellTipManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CloseButton.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CloseButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ColorIcon.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ColorIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ComponentMorpher.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ComponentMorpher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ComponentMorpher2.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ComponentMorpher2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CustomTaskButtonBorder.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/CustomTaskButtonBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/DiscreteProgress.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/DiscreteProgress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/EqualFlowLayout.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/EqualFlowLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/FilterComponent.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/FilterComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/FlatToolBar.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/FlatToolBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/HTMLLabel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/HTMLLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/HTMLTextArea.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/HTMLTextArea.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ImageBlenderPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ImageBlenderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ImagePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ImagePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JAntiLabel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JAntiLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JCheckTree.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JCheckTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JCompoundSplitPane.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JCompoundSplitPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedComboBox.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedRadioButton.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedRadioButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedSpinner.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedSpinner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedSplitPane.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedSplitPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTable.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTree.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JTitledPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JTitledPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JTreeTable.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JTreeTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/LazyComboBox.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/LazyComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/NoCaret.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/NoCaret.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ProfilerToolbar.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ProfilerToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/SnippetPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/SnippetPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ThinBevelBorder.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/ThinBevelBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/VerticalLayout.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/VerticalLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/XPStyleBorder.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/XPStyleBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/BooleanTableCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/BooleanTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/ClassNameTableCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/ClassNameTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/CustomBarCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/CustomBarCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/CustomSortableHeaderRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/CustomSortableHeaderRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/DiffBarCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/DiffBarCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/EnhancedTableCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/EnhancedTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/ExtendedTableModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/ExtendedTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/HTMLLabelTableCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/HTMLLabelTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/JExtendedTablePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/JExtendedTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/LabelBracketTableCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/LabelBracketTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/LabelTableCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/LabelTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/MethodNameTableCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/MethodNameTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/SortableTableModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/SortableTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/TableCellRendererPersistent.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/table/TableCellRendererPersistent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/CheckTreeCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/CheckTreeCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/CheckTreeNode.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/CheckTreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/EnhancedTreeCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/EnhancedTreeCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/MethodNameTreeCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/MethodNameTreeCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/TreeCellRendererPersistent.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/TreeCellRendererPersistent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/AbstractTreeTableModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/AbstractTreeTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/ExtendedTreeTableModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/ExtendedTreeTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/JTreeTablePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/JTreeTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/TreeTableModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/TreeTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/TreeTableModelAdapter.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/treetable/TreeTableModelAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CCTDisplay.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CCTDisplay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUJavaNameRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUJavaNameRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUResUserActionsHandler.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUResUserActionsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUSelectionHandler.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUSelectionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUTreeTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUTreeTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CPUView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CodeRegionLivePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CodeRegionLivePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CodeRegionSnapshotPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CodeRegionSnapshotPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CombinedPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CombinedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffCCTDisplay.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffCCTDisplay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffFlatProfilePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffFlatProfilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/FlatProfilePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/FlatProfilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/LiveCPUView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/LiveCPUView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/LiveFlatProfileCollectorPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/LiveFlatProfileCollectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/LiveFlatProfilePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/LiveFlatProfilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ReverseCallGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ReverseCallGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ScreenshotProvider.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ScreenshotProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SnapshotCPUResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SnapshotCPUResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SnapshotCPUView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SnapshotCPUView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SnapshotFlatProfilePanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SnapshotFlatProfilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/StatisticsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/StatisticsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SubtreeCallGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SubtreeCallGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ThreadsSelector.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ThreadsSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/StatisticalModule.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/StatisticalModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/StatisticalModuleContainer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/StatisticalModuleContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/TimingData.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/TimingData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/AllocationsHistoryGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/AllocationsHistoryGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/CPUGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/CPUGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/ColorFactory.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/ColorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/GraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/GraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/GraphsUI.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/GraphsUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/LivenessHistoryGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/LivenessHistoryGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/MemoryGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/MemoryGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/SurvivingGenerationsGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/SurvivingGenerationsGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/ThreadsGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/ThreadsGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/XYBackground.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/graphs/XYBackground.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/JDBCJavaNameRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/JDBCJavaNameRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/JDBCTreeTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/JDBCTreeTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/JDBCView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/JDBCView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/LiveJDBCView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/LiveJDBCView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/SQLFilterPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/SQLFilterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/SQLFormatter.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/SQLFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/SnapshotJDBCView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/SnapshotJDBCView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/TablesSelector.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/jdbc/TablesSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/locks/LockContentionPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/locks/LockContentionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/locks/LockContentionRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/locks/LockContentionRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/locks/LockContentionTreeCellRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/locks/LockContentionTreeCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ActionsHandler.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ActionsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/AllocResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/AllocResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/AllocTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/AllocTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/AllocTreeTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/AllocTreeTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ClassHistoryActionsHandler.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ClassHistoryActionsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ClassHistoryModels.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ClassHistoryModels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/DiffAllocResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/DiffAllocResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/DiffLivenessResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/DiffLivenessResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/DiffSampledResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/DiffSampledResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveAllocResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveAllocResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveLivenessResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveLivenessResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveMemoryView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveMemoryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveReverseMemCallGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveReverseMemCallGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveSampledResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LiveSampledResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LivenessResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LivenessResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LivenessTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LivenessTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LivenessTreeTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/LivenessTreeTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryCCTTreeModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryCCTTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryJavaNameRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryJavaNameRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryResUserActionsHandler.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryResUserActionsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/MemoryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ReverseMemCallGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/ReverseMemCallGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SampledResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SampledResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SampledTableView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SampledTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotAllocResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotAllocResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotLivenessResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotLivenessResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotMemoryView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotMemoryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotReverseMemCallGraphPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotReverseMemCallGraphPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotSampledResultsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/memory/SnapshotSampledResultsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/monitor/MonitorView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/monitor/MonitorView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/monitor/VMTelemetryModels.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/monitor/VMTelemetryModels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/results/ColoredFilter.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/results/ColoredFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/results/DataView.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/results/DataView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/results/PackageColorer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/results/PackageColorer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ActionPopupButton.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ActionPopupButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/EditableHistoryCombo.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/EditableHistoryCombo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ExportUtils.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ExportUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/FilterUtils.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/FilterUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/FilteringToolbar.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/FilteringToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/GenericToolbar.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/GenericToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/GrayLabel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/GrayLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/HeaderComponent.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/HeaderComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/InvisibleToolbar.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/InvisibleToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/MultiButtonGroup.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/MultiButtonGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/PopupButton.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/PopupButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerColumnModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerPopup.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerRowSorter.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerRowSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTable.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableActions.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableContainer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableHover.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableHover.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableHovers.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTableHovers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTreeTable.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTreeTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTreeTableModel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTreeTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/SearchUtils.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/SearchUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/SmallButton.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/SmallButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/TextArea.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/TextArea.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/BarRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/BarRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/BaseRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/BaseRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/CheckBoxRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/CheckBoxRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/FormattedLabelRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/FormattedLabelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/HideableBarRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/HideableBarRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/JavaNameRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/JavaNameRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/LabelRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/LabelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/McsTimeRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/McsTimeRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/Movable.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/Movable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/MultiRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/MultiRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/NormalBoldGrayRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/NormalBoldGrayRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/NumberPercentRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/NumberPercentRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/NumberRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/NumberRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/PercentRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/PercentRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/ProfilerRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/ProfilerRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/RelativeRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/renderer/RelativeRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/NameStateRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/NameStateRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ThreadStateIcon.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ThreadStateIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ThreadTimeRelRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ThreadTimeRelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ThreadsPanel.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ThreadsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/TimelineHeaderRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/TimelineHeaderRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/TimelineRenderer.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/TimelineRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ViewManager.java
+++ b/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/threads/ViewManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler.ui/test/unit/src/org/netbeans/lib/profiler/ui/SwingWorkerTest.java
+++ b/lib.profiler.ui/test/unit/src/org/netbeans/lib/profiler/ui/SwingWorkerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/Classes.c
+++ b/lib.profiler/native/src-jdk15/Classes.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/GC.c
+++ b/lib.profiler/native/src-jdk15/GC.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/HeapDump.c
+++ b/lib.profiler/native/src-jdk15/HeapDump.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/Stacks.c
+++ b/lib.profiler/native/src-jdk15/Stacks.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/Threads.c
+++ b/lib.profiler/native/src-jdk15/Threads.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/Threads.h
+++ b/lib.profiler/native/src-jdk15/Threads.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/Timers.c
+++ b/lib.profiler/native/src-jdk15/Timers.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/attach.c
+++ b/lib.profiler/native/src-jdk15/attach.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/class_file_cache.c
+++ b/lib.profiler/native/src-jdk15/class_file_cache.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/common_functions.c
+++ b/lib.profiler/native/src-jdk15/common_functions.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/common_functions.h
+++ b/lib.profiler/native/src-jdk15/common_functions.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Classes.h
+++ b/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Classes.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Classes_RedefineException.h
+++ b/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Classes_RedefineException.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_GC.h
+++ b/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_GC.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_HeapDump.h
+++ b/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_HeapDump.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Stacks.h
+++ b/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Stacks.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Threads.h
+++ b/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Threads.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Timers.h
+++ b/lib.profiler/native/src-jdk15/org_netbeans_lib_profiler_server_system_Timers.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/windows/version.h
+++ b/lib.profiler/native/src-jdk15/windows/version.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/native/src-jdk15/windows/version.rc
+++ b/lib.profiler/native/src-jdk15/windows/version.rc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/Classes.java
+++ b/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/Classes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/HeapDump.java
+++ b/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/HeapDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/Histogram.java
+++ b/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/Histogram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/ThreadDump.java
+++ b/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/ThreadDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/Timers.java
+++ b/lib.profiler/src-cvm/org/netbeans/lib/profiler/server/system/Timers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/ProfilerActivate15.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/ProfilerActivate15.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Classes.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Classes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/HeapDump.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/HeapDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Histogram.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Histogram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Histogram18.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Histogram18.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Histogram19.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Histogram19.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/ThreadDump.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/ThreadDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Timers.java
+++ b/lib.profiler/src-jdk15/org/netbeans/lib/profiler/server/system/Timers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/ProfilerClient.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/ProfilerClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/ProfilerClientListener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/ProfilerClientListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/ProfilerEngineSettings.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/ProfilerEngineSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/ProfilerLogger.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/ProfilerLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/ProfilingEventListener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/ProfilingEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/TargetAppRunner.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/TargetAppRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/BaseClassInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/BaseClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassFileCache.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassFileCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassFileParser.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassFileParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassLoaderTable.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassLoaderTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassPath.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassRepository.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/DynamicClassInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/DynamicClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/LazyDynamicClassInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/LazyDynamicClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/PlaceholderClassInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/PlaceholderClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/classfile/SameNameClassGroup.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/classfile/SameNameClassGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/client/AppStatusHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/client/AppStatusHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/client/ClientUtils.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/client/ClientUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/client/MonitoredData.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/client/MonitoredData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/client/ProfilingPointsProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/client/ProfilingPointsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/client/RuntimeProfilingPoint.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/client/RuntimeProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/filters/GenericFilter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/filters/GenericFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/filters/InstrumentationFilter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/filters/InstrumentationFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/filters/JavaTypeFilter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/filters/JavaTypeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/filters/TextFilter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/filters/TextFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/global/CalibrationDataFileIO.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/global/CalibrationDataFileIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/global/CommonConstants.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/global/CommonConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/global/Platform.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/global/Platform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/global/ProfilingSessionStatus.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/global/ProfilingSessionStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/global/TransactionalSupport.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/global/TransactionalSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/AbstractLongMap.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/AbstractLongMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ArrayDump.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ArrayDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ArrayItemValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ArrayItemValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDump.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpInstance.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassLoaderFieldValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassLoaderFieldValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ComputedSummary.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ComputedSummary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/DomMap.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/DomMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/DominatorTree.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/DominatorTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/Field.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/FieldValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/FieldValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/GCRoot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/GCRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/Heap.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/Heap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapProgress.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapProgress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapSummary.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapSummary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofArrayValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofArrayValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofField.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFieldObjectValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFieldObjectValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFieldValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFieldValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoots.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoots.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofInstanceObjectValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofInstanceObjectValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofInstanceValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofInstanceValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofLongMappedByteBuffer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofLongMappedByteBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofMappedByteBuffer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofMappedByteBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofObject.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofPrimitiveType.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofPrimitiveType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofProxy.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/Instance.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/Instance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/InstanceDump.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/InstanceDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaClass.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaFrameGCRoot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaFrameGCRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaFrameHprofGCRoot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaFrameHprofGCRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/LoadClass.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/LoadClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/LoadClassSegment.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/LoadClassSegment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/LongHashMap.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/LongHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/LongMap.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/LongMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/LongSet.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/LongSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/NearestGCRoot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/NearestGCRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectArrayDump.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectArrayDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectArrayInstance.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectArrayInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectArrayLazyList.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectArrayLazyList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectFieldValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectFieldValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectType.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveArrayDump.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveArrayDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveArrayInstance.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveArrayInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveArrayLazyList.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveArrayLazyList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveType.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/PrimitiveType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrame.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrameSegment.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrameSegment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTrace.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTrace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTraceSegment.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTraceSegment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/Summary.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/Summary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/SyntheticClassField.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/SyntheticClassField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/SyntheticClassObjectValue.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/SyntheticClassObjectValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/TagBounds.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/TagBounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ThreadObjectGCRoot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ThreadObjectGCRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/ThreadObjectHprofGCRoot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/ThreadObjectHprofGCRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/TreeObject.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/TreeObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/Type.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/Type.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/heap/Value.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/heap/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/BadLocationException.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/BadLocationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CPExtensionsRepository.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CPExtensionsRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ClassManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ClassManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ClassRewriter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ClassRewriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CodeRegionEntryExitCallsInjector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CodeRegionEntryExitCallsInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CodeRegionMethodInstrumentor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CodeRegionMethodInstrumentor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ConstantPoolExtension.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ConstantPoolExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/DynamicConstantPoolExtension.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/DynamicConstantPoolExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/HandleReflectInvokeCallInjector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/HandleReflectInvokeCallInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/HandleServletDoMethodCallInjector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/HandleServletDoMethodCallInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/Injector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/Injector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/InstrumentationException.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/InstrumentationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/InstrumentationFactory.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/InstrumentationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/Instrumentor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/Instrumentor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/JavaClassConstants.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/JavaClassConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/MemoryProfMethodInstrumentor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/MemoryProfMethodInstrumentor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/MethodEntryExitCallsInjector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/MethodEntryExitCallsInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/MiscInstrumentationOps.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/MiscInstrumentationOps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ObjLivenessInstrCallsInjector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ObjLivenessInstrCallsInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ObjLivenessMethodInstrumentor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ObjLivenessMethodInstrumentor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ProfilePointHitCallInjector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ProfilePointHitCallInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor1.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor2.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor3.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RootMethods.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RootMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/SingleMethodScaner.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/SingleMethodScaner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/SpecialCallInjector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/SpecialCallInjector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/jps/JpsProxy.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/jps/JpsProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/jps/RunningVM.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/jps/RunningVM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/marker/ClassMarker.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/marker/ClassMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/marker/CompositeMarker.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/marker/CompositeMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/marker/Mark.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/marker/Mark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/marker/Marker.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/marker/Marker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/marker/MethodMarker.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/marker/MethodMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/marker/PackageMarker.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/marker/PackageMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/AbstractDataFrameProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/AbstractDataFrameProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/BaseCallGraphBuilder.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/BaseCallGraphBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/CCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/CCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/CCTProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/CCTProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/DataFrameProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/DataFrameProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/DataManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/DataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/DataManagerListener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/DataManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/EventBufferProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/EventBufferProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/EventBufferResultsProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/EventBufferResultsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/ExportDataDumper.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/ExportDataDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/FilterSortSupport.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/FilterSortSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/ProfilingResultListener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/ProfilingResultListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/ProfilingResultsDispatcher.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/ProfilingResultsDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/ProfilingResultsProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/ProfilingResultsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/ResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/ResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/RuntimeCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/RuntimeCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/RuntimeCCTNodeProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/RuntimeCCTNodeProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/coderegion/CodeRegionResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/coderegion/CodeRegionResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/AllThreadsMergedCPUCCTContainer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/AllThreadsMergedCPUCCTContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTClassContainer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTClassContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTContainer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCallGraphBuilder.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCallGraphBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUDataFrameProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUDataFrameProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUProfilingResultListener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUProfilingResultListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUResultsDiff.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUResultsDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUSamplingDataFrameProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUSamplingDataFrameProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/DiffCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/DiffCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/DiffFlatProfileContainer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/DiffFlatProfileContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileBuilder.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileContainer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileContainerBacked.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileContainerBacked.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileContainerFree.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileContainerFree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/FlatProfileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/InstrTimingData.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/InstrTimingData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/MethodIdMap.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/MethodIdMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/MethodInfoMapper.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/MethodInfoMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/PrestimeCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/PrestimeCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/PrestimeCPUCCTNodeBacked.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/PrestimeCPUCCTNodeBacked.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/PrestimeCPUCCTNodeFree.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/PrestimeCPUCCTNodeFree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/StackTraceSnapshotBuilder.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/StackTraceSnapshotBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/ThreadInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/ThreadInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/ThreadInfos.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/ThreadInfos.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/TimingAdjuster.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/TimingAdjuster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/TimingAdjusterOld.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/TimingAdjusterOld.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTFlattener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTFlattener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/TimeCollector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/TimeCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/BaseCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/BaseCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/MarkedCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/MarkedCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/MethodCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/MethodCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/RuntimeCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/RuntimeCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/ServletRequestCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/ServletRequestCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/SimpleCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/SimpleCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/ThreadCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/ThreadCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/TimedCPUCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/nodes/TimedCPUCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/CharStack.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/CharStack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkAwareNodeProcessorPlugin.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkAwareNodeProcessorPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkMapper.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkMapping.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkingEngine.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/marking/MarkingEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcCCTProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcCCTProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcGraphBuilder.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcGraphBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcResultsDiff.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcResultsDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/JdbcResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/SQLConnection.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/SQLConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/SQLParser.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/SQLParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/SQLStatement.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/SQLStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/StringCache.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/jdbc/StringCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/AbstractLockDataFrameProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/AbstractLockDataFrameProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockCCTProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockCCTProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockDataFrameProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockDataFrameProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockGraphBuilder.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockGraphBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockProfilingResultListener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockProfilingResultListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockRuntimeCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockRuntimeCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/MonitorCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/MonitorCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/MonitorInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/MonitorInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/ThreadInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/ThreadInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/ThreadInfos.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/ThreadInfos.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/ThreadLockCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/ThreadLockCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/locks/TopLockCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/locks/TopLockCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/AllocMemoryResultsDiff.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/AllocMemoryResultsDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/AllocMemoryResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/AllocMemoryResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/ClassHistoryDataManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/ClassHistoryDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/DiffObjAllocCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/DiffObjAllocCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/DiffObjLivenessCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/DiffObjLivenessCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/HeapHistogram.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/HeapHistogram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/HeapHistogramManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/HeapHistogramManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/JMethodIdTable.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/JMethodIdTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/LivenessMemoryResultsDiff.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/LivenessMemoryResultsDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/LivenessMemoryResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/LivenessMemoryResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryCCTManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryCCTManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryCCTProvider.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryCCTProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryCallGraphBuilder.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryCallGraphBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryDataFrameProcessor.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryDataFrameProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryProfilingResultsListener.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryProfilingResultsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/MemoryResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/PresoObjAllocCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/PresoObjAllocCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/PresoObjLivenessCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/PresoObjLivenessCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/RuntimeMemoryCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/RuntimeMemoryCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/RuntimeObjAllocTermCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/RuntimeObjAllocTermCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/RuntimeObjLivenessTermCCTNode.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/RuntimeObjLivenessTermCCTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/SampledMemoryResultsDiff.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/SampledMemoryResultsDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/SampledMemoryResultsSnapshot.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/SampledMemoryResultsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/memory/SurvGenSet.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/memory/SurvGenSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/monitor/VMTelemetryDataManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/monitor/VMTelemetryDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/threads/ThreadData.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/threads/ThreadData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/threads/ThreadDump.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/threads/ThreadDump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/results/threads/ThreadsDataManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/results/threads/ThreadsDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ClassBytesLoader.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ClassBytesLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ClassLoaderManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ClassLoaderManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/EventBufferManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/EventBufferManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/HeapHistogramManager.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/HeapHistogramManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/Monitors.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/Monitors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerAPI.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerAPI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerCalibrator.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerCalibrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerInterface.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntime.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPU.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPU.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPUCodeRegion.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPUCodeRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPUFullInstr.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPUFullInstr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPUSampledInstr.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPUSampledInstr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeMemory.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeObjAlloc.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeObjAlloc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeObjLiveness.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeObjLiveness.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeSampler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeSampler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerServer.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilingPointServerHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilingPointServerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ResetResultsProfilingPointHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ResetResultsProfilingPointHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/SamplingThread.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/SamplingThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/StartProfilingPointHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/StartProfilingPointHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/StopProfilingPointHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/StopProfilingPointHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/TakeHeapdumpProfilingPointHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/TakeHeapdumpProfilingPointHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/TakeSnapshotProfilingPointHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/TakeSnapshotProfilingPointHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/TakeSnapshotWithResetProfilingPointHandler.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/TakeSnapshotWithResetProfilingPointHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/ThreadInfo.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/ThreadInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/system/GC.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/system/GC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/system/Stacks.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/system/Stacks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/server/system/Threads.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/server/system/Threads.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/CharStack.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/CharStack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/FileOrZipEntry.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/FileOrZipEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/FloatSorter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/FloatSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/ImmutableList.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/ImmutableList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/IntSorter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/IntSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/IntVector.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/IntVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/LongSorter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/LongSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/MiscUtils.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/MiscUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/StringSorter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/StringSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/StringUtils.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/VMUtils.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/VMUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/Wildcards.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/Wildcards.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/DefaultMethodNameFormatter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/DefaultMethodNameFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/Formattable.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/Formattable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/MethodNameFormatter.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/MethodNameFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/MethodNameFormatterFactory.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/MethodNameFormatterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/PlainFormattableMethodName.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/utils/formatting/PlainFormattableMethodName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/AsyncMessageCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/AsyncMessageCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/CalibrationDataResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/CalibrationDataResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ClassLoadedCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ClassLoadedCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/CodeRegionCPUResultsResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/CodeRegionCPUResultsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/Command.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/DefiningLoaderResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/DefiningLoaderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/DumpResultsResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/DumpResultsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/EventBufferDumpedCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/EventBufferDumpedCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassFileBytesCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassFileBytesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassFileBytesResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassFileBytesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassIdCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassIdCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassIdResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetClassIdResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetDefiningClassLoaderCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetDefiningClassLoaderCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetMethodNamesForJMethodIdsCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/GetMethodNamesForJMethodIdsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/HeapHistogramResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/HeapHistogramResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InitiateProfilingCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InitiateProfilingCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InstrumentMethodGroupCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InstrumentMethodGroupCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InstrumentMethodGroupData.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InstrumentMethodGroupData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InstrumentMethodGroupResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InstrumentMethodGroupResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InternalStatsResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/InternalStatsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MethodInvokedFirstTimeCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MethodInvokedFirstTimeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MethodLoadedCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MethodLoadedCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MethodNamesResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MethodNamesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MonitoredNumbersResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/MonitoredNumbersResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ObjectAllocationResultsResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ObjectAllocationResultsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/Response.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/Response.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/RootClassLoadedCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/RootClassLoadedCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/SetChangeableInstrParamsCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/SetChangeableInstrParamsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/SetUnchangeableInstrParamsCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/SetUnchangeableInstrParamsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/TakeHeapDumpCommand.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/TakeHeapDumpCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ThreadDumpResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ThreadDumpResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ThreadLivenessStatusResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/ThreadLivenessStatusResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/VMPropertiesResponse.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/VMPropertiesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/WireIO.java
+++ b/lib.profiler/src/org/netbeans/lib/profiler/wireprotocol/WireIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/functional/src/org/netbeans/lib/profiler/tests/jfluid/perf/InstrumentationTest.java
+++ b/lib.profiler/test/functional/src/org/netbeans/lib/profiler/tests/jfluid/perf/InstrumentationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/CPU.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/CPU.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Consumer.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Consumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Data.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Data.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Memory.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Memory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Monitor.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Monitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Producer.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/Producer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/AnotherThread.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/AnotherThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Bean.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Bean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/CPU1.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/CPU1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/CPUThread.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/CPUThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Measure.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Measure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Methods.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Methods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Methods2.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Methods2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Region.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/Region.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/WaitingTest.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/cpu/WaitingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/memory/Bean.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/memory/Bean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/memory/Memory1.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/memory/Memory1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/monitor/CascadeThread.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/monitor/CascadeThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/monitor/Monitor1.java
+++ b/lib.profiler/test/qa-functional/data/projects/j2se-simple/src/simple/monitor/Monitor1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/BasicTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/CommonProfilerTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/CommonProfilerTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/ProfilerStableTestSuite.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/ProfilerStableTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/benchmarks/JbbTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/benchmarks/JbbTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/benchmarks/JbbTestType.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/benchmarks/JbbTestType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/BasicTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/CPUSnapshotTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/CPUSnapshotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/CPUSnapshotTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/CPUSnapshotTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/CPUTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/cpu/CPUTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/BasicTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/MemorySnapshotTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/MemorySnapshotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/MemorySnapshotTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/MemorySnapshotTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/MemoryTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/memory/MemoryTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/monitor/BasicTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/monitor/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/monitor/MonitorTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/monitor/MonitorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/others/MeasureDiffsTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/others/MeasureDiffsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/others/MeasureDiffsTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/others/MeasureDiffsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/perf/InstrumentationTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/perf/InstrumentationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/profilingpoints/BasicTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/profilingpoints/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/profilingpoints/ProfilingPointsTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/profilingpoints/ProfilingPointsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/DumpStream.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/DumpStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/TestAsyncDialog.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/TestAsyncDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/TestProfilerAppHandler.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/TestProfilerAppHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/TestProfilingPointsProcessor.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/TestProfilingPointsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/Utils.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/wireio/BasicTest.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/wireio/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/wireio/CommonWireIOTestCase.java
+++ b/lib.profiler/test/qa-functional/src/org/netbeans/lib/profiler/tests/jfluid/wireio/CommonWireIOTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
+++ b/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/unit/src/org/netbeans/lib/profiler/results/cpu/StackTraceSnapshotBuilderTest.java
+++ b/lib.profiler/test/unit/src/org/netbeans/lib/profiler/results/cpu/StackTraceSnapshotBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/unit/src/org/netbeans/lib/profiler/utils/VMUtilsTest.java
+++ b/lib.profiler/test/unit/src/org/netbeans/lib/profiler/utils/VMUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.profiler/test/unit/src/org/netbeans/lib/profiler/utils/formatting/PlainFormattableMethodNameTest.java
+++ b/lib.profiler/test/unit/src/org/netbeans/lib/profiler/utils/formatting/PlainFormattableMethodNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermApp/src/nbterm/ErrorProcessor.java
+++ b/lib.terminalemulator/examples/TermApp/src/nbterm/ErrorProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermApp/src/nbterm/Injector.java
+++ b/lib.terminalemulator/examples/TermApp/src/nbterm/Injector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermApp/src/nbterm/Main.java
+++ b/lib.terminalemulator/examples/TermApp/src/nbterm/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermApp/src/nbterm/TermExecutor.java
+++ b/lib.terminalemulator/examples/TermApp/src/nbterm/TermExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermApp/src/nbterm/Terminal.java
+++ b/lib.terminalemulator/examples/TermApp/src/nbterm/Terminal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermDriver/src/termdriver/Main.java
+++ b/lib.terminalemulator/examples/TermDriver/src/termdriver/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/CmdTermAction.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/CmdTermAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/Config.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/Config.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/IOShuttle.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/IOShuttle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/ShellTermAction.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/ShellTermAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/TermExecutor.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/TermExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/TermWindowAction.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/TermWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/TerminalIOProviderSupport.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/TerminalIOProviderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/comprehensive/CommandTerminalAction.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/comprehensive/CommandTerminalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/comprehensive/SelectLastAction.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/comprehensive/SelectLastAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/comprehensive/TerminalPanel.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/comprehensive/TerminalPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/control/ControlModel.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/control/ControlModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/control/ControlTopComponent.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/control/ControlTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/control/ControlView.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/control/ControlView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/iofeatures/IOFeaturesAction.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/iofeatures/IOFeaturesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/topcomponent/MuxableTerminalTopComponent.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/topcomponent/MuxableTerminalTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/topcomponent/TerminalTopComponent.java
+++ b/lib.terminalemulator/examples/TermExample/src/org/netbeans/terminal/example/topcomponent/TerminalTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/interp/BaseCmdSet.java
+++ b/lib.terminalemulator/examples/TermTester/src/interp/BaseCmdSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/interp/Cmd.java
+++ b/lib.terminalemulator/examples/TermTester/src/interp/Cmd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/interp/CmdSet.java
+++ b/lib.terminalemulator/examples/TermTester/src/interp/CmdSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/interp/Interp.java
+++ b/lib.terminalemulator/examples/TermTester/src/interp/Interp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/interp/Listener.java
+++ b/lib.terminalemulator/examples/TermTester/src/interp/Listener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/interp/ListenerOutput.java
+++ b/lib.terminalemulator/examples/TermTester/src/interp/ListenerOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/interp/SysCmdSet.java
+++ b/lib.terminalemulator/examples/TermTester/src/interp/SysCmdSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/Context.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/ExternalTestSubject.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/ExternalTestSubject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/InternalTestSubject.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/InternalTestSubject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/Main.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/MainCmdSet.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/MainCmdSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/MainFrame.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/MainFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/SequenceViewer.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/SequenceViewer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/Test.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/TestSubject.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/TestSubject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/termtester/Util.java
+++ b/lib.terminalemulator/examples/TermTester/src/termtester/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_acs.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_acs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_al.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_al.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_attr.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_attr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_bc.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_bc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_cd.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_cd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_ce.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_ce.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_cha.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_cha.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_cm.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_cm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_cud.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_cud.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_cuu.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_cuu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_cv.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_cv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_dc.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_dc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_dl.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_dl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_do.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_do.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_ech.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_ech.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_ed.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_ed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_el.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_el.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_el2.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_el2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_font.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_font.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_ic.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_ic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_im.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_im.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_key.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_key.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_lf.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_lf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_misc.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_misc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_nd.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_nd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_om.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_om.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_overstrike.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_overstrike.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_reverse.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_reverse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_ri.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_ri.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_scrc.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_scrc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_tab.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_tab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_txtprm.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_txtprm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_up.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_up.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/TermTester/src/tests/Test_vpa.java
+++ b/lib.terminalemulator/examples/TermTester/src/tests/Test_vpa.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/buildtool/BuildTool.java
+++ b/lib.terminalemulator/examples/buildtool/BuildTool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/buildtool/Junk.java
+++ b/lib.terminalemulator/examples/buildtool/Junk.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/process_start.c
+++ b/lib.terminalemulator/examples/lib.richexecution/process_start.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/CLibrary.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/CLibrary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/JNAPty.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/JNAPty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/OS.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/OS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/Platform.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/Platform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/Pty.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/Pty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/PtyException.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/PtyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/PtyExecutor.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/PtyExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/PtyProcess.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/PtyProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/Util.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/program/Command.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/program/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/program/Program.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/program/Program.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/program/Shell.java
+++ b/lib.terminalemulator/examples/lib.richexecution/src/org/netbeans/lib/richexecution/program/Shell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/examples/telnet/TelnetApp.java
+++ b/lib.terminalemulator/examples/telnet/TelnetApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/AbstractInterp.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/AbstractInterp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/ActiveRegion.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/ActiveRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/ActiveTerm.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/ActiveTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/ActiveTermListener.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/ActiveTermListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Attr.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Attr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/AttrSave.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/AttrSave.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/BCoord.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/BCoord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/BExtent.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/BExtent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Buffer.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Buffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Coord.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Coord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Extent.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Extent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Interp.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Interp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpANSI.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpANSI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpDtTerm.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpDtTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpDumb.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpDumb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpKit.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpProtoANSI.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpProtoANSI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpProtoANSIX.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpProtoANSIX.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpXTerm.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/InterpXTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Line.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Line.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/LineDiscipline.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/LineDiscipline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/LineVisitor.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/LineVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/LogicalLineVisitor.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/LogicalLineVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/MyFontMetrics.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/MyFontMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/NullTermStream.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/NullTermStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Ops.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Ops.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/RegionException.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/RegionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/RegionManager.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/RegionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Screen.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Screen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Sel.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Sel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/State.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/State.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/StreamTerm.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/StreamTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Term.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/Term.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermAdapter.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermInputListener.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermInputListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermListener.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermStream.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/TermStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/WordDelineator.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/WordDelineator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/Catalog.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/Catalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorComboBox.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorComboBoxRenderer.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorComboBoxRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorValue.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/DefaultFindState.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/DefaultFindState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/FindBar.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/FindBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/FindState.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/FindState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/FontPanel.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/FontPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/LineFilter.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/LineFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptions.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptionsPanel.java
+++ b/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.terminalemulator/test/unit/src/org/netbeans/lib/terminalemulator/TermTest.java
+++ b/lib.terminalemulator/test/unit/src/org/netbeans/lib/terminalemulator/TermTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/BugTrackingAccessor.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/BugTrackingAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/Decorable.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/Decorable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/Decorations.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/Decorations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/InputGesture.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/InputGesture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/LogFormatter.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/LogFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/LogRecords.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/LogRecords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/MultiPartHandler.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/MultiPartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/PasswdEncryption.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/PasswdEncryption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/src/org/netbeans/lib/uihandler/ProjectOp.java
+++ b/lib.uihandler/src/org/netbeans/lib/uihandler/ProjectOp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/DecorableTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/DecorableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/LogFormatterTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/LogFormatterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/LogRecordsRepairTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/LogRecordsRepairTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/PasswdEncryptionTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/PasswdEncryptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/ProjectOpTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/ProjectOpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/TestHandler.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandler/TestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandlerserver/InputGestureTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandlerserver/InputGestureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandlerserver/LogRecordsTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandlerserver/LogRecordsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lib.uihandler/test/unit/src/org/netbeans/lib/uihandlerserver/ReadBigDataTest.java
+++ b/lib.uihandler/test/unit/src/org/netbeans/lib/uihandlerserver/ReadBigDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/src/org/netbeans/libs/freemarker/FreemarkerEngine.java
+++ b/libs.freemarker/src/org/netbeans/libs/freemarker/FreemarkerEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/src/org/netbeans/libs/freemarker/FreemarkerFactory.java
+++ b/libs.freemarker/src/org/netbeans/libs/freemarker/FreemarkerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/src/org/netbeans/libs/freemarker/RsrcLoader.java
+++ b/libs.freemarker/src/org/netbeans/libs/freemarker/RsrcLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/api/templates/ClassInfo.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/api/templates/ClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/api/templates/MethodInfo.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/api/templates/MethodInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/api/templates/ProcessorTest.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/api/templates/ProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/api/templates/SpeedTest.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/api/templates/SpeedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/api/templates/TemplateUtilsTest.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/api/templates/TemplateUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/IndentEngineIntTest.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/IndentEngineIntTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SCFTHandlerTest.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SCFTHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/ScriptingCreateFromTemplateTest.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/ScriptingCreateFromTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SpeedTest.java
+++ b/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SpeedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitBlameResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitBlameResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitBranch.java
+++ b/libs.git/src/org/netbeans/libs/git/GitBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitCherryPickResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitCherryPickResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitClassFactoryImpl.java
+++ b/libs.git/src/org/netbeans/libs/git/GitClassFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitClient.java
+++ b/libs.git/src/org/netbeans/libs/git/GitClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitClientCallback.java
+++ b/libs.git/src/org/netbeans/libs/git/GitClientCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitConflictDescriptor.java
+++ b/libs.git/src/org/netbeans/libs/git/GitConflictDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitException.java
+++ b/libs.git/src/org/netbeans/libs/git/GitException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitLineDetails.java
+++ b/libs.git/src/org/netbeans/libs/git/GitLineDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitMergeResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitMergeResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitObjectType.java
+++ b/libs.git/src/org/netbeans/libs/git/GitObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitPullResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitPullResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitPushResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitPushResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitRebaseResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitRebaseResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitRefUpdateResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitRefUpdateResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitRemoteConfig.java
+++ b/libs.git/src/org/netbeans/libs/git/GitRemoteConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitRepository.java
+++ b/libs.git/src/org/netbeans/libs/git/GitRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitRepositoryState.java
+++ b/libs.git/src/org/netbeans/libs/git/GitRepositoryState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitRevertResult.java
+++ b/libs.git/src/org/netbeans/libs/git/GitRevertResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitRevisionInfo.java
+++ b/libs.git/src/org/netbeans/libs/git/GitRevisionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitStatus.java
+++ b/libs.git/src/org/netbeans/libs/git/GitStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitSubmoduleStatus.java
+++ b/libs.git/src/org/netbeans/libs/git/GitSubmoduleStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitTag.java
+++ b/libs.git/src/org/netbeans/libs/git/GitTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitTransportUpdate.java
+++ b/libs.git/src/org/netbeans/libs/git/GitTransportUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitURI.java
+++ b/libs.git/src/org/netbeans/libs/git/GitURI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/GitUser.java
+++ b/libs.git/src/org/netbeans/libs/git/GitUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/SearchCriteria.java
+++ b/libs.git/src/org/netbeans/libs/git/SearchCriteria.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/DelegatingGitProgressMonitor.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/DelegatingGitProgressMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/DelegatingProgressMonitor.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/DelegatingProgressMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/ExactPathFilter.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/ExactPathFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/GitClassFactory.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/GitClassFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/IgnoreRule.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/IgnoreRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/JGitCredentialsProvider.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/JGitCredentialsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/JGitRepository.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/JGitRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/JGitSshSessionFactory.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/JGitSshSessionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/Utils.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/AddCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/AddCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/BlameCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/BlameCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CatCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CatCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CheckoutIndexCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CheckoutIndexCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CheckoutRevisionCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CheckoutRevisionCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CherryPickCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CherryPickCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CleanCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CleanCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CommitCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CommitCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CompareCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CompareCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ConflictCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ConflictCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CopyCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CopyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CreateBranchCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CreateBranchCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/CreateTagCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/CreateTagCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/DeleteBranchCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/DeleteBranchCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/DeleteTagCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/DeleteTagCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ExportCommitCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ExportCommitCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ExportDiffCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ExportDiffCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/FetchCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/FetchCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/GetCommonAncestorCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/GetCommonAncestorCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/GetPreviousCommitCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/GetPreviousCommitCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/GetRemotesCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/GetRemotesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/GitCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/GitCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/InitRepositoryCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/InitRepositoryCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ListBranchCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ListBranchCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ListModifiedIndexEntriesCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ListModifiedIndexEntriesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ListRemoteBranchesCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ListRemoteBranchesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ListRemoteObjectsCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ListRemoteObjectsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ListRemoteTagsCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ListRemoteTagsCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ListTagCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ListTagCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/MergeCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/MergeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/MoveTreeCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/MoveTreeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/PullCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/PullCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/PushCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/PushCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/RebaseCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/RebaseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/RemoveCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/RemoveCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/RemoveRemoteCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/RemoveRemoteCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/RenameCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/RenameCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/ResetCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/ResetCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/RevertCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/RevertCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/SetRemoteCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/SetRemoteCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/SetUpstreamBranchCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/SetUpstreamBranchCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/StashApplyCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/StashApplyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/StashDropCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/StashDropCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/StashListCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/StashListCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/StashSaveCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/StashSaveCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/StatusCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/StatusCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/SubmoduleInitializeCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/SubmoduleInitializeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/SubmoduleStatusCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/SubmoduleStatusCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/SubmoduleUpdateCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/SubmoduleUpdateCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/TransportCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/TransportCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/UnignoreCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/UnignoreCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/commands/UpdateRefCommand.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/commands/UpdateRefCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/utils/AutoCRLFComparator.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/utils/AutoCRLFComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/utils/CancelRevFilter.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/utils/CancelRevFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/jgit/utils/CheckoutIndex.java
+++ b/libs.git/src/org/netbeans/libs/git/jgit/utils/CheckoutIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/progress/FileListener.java
+++ b/libs.git/src/org/netbeans/libs/git/progress/FileListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/progress/NotificationListener.java
+++ b/libs.git/src/org/netbeans/libs/git/progress/NotificationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/progress/ProgressMonitor.java
+++ b/libs.git/src/org/netbeans/libs/git/progress/ProgressMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/progress/RevisionInfoListener.java
+++ b/libs.git/src/org/netbeans/libs/git/progress/RevisionInfoListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/src/org/netbeans/libs/git/progress/StatusListener.java
+++ b/libs.git/src/org/netbeans/libs/git/progress/StatusListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/ApiUtils.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/ApiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/GitEnumsStateTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/GitEnumsStateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/GitURITest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/GitURITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ClientFactoryTestSuite.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ClientFactoryTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/CommandsTestSuite.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/CommandsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ConnectionTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ProtocolsTestSuite.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ProtocolsTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/AddTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/AddTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/BlameTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/BlameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/BranchTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/BranchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CatTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CheckoutTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CheckoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CleanTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CleanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CommitTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CommitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CompareCommitTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CompareCommitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CopyTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CopyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ExportCommitTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ExportCommitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ExportDiffTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ExportDiffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/FetchTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/FetchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetCommonAncestorTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetCommonAncestorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetPreviousRevisionTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetPreviousRevisionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetRemotesTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetRemotesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetUserTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/GetUserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/IgnoreTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/IgnoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/InitTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/InitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ListModifiedIndexEntriesTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ListModifiedIndexEntriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/LogTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/LogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/MergeTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/MergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/PullTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/PullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/PushTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/PushTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RebaseTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RebaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RemotesTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RemotesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RemoveTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RemoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RenameTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ResetTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ResetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RevertTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/RevertTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/SetUpstreamBranchTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/SetUpstreamBranchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/StashTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/StashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/StatusTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/StatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/SubmoduleTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/SubmoduleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/TagTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/TagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/UnignoreTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/UnignoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/UpdateRefTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/UpdateRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/factory/CheckJava7ExtensionTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/factory/CheckJava7ExtensionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/factory/CreateClientTest.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/factory/CreateClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.git/test/unit/src/org/netbeans/libs/git/jgit/utils/TestUtils.java
+++ b/libs.git/test/unit/src/org/netbeans/libs/git/jgit/utils/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.javafx/test/unit/src/org/netbeans/libs/javafx/IsFXEnabledTest.java
+++ b/libs.javafx/test/unit/src/org/netbeans/libs/javafx/IsFXEnabledTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.jna/src/org/netbeans/libs/jna/Installer.java
+++ b/libs.jna/src/org/netbeans/libs/jna/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.jsch.agentproxy/src/org/netbeans/libs/jsch/agentproxy/ConnectorFactory.java
+++ b/libs.jsch.agentproxy/src/org/netbeans/libs/jsch/agentproxy/ConnectorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.jsr223/src/org/netbeans/libs/jsr223/Dummy.java
+++ b/libs.jsr223/src/org/netbeans/libs/jsr223/Dummy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/components/products/helloworld/src/org/mycompany/ConfigurationLogic.java
+++ b/libs.nbi.ant/stub/ext/components/products/helloworld/src/org/mycompany/ConfigurationLogic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/components/products/helloworld/src/org/mycompany/wizard/panels/HelloWorldPanel.java
+++ b/libs.nbi.ant/stub/ext/components/products/helloworld/src/org/mycompany/wizard/panels/HelloWorldPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/utils/applications/NetBeansRCPUtils.java
+++ b/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/utils/applications/NetBeansRCPUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/actions/InitializeAction.java
+++ b/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/actions/InitializeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/panels/PostInstallSummaryPanel.java
+++ b/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/panels/PostInstallSummaryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/panels/PreInstallSummaryPanel.java
+++ b/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/panels/PreInstallSummaryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/panels/WelcomePanel.java
+++ b/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/panels/WelcomePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/sequences/MainSequence.java
+++ b/libs.nbi.ant/stub/ext/engine/src/org/mycompany/installer/wizard/components/sequences/MainSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.svnClientAdapter.javahl/src/org/netbeans/libs/svnclientadapter/javahl/JavaHlClientAdapterFactory.java
+++ b/libs.svnClientAdapter.javahl/src/org/netbeans/libs/svnclientadapter/javahl/JavaHlClientAdapterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.svnClientAdapter.svnkit/src/org/netbeans/libs/svnclientadapter/svnkit/SvnKitClientAdapterFactory.java
+++ b/libs.svnClientAdapter.svnkit/src/org/netbeans/libs/svnclientadapter/svnkit/SvnKitClientAdapterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/libs.svnClientAdapter/src/org/netbeans/libs/svnclientadapter/SvnClientAdapterFactory.java
+++ b/libs.svnClientAdapter/src/org/netbeans/libs/svnclientadapter/SvnClientAdapterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/LocalHistory.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/LocalHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryProvider.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryVCS.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryVCSAnnotator.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryVCSAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryVCSInterceptor.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/LocalHistoryVCSInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/ModuleLifecycleManager.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/ModuleLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/store/LocalHistoryStore.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/store/LocalHistoryStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/store/LocalHistoryStoreFactory.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/store/LocalHistoryStoreFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/store/LocalHistoryStoreImpl.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/store/LocalHistoryStoreImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/store/StoreEntry.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/store/StoreEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/ui/actions/DeletedListRenderer.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/ui/actions/DeletedListRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/ui/actions/FileNode.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/ui/actions/FileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/ui/actions/RevertDeletedAction.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/ui/actions/RevertDeletedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/ui/actions/RevertPanel.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/ui/actions/RevertPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/ui/view/HistoryTopComponent.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/ui/view/HistoryTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/ui/view/ShowHistoryAction.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/ui/view/ShowHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/utils/FileUtils.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/utils/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/src/org/netbeans/modules/localhistory/utils/Utils.java
+++ b/localhistory/src/org/netbeans/modules/localhistory/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/qa-functional/data/JavaApp/src/javaapp/Main.java
+++ b/localhistory/test/qa-functional/data/JavaApp/src/javaapp/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/LocalHistoryViewTest.java
+++ b/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/LocalHistoryViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/actions/ShowLocalHistoryAction.java
+++ b/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/actions/ShowLocalHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/operators/OutlineViewOperator.java
+++ b/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/operators/OutlineViewOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/operators/ShowLocalHistoryOperator.java
+++ b/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/operators/ShowLocalHistoryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/ts/LocalHistoryTestSuite.java
+++ b/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/ts/LocalHistoryTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/utils/TestKit.java
+++ b/localhistory/test/qa-functional/src/org/netbeans/test/localhistory/utils/TestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/InterceptorTest.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/InterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/IsManagedTest.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/IsManagedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/LHFileSystemTest.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/LHFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/LogHandler.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/LogHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/CleanupTest.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/CleanupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/LHTestCase.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/LHTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/LocalHistoryTestStore.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/LocalHistoryTestStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/Store.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/Store.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/StoreTest.java
+++ b/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/StoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/IssueProviderImpl.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/IssueProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/IssueSchedulingProviderImpl.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/IssueSchedulingProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/IssueStatusProviderImpl.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/IssueStatusProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/LocalQuery.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/LocalQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/LocalRepository.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/LocalRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/LocalRepositoryConfig.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/LocalRepositoryConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/LocalTaskConnector.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/LocalTaskConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/QueryProviderImpl.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/QueryProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/RepositoryProviderImpl.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/RepositoryProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/task/AddSubtaskPanel.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/task/AddSubtaskPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/task/LocalTask.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/task/LocalTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/task/SubtaskTableModel.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/task/SubtaskTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/task/TaskController.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/task/TaskController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/task/TaskPanel.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/task/TaskPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/localtasks/src/org/netbeans/modules/localtasks/util/FileUtils.java
+++ b/localtasks/src/org/netbeans/modules/localtasks/util/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.linux/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier.java
+++ b/masterfs.linux/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.linux/test/unit/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier235632Test.java
+++ b/masterfs.linux/test/unit/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier235632Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.macosx/src/org/netbeans/modules/masterfs/watcher/macosx/OSXNotifier.java
+++ b/masterfs.macosx/src/org/netbeans/modules/masterfs/watcher/macosx/OSXNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.nio2/src/org/netbeans/modules/masterfs/watcher/nio2/NioNotifier.java
+++ b/masterfs.nio2/src/org/netbeans/modules/masterfs/watcher/nio2/NioNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.ui/src/org/netbeans/modules/masterfs/providers/AnnotationProvider.java
+++ b/masterfs.ui/src/org/netbeans/modules/masterfs/providers/AnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.ui/src/org/netbeans/modules/masterfs/ui/FileBasedFSWithUI.java
+++ b/masterfs.ui/src/org/netbeans/modules/masterfs/ui/FileBasedFSWithUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.ui/src/org/netbeans/modules/masterfs/ui/Init.java
+++ b/masterfs.ui/src/org/netbeans/modules/masterfs/ui/Init.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.ui/src/org/netbeans/modules/masterfs/ui/suspend/PauseAction.java
+++ b/masterfs.ui/src/org/netbeans/modules/masterfs/ui/suspend/PauseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
+++ b/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/ExLocalFileSystem.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/ExLocalFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/GlobalSharabilityQueryImpl.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/GlobalSharabilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/GlobalVisibilityQueryImpl.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/GlobalVisibilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/Installer.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/MasterURLMapper.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/MasterURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsAccessor.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsProxy.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystem.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedURLMapper.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/MasterFileSystemFactory.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/MasterFileSystemFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/Statistics.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/Statistics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenCache.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenSupport.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/BaseFileObj.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/BaseFileObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObj.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactory.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectKeeper.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectKeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObj.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/LockForFile.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/LockForFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/MutualExclusionSupport.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/MutualExclusionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RefreshSlow.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RefreshSlow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/ReplaceForSerialization.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/ReplaceForSerialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RootObj.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RootObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RootObjWindows.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RootObjWindows.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/WriteLockUtils.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/WriteLockUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/FileName.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/FileName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/FileNaming.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/FileNaming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/FolderName.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/FolderName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NameRef.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NameRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactory.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/FSException.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/FSException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManager.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileInfo.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/Utils.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/providers/Attributes.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/providers/Attributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/providers/BaseAnnotationProvider.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/providers/BaseAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/providers/InterceptionListener.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/providers/InterceptionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/providers/Notifier.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/providers/Notifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/providers/ProvidedExtensions.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/providers/ProvidedExtensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/watcher/FOFile.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/watcher/FOFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/watcher/NotifierAccessor.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/watcher/NotifierAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/watcher/NotifierKeyRef.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/watcher/NotifierKeyRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/src/org/netbeans/modules/masterfs/watcher/Watcher.java
+++ b/masterfs/src/org/netbeans/modules/masterfs/watcher/Watcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/CreateFileOnWindowsTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/CreateFileOnWindowsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/ExLocalFileSystemTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/ExLocalFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/FileObjectCyclicSymlinksTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/FileObjectCyclicSymlinksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/FolderCopyProblemTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/FolderCopyProblemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/GlobalSharabilityQueryImplTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/GlobalSharabilityQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/GlobalVisibilityQueryImplTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/GlobalVisibilityQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/RenameLeavesLockTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/RenameLeavesLockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshAndPriorityIOTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshAndPriorityIOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshIncrementalTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshIncrementalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshInterruptibleTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshInterruptibleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshPreferrableTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshPreferrableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshSuspendableTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshSuspendableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/SlowRefreshTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/URLMapperTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/URLMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/WrongHashTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/WrongHashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/Deadlock54741Test.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/Deadlock54741Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/Deadlock73332Test.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/Deadlock73332Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemTestStat.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemTestStat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemWithExtensionsTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemWithExtensionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemWithUninitializedExtensionsTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystemWithUninitializedExtensionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedURLMapperTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedURLMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerFilterTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerOnClassFileTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerOnClassFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerStopTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerStopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilAddRecursiveListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/MIMESupportLoggingTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/MIMESupportLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/RecursiveListenerOnOffTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/RecursiveListenerOnOffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/RecursiveValidityTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/RecursiveValidityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/TwoFileNamesForASingleFileTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/TwoFileNamesForASingleFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenSupportTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/ExternalTouchTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/ExternalTouchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjSymlinkTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjSymlinkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactorySizeTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactorySizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactoryTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectKeeperTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectKeeperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObjCacheTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObjCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObjTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObjTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/LockForFileTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/LockForFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/MutualExclusionSupportTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/MutualExclusionSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/NoLockWhenRefreshIOTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/NoLockWhenRefreshIOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RefreshSlowTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/RefreshSlowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/StatFilesTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/StatFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/TestUtils.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/WatcherDeadlockTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/WatcherDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/naming/FileNameTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/naming/FileNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactoryTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManagerDeadlockTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManagerDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManagerNotInLookupTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManagerNotInLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManagerTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileChangedManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileInfoTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/FileInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/UtilsTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/utils/UtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/CheckProviders.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/CheckProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/InterceptionListenerTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/InterceptionListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/ProvidedExtensionsTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/ProvidedExtensionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/CyclicSymlinkTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/CyclicSymlinkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/WatcherLoggingTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/WatcherLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/WatcherSuspendTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/WatcherSuspendTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/WatcherTest.java
+++ b/masterfs/test/unit/src/org/netbeans/modules/masterfs/watcher/WatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AccessQueryImpl.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AccessQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AdaptNbVersion.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AdaptNbVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AddOSGiParamToNbmPluginConfiguration.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AddOSGiParamToNbmPluginConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AnnotatedNode.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AnnotatedNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ApisupportOutputProcessorFactory.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ApisupportOutputProcessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ApisupportRecoPrivTemplates.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ApisupportRecoPrivTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/CoSApplicationLateBoundChecker.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/CoSApplicationLateBoundChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExecutionChecker.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExecutionChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/IDEOutputListenerProvider.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/IDEOutputListenerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ImportantFilesNodeFactory.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ImportantFilesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/InstallerPanel.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/InstallerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenExecProject.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenExecProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPackageModifierImpl.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPackageModifierImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPlatformJarProvider.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPlatformJarProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenRefactoringProviderImpl.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenRefactoringProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MissingNbInstallationProblemProvider.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MissingNbInstallationProblemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ModuleJarAccessibilityQueryImpl.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ModuleJarAccessibilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmActionGoalProvider.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmActionGoalProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmIcons.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanel.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NetBeansRunParamsIDEChecker.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NetBeansRunParamsIDEChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NetBeansStartupArgs.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NetBeansStartupArgs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/OpenBrandingEditorAction.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/OpenBrandingEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/PackagesPanelProvider.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/PackagesPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/PublicPackagesPanel.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/PublicPackagesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/src/org/netbeans/modules/maven/apisupport/RunIDEInstallationChecker.java
+++ b/maven.apisupport/src/org/netbeans/modules/maven/apisupport/RunIDEInstallationChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/test/org/netbeans/modules/maven/apisupport/AccessQueryImplTest.java
+++ b/maven.apisupport/test/org/netbeans/modules/maven/apisupport/AccessQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/PublicPackagesPanelTest.java
+++ b/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/PublicPackagesPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/AuxPropsImpl.java
+++ b/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/AuxPropsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/CheckstyleCustomizerPanel.java
+++ b/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/CheckstyleCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/CheckstylePanel.java
+++ b/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/CheckstylePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/ModuleConvertor.java
+++ b/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/ModuleConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.coverage/src/org/netbeans/modules/maven/coverage/CoverageActionsProvider.java
+++ b/maven.coverage/src/org/netbeans/modules/maven/coverage/CoverageActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.coverage/src/org/netbeans/modules/maven/coverage/CoveragePopup.java
+++ b/maven.coverage/src/org/netbeans/modules/maven/coverage/CoveragePopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.coverage/src/org/netbeans/modules/maven/coverage/MavenCoverageProvider.java
+++ b/maven.coverage/src/org/netbeans/modules/maven/coverage/MavenCoverageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/ArtifactFixer.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/ArtifactFixer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/DependencyTreeFactory.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/DependencyTreeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderConfiguration.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderFactory.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/MavenEmbedder.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/MavenEmbedder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/NBPluginParameterExpressionEvaluator.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/NBPluginParameterExpressionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/NBRepositoryModelResolver.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/NBRepositoryModelResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/exec/ProgressTransferListener.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/exec/ProgressTransferListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/ExtensionModule.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/ExtensionModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/MavenProtocolHandler.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/MavenProtocolHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NBModelBuilder.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NBModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbInheritanceAssembler.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbInheritanceAssembler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbPluginDependenciesResolver.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbPluginDependenciesResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbRepositoryCache.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbRepositoryCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbRepositorySystem.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbRepositorySystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbWorkspaceReader.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbWorkspaceReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/OfflineConnector.java
+++ b/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/OfflineConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/test/unit/src/org/netbeans/modules/maven/embedder/EmbedderFactoryTest.java
+++ b/maven.embedder/test/unit/src/org/netbeans/modules/maven/embedder/EmbedderFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.embedder/test/unit/src/org/netbeans/modules/maven/embedder/impl/NbRepositoryCacheTest.java
+++ b/maven.embedder/test/unit/src/org/netbeans/modules/maven/embedder/impl/NbRepositoryCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/AbstractGenerator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/AbstractGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/ContextProvider.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/ContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/DependencyGenerator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/DependencyGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/ExclusionGenerator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/ExclusionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/LicenseGenerator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/LicenseGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/MirrorGenerator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/MirrorGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/NewLicensePanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/NewLicensePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/NewMirrorPanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/NewMirrorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/NewProfilePanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/NewProfilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/PluginGenerator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/PluginGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/ProfileGenerator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/ProfileGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/codegen/SettingsContextProvider.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/codegen/SettingsContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/BasicPomMD.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/BasicPomMD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/DefaultGrammarFactory.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/DefaultGrammarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/EffectivePomMD.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/EffectivePomMD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/GoalsProviderImpl.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/GoalsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/GrammarFactory.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/GrammarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenArchetypeGrammar.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenArchetypeGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenAssemblyGrammar.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenAssemblyGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenNbmGrammar.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenNbmGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenProjectGrammar.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenProjectGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenQueryProvider.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenSettingsGrammar.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenSettingsGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/POMDataObject.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/POMDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/ShowEffPomDiffAction.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/ShowEffPomDiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/ShowEffPomDiffPanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/ShowEffPomDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/catalog/MavenCatalog.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/catalog/MavenCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationBar.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationBarManager.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationBarManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationMark.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationMarkInstaller.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationMarkInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationMarkProvider.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/AnnotationMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/spi/AbstractSchemaBasedGrammar.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/spi/AbstractSchemaBasedGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/grammar/spi/GrammarExtensionProvider.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/grammar/spi/GrammarExtensionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/hyperlinks/GoToImplementation.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/hyperlinks/GoToImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/hyperlinks/HyperlinkProviderImpl.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/hyperlinks/HyperlinkProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/navigator/POMInheritanceNavigator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/navigator/POMInheritanceNavigator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/navigator/POMInheritancePanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/navigator/POMInheritancePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelNavigator.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelNavigator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelPanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelVisitor.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/navigator/TapPanel.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/navigator/TapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/src/org/netbeans/modules/maven/navigator/TrivialLayout.java
+++ b/maven.grammar/src/org/netbeans/modules/maven/navigator/TrivialLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.grammar/test/unit/src/org/netbeans/modules/maven/grammar/MavenProjectGrammarTest.java
+++ b/maven.grammar/test/unit/src/org/netbeans/modules/maven/grammar/MavenProjectGrammarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/DependencyGraphTopComponent.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/DependencyGraphTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/ExcludeDepAction.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/ExcludeDepAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/FixVersionConflictAction.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/FixVersionConflictAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/FixVersionConflictPanel.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/FixVersionConflictPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/GraphConstructor.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/GraphConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/GraphMD.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/GraphMD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/MavenAction.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/MavenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/MavenActionsProvider.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/MavenActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/MavenDependencyNode.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/MavenDependencyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.graph/src/org/netbeans/modules/maven/graph/ScopesVisitor.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/ScopesVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/errors/SearchClassDependencyHint.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/errors/SearchClassDependencyHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/errors/SearchClassDependencyInRepo.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/errors/SearchClassDependencyInRepo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/CompilerPluginVersionError.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/CompilerPluginVersionError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsOptionsPanelController.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanel.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanelLogic.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanelLogic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryError.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryErrorCustomizer.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryErrorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementHint.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementPanel.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/OverrideDependencyManagementError.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/OverrideDependencyManagementError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/OverridePluginManagementError.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/OverridePluginManagementError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionError.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorCustomizer.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionError.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionErrorCustomizer.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionErrorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/RulesManager.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/RulesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/StatusProvider.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/StatusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/TaskListBridge.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/TaskListBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/props/TurnToPropertyHint.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/props/TurnToPropertyHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/Configuration.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/POMErrorFixBase.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/POMErrorFixBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/POMErrorFixProvider.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/POMErrorFixProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/SelectionPOMFixProvider.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/pom/spi/SelectionPOMFixProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/ui/SearchDependencyUI.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/ui/SearchDependencyUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/ui/customizers/SearchDependencyCustomizer.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/ui/customizers/SearchDependencyCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/ui/nodes/ArtifactNode.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/ui/nodes/ArtifactNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/src/org/netbeans/modules/maven/hints/ui/nodes/VersionNode.java
+++ b/maven.hints/src/org/netbeans/modules/maven/hints/ui/nodes/VersionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorTest.java
+++ b/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/StatusProviderTest.java
+++ b/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/StatusProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.htmlui/src/org/netbeans/modules/maven/htmlui/DukeScriptWizard.java
+++ b/maven.htmlui/src/org/netbeans/modules/maven/htmlui/DukeScriptWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.htmlui/src/org/netbeans/modules/maven/htmlui/MavenUtilities.java
+++ b/maven.htmlui/src/org/netbeans/modules/maven/htmlui/MavenUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/IndexingNotificationProviderImpl.java
+++ b/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/IndexingNotificationProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/api/ui/ArtifactViewer.java
+++ b/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/api/ui/ArtifactViewer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/spi/ui/ArtifactNodeSelector.java
+++ b/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/spi/ui/ArtifactNodeSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/spi/ui/ArtifactViewerFactory.java
+++ b/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/spi/ui/ArtifactViewerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/spi/ui/ArtifactViewerPanelProvider.java
+++ b/maven.indexer.ui/src/org/netbeans/modules/maven/indexer/spi/ui/ArtifactViewerPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/external/mvn-indexer.patch
+++ b/maven.indexer/external/mvn-indexer.patch
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/ArtifactDependencyIndexCreator.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/ArtifactDependencyIndexCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/Cancellation.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/Cancellation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/ClassDependencyIndexCreator.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/ClassDependencyIndexCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/CustomArtifactContextProducer.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/CustomArtifactContextProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/NotifyingIndexCreator.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/NotifyingIndexCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/OnStop.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/OnStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/RemoteIndexTransferListener.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/RemoteIndexTransferListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/RepositoryIndexerListener.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/RepositoryIndexerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/ResultImpl.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/ResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/NBArtifactInfo.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/NBArtifactInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/NBGroupInfo.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/NBGroupInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/NBVersionInfo.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/NBVersionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/PluginIndexManager.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/PluginIndexManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/QueryField.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/QueryField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/QueryRequest.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/QueryRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryIndexer.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryInfo.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryQueries.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryUtil.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ArchetypeQueries.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ArchetypeQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/BaseQueries.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/BaseQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ChecksumQueries.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ChecksumQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ClassUsageQuery.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ClassUsageQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ClassesQuery.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ClassesQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ContextLoadedQuery.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ContextLoadedQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/DependencyInfoQueries.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/DependencyInfoQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/GenericFindQuery.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/GenericFindQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/NullResultImpl.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/NullResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/RepositoryIndexQueryProvider.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/RepositoryIndexQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ResultImplementation.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/ResultImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/impl/IndexingNotificationProvider.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/impl/IndexingNotificationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/impl/Redo.java
+++ b/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/impl/Redo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/ClassDependencyIndexCreatorTest.java
+++ b/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/ClassDependencyIndexCreatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImplTest.java
+++ b/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/NexusTestBase.java
+++ b/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/NexusTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/AbstractTestQueryProvider.java
+++ b/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/AbstractTestQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/NBVersionInfoTest.java
+++ b/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/NBVersionInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
+++ b/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryQueriesTest.java
+++ b/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryQueriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitManagerProvider.java
+++ b/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitManagerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
+++ b/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
+++ b/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestRunnerNodeFactory.java
+++ b/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestRunnerNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
+++ b/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputProcessorFactory.java
+++ b/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputProcessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.junit/test/unit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProviderTest.java
+++ b/maven.junit/test/unit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/config/Header.txt
+++ b/maven.model/config/Header.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/ModelOperation.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/ModelOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/Utilities.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Activation.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Activation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationCustom.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationCustom.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationFile.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationOS.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationOS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationProperty.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ActivationProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Build.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Build.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/BuildBase.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/BuildBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/CiManagement.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/CiManagement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Configuration.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Contributor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Contributor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Dependency.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Dependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/DependencyContainer.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/DependencyContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/DependencyManagement.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/DependencyManagement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/DeploymentRepository.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/DeploymentRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Developer.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Developer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/DistributionManagement.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/DistributionManagement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Exclusion.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Exclusion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Extension.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Extension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/IdPOMComponent.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/IdPOMComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/IssueManagement.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/IssueManagement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/License.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/License.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/MailingList.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/MailingList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ModelList.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ModelList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Notifier.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Notifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Organization.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Organization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMComponent.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMComponentFactory.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMComponentVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMComponentVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMExtensibilityElement.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMExtensibilityElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMModel.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMModelFactory.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMQName.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMQName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/POMQNames.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/POMQNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Parent.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Parent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Plugin.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Plugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/PluginContainer.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/PluginContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/PluginExecution.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/PluginExecution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/PluginManagement.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/PluginManagement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Prerequisites.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Prerequisites.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Profile.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Profile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Project.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Project.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Properties.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Properties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ReportPlugin.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ReportPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ReportPluginContainer.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ReportPluginContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/ReportSet.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/ReportSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Reporting.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Reporting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Repository.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Repository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/RepositoryContainer.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/RepositoryContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/RepositoryPolicy.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/RepositoryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Resource.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Resource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Scm.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Scm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/Site.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/Site.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/StringList.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/StringList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/VersionablePOMComponent.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/VersionablePOMComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationCustomImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationCustomImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationFileImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationFileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationOSImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationOSImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationPropertyImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ActivationPropertyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/BuildBaseImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/BuildBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/BuildImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/BuildImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/CiManagementImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/CiManagementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ConfigurationImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ContributorImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ContributorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DependencyImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DependencyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DependencyManagementImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DependencyManagementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DeploymentRepositoryImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DeploymentRepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DeveloperImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DeveloperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DistributionManagementImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/DistributionManagementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ExclusionImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ExclusionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ExtensionImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ExtensionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/IdPOMComponentImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/IdPOMComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/IssueManagementImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/IssueManagementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/LicenseImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/LicenseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ListImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/MailingListImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/MailingListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/NotifierImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/NotifierImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/OrganizationImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/OrganizationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMAttribute.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMComponentFactoryImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMComponentImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMElementFactoryProvider.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMElementFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMModelImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ParentImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ParentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PluginExecutionImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PluginExecutionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PluginImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PluginImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PluginManagementImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PluginManagementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PrerequisitesImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PrerequisitesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ProfileImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ProfileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ProjectImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ProjectImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PropertiesImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PropertiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ReportPluginImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ReportPluginImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ReportSetImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ReportSetImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ReportingImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ReportingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/RepositoryImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/RepositoryPolicyImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/RepositoryPolicyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ResourceImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ScmImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ScmImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/SiteImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/SiteImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/StringListImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/StringListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/impl/VersionablePOMComponentImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/impl/VersionablePOMComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/spi/ElementFactory.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/spi/ElementFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/spi/POMExtensibilityElementBase.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/spi/POMExtensibilityElementBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/visitor/ChildComponentUpdateVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/visitor/ChildComponentUpdateVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/visitor/ChildVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/visitor/ChildVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/pom/visitor/DefaultVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/pom/visitor/DefaultVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Activation.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Activation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationCustom.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationCustom.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationFile.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationOS.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationOS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationProperty.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/ActivationProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Configuration.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Mirror.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Mirror.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/ModelList.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/ModelList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Profile.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Profile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Properties.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Properties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Proxy.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Proxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Repository.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Repository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/RepositoryPolicy.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/RepositoryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Server.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Server.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/Settings.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsAttribute.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsComponent.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsComponentFactory.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsComponentVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsComponentVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsExtensibilityElement.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsExtensibilityElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsModel.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsModelFactory.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsQName.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsQName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsQNames.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/SettingsQNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/StringList.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/StringList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationCustomImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationCustomImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationFileImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationFileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationOSImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationOSImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationPropertyImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ActivationPropertyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ConfigurationImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ElementFactoryRegistry.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ElementFactoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ListImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/MirrorImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/MirrorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ProfileImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ProfileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ProfilesAttribute.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ProfilesAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/PropertiesImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/PropertiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ProxyImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ProxyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/RepositoryImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/RepositoryPolicyImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/RepositoryPolicyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ServerImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ServerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsComponentFactoryImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsComponentImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsElementFactoryProvider.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsElementFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsModelImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/impl/StringListImpl.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/impl/StringListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/spi/ElementFactory.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/spi/ElementFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/spi/SettingsExtensibilityElementBase.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/spi/SettingsExtensibilityElementBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/visitor/ChildComponentUpdateVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/visitor/ChildComponentUpdateVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/visitor/ChildVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/visitor/ChildVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/settings/visitor/DefaultVisitor.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/settings/visitor/DefaultVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/src/org/netbeans/modules/maven/model/util/ModelImplUtils.java
+++ b/maven.model/src/org/netbeans/modules/maven/model/util/ModelImplUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/test/unit/src/org/netbeans/modules/maven/model/UtilitiesTest.java
+++ b/maven.model/test/unit/src/org/netbeans/modules/maven/model/UtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/test/unit/src/org/netbeans/modules/maven/model/pom/impl/ResourceImplTest.java
+++ b/maven.model/test/unit/src/org/netbeans/modules/maven/model/pom/impl/ResourceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/test/unit/src/org/netbeans/modules/maven/model/settings/impl/SettingsTest.java
+++ b/maven.model/test/unit/src/org/netbeans/modules/maven/model/settings/impl/SettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.model/test/unit/src/org/netbeans/modules/maven/pom/ModelTest.java
+++ b/maven.model/test/unit/src/org/netbeans/modules/maven/pom/ModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/AccessQueryImpl.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/AccessQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/FelixPluginGrammarExtension.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/FelixPluginGrammarExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/ForeignClassBundlerImpl.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/ForeignClassBundlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/Matcher.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/Matcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGILookupProvider.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGILookupProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGIRecoPrivTemplates.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGIRecoPrivTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGiConstants.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGiConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGiIcon.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGiIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGiJarAccessibilityQueryImpl.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/OSGiJarAccessibilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/FelixExportPersister.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/FelixExportPersister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/InstructionsConverter.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/InstructionsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/PackagesPanel.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/PackagesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/PackagesPanelProvider.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/customizer/PackagesPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/templates/ActivatorIterator.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/templates/ActivatorIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/templates/BundleWizard.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/templates/BundleWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/util/PackageDefinitionUtil.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/util/PackageDefinitionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/src/org/netbeans/modules/maven/osgi/util/PackageDefinitionVisitor.java
+++ b/maven.osgi/src/org/netbeans/modules/maven/osgi/util/PackageDefinitionVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.osgi/test/unit/src/org/netbeans/modules/maven/osgi/MatcherTest.java
+++ b/maven.osgi/test/unit/src/org/netbeans/modules/maven/osgi/MatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/CPExtender.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/CPExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/EntityClassScopeProviderImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/EntityClassScopeProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/MavenPersistenceProvider.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/MavenPersistenceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceLocationProviderImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceLocationProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopeImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopeProviderImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopeProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopesProviderImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopesProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/RecommendedTemplatesImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/RecommendedTemplatesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.profiler/src/org/netbeans/modules/maven/profiler/MavenProjectProfilingSupportProvider.java
+++ b/maven.profiler/src/org/netbeans/modules/maven/profiler/MavenProjectProfilingSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.profiler/src/org/netbeans/modules/maven/profiler/RunCheckerImpl.java
+++ b/maven.profiler/src/org/netbeans/modules/maven/profiler/RunCheckerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/ArtifactTreeElement.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/ArtifactTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringElementImplementation.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringElementImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringPlugin.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringPluginFactory.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenTreeElementFactory.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenTreeElementFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/ReferringClass.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/ReferringClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/ReferringClassTreeElement.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/ReferringClassTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.refactoring/src/org/netbeans/modules/maven/refactoring/RepositoryTreeElement.java
+++ b/maven.refactoring/src/org/netbeans/modules/maven/refactoring/RepositoryTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ArtifactChildren.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ArtifactChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ArtifactNode.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ArtifactNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ArtifactNodeSelectorImpl.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ArtifactNodeSelectorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/FindInRepoPanel.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/FindInRepoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/FindResultsNode.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/FindResultsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/GroupListChildren.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/GroupListChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/GroupNode.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/GroupNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/M2RepositoryBrowser.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/M2RepositoryBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/RepositoryNode.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/RepositoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/VersionNode.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/VersionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/dependency/AddAsDependencyAction.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/dependency/AddAsDependencyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/dependency/ui/AddDependencyUI.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/dependency/ui/AddDependencyUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/register/RepositoryRegisterUI.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/register/RepositoryRegisterUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/ArtifactMultiViewFactory.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/ArtifactMultiViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicArtifactMD.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicArtifactMD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicArtifactPanel.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicArtifactPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicDependencyMD.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicDependencyMD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicProjectMD.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/BasicProjectMD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/DependencyPanel.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/DependencyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/ErrorPanel.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/ErrorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/LicensePanel.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/LicensePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/MailingListPanel.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/MailingListPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.repository/src/org/netbeans/modules/maven/repository/ui/ProjectInfoPanel.java
+++ b/maven.repository/src/org/netbeans/modules/maven/repository/ui/ProjectInfoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.search/src/org/netbeans/modules/maven/search/MavenRepoProvider.java
+++ b/maven.search/src/org/netbeans/modules/maven/search/MavenRepoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.spring/src/org/netbeans/modules/maven/spring/MavenSpringConfigProviderImpl.java
+++ b/maven.spring/src/org/netbeans/modules/maven/spring/MavenSpringConfigProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven.spring/src/org/netbeans/modules/maven/spring/RecommendedTemplatesImpl.java
+++ b/maven.spring/src/org/netbeans/modules/maven/spring/RecommendedTemplatesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/mavensrc/org/netbeans/modules/maven/event/NbEventSpy.java
+++ b/maven/mavensrc/org/netbeans/modules/maven/event/NbEventSpy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/mavensrc/org/netbeans/modules/maven/workspace/reader/AbstractIDEWorkspaceReader.java
+++ b/maven/mavensrc/org/netbeans/modules/maven/workspace/reader/AbstractIDEWorkspaceReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/mavensrc/org/netbeans/modules/maven/workspace/reader/IDEWorkspaceReader1.java
+++ b/maven/mavensrc/org/netbeans/modules/maven/workspace/reader/IDEWorkspaceReader1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/mavensrc/org/netbeans/modules/maven/workspace/reader/IDEWorkspaceReader2.java
+++ b/maven/mavensrc/org/netbeans/modules/maven/workspace/reader/IDEWorkspaceReader2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/CacheDirProvider.java
+++ b/maven/src/org/netbeans/modules/maven/CacheDirProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/DependencyProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/DependencyProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/DependencyProviderImpl2.java
+++ b/maven/src/org/netbeans/modules/maven/DependencyProviderImpl2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/DependencyType.java
+++ b/maven/src/org/netbeans/modules/maven/DependencyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/LogicalViewProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/LogicalViewProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/M2AuxilaryConfigImpl.java
+++ b/maven/src/org/netbeans/modules/maven/M2AuxilaryConfigImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/MavenProjectPropsImpl.java
+++ b/maven/src/org/netbeans/modules/maven/MavenProjectPropsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/ModuleInfoSupport.java
+++ b/maven/src/org/netbeans/modules/maven/ModuleInfoSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/NbArtifactFixer.java
+++ b/maven/src/org/netbeans/modules/maven/NbArtifactFixer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/NbMavenProjectFactory.java
+++ b/maven/src/org/netbeans/modules/maven/NbMavenProjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/ProjectContainerProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/ProjectContainerProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
+++ b/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/SubprojectProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/SubprojectProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/TemplateAttrProvider.java
+++ b/maven/src/org/netbeans/modules/maven/TemplateAttrProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/TestChecker.java
+++ b/maven/src/org/netbeans/modules/maven/TestChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/TextValueCompleter.java
+++ b/maven/src/org/netbeans/modules/maven/TextValueCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/TransientRepositories.java
+++ b/maven/src/org/netbeans/modules/maven/TransientRepositories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/VisibilityQueryDataFilter.java
+++ b/maven/src/org/netbeans/modules/maven/VisibilityQueryDataFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/CreateLibraryAction.java
+++ b/maven/src/org/netbeans/modules/maven/actions/CreateLibraryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/CreateLibraryPanel.java
+++ b/maven/src/org/netbeans/modules/maven/actions/CreateLibraryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/OpenPOMAction.java
+++ b/maven/src/org/netbeans/modules/maven/actions/OpenPOMAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/RefreshAction.java
+++ b/maven/src/org/netbeans/modules/maven/actions/RefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/RunCustomMavenAction.java
+++ b/maven/src/org/netbeans/modules/maven/actions/RunCustomMavenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/ViewJavadocAction.java
+++ b/maven/src/org/netbeans/modules/maven/actions/ViewJavadocAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/scm/CheckoutAction.java
+++ b/maven/src/org/netbeans/modules/maven/actions/scm/CheckoutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/scm/ui/CheckoutUI.java
+++ b/maven/src/org/netbeans/modules/maven/actions/scm/ui/CheckoutUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/usages/FindArtifactUsages.java
+++ b/maven/src/org/netbeans/modules/maven/actions/usages/FindArtifactUsages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/actions/usages/ui/UsagesUI.java
+++ b/maven/src/org/netbeans/modules/maven/actions/usages/ui/UsagesUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/CommonArtifactActions.java
+++ b/maven/src/org/netbeans/modules/maven/api/CommonArtifactActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/Constants.java
+++ b/maven/src/org/netbeans/modules/maven/api/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/FileUtilities.java
+++ b/maven/src/org/netbeans/modules/maven/api/FileUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/MavenConfiguration.java
+++ b/maven/src/org/netbeans/modules/maven/api/MavenConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/MavenValidators.java
+++ b/maven/src/org/netbeans/modules/maven/api/MavenValidators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/ModelUtils.java
+++ b/maven/src/org/netbeans/modules/maven/api/ModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/ModuleInfoUtils.java
+++ b/maven/src/org/netbeans/modules/maven/api/ModuleInfoUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
+++ b/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
+++ b/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/ProjectProfileHandler.java
+++ b/maven/src/org/netbeans/modules/maven/api/ProjectProfileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/archetype/Archetype.java
+++ b/maven/src/org/netbeans/modules/maven/api/archetype/Archetype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/archetype/ArchetypeProvider.java
+++ b/maven/src/org/netbeans/modules/maven/api/archetype/ArchetypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/archetype/ArchetypeWizards.java
+++ b/maven/src/org/netbeans/modules/maven/api/archetype/ArchetypeWizards.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/archetype/ProjectInfo.java
+++ b/maven/src/org/netbeans/modules/maven/api/archetype/ProjectInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/classpath/DependencyProjectsProvider.java
+++ b/maven/src/org/netbeans/modules/maven/api/classpath/DependencyProjectsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/classpath/ProjectSourcesClassPathProvider.java
+++ b/maven/src/org/netbeans/modules/maven/api/classpath/ProjectSourcesClassPathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle2.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/support/CheckBoxUpdater.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/support/CheckBoxUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/support/ComboBoxUpdater.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/support/ComboBoxUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/support/DelayedDocumentChangeListener.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/support/DelayedDocumentChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/support/ReflectionTextComponentUpdater.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/support/ReflectionTextComponentUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/support/SelectedItemsTable.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/support/SelectedItemsTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/customizer/support/TextComponentUpdater.java
+++ b/maven/src/org/netbeans/modules/maven/api/customizer/support/TextComponentUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/execute/ActiveJ2SEPlatformProvider.java
+++ b/maven/src/org/netbeans/modules/maven/api/execute/ActiveJ2SEPlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/execute/ExecutionContext.java
+++ b/maven/src/org/netbeans/modules/maven/api/execute/ExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/execute/ExecutionResultChecker.java
+++ b/maven/src/org/netbeans/modules/maven/api/execute/ExecutionResultChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/execute/LateBoundPrerequisitesChecker.java
+++ b/maven/src/org/netbeans/modules/maven/api/execute/LateBoundPrerequisitesChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/execute/PrerequisitesChecker.java
+++ b/maven/src/org/netbeans/modules/maven/api/execute/PrerequisitesChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/execute/RunConfig.java
+++ b/maven/src/org/netbeans/modules/maven/api/execute/RunConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
+++ b/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/output/ContextOutputProcessorFactory.java
+++ b/maven/src/org/netbeans/modules/maven/api/output/ContextOutputProcessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/output/NotifyFinishOutputProcessor.java
+++ b/maven/src/org/netbeans/modules/maven/api/output/NotifyFinishOutputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/output/OutputProcessor.java
+++ b/maven/src/org/netbeans/modules/maven/api/output/OutputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/output/OutputProcessorFactory.java
+++ b/maven/src/org/netbeans/modules/maven/api/output/OutputProcessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/output/OutputUtils.java
+++ b/maven/src/org/netbeans/modules/maven/api/output/OutputUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/output/OutputVisitor.java
+++ b/maven/src/org/netbeans/modules/maven/api/output/OutputVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/output/TestOutputObserver.java
+++ b/maven/src/org/netbeans/modules/maven/api/output/TestOutputObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/problem/ProblemReport.java
+++ b/maven/src/org/netbeans/modules/maven/api/problem/ProblemReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/api/problem/ProblemReporter.java
+++ b/maven/src/org/netbeans/modules/maven/api/problem/ProblemReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/AbstractBootPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/AbstractBootPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/AbstractProjectClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/AbstractProjectClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/BootClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/BootClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/CPExtender.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/CPExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/CompileClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/CompileClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/EndorsedClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/EndorsedClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/MavenSourcesImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/MavenSourcesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/PlatformModulesPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/PlatformModulesPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/RuntimeClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/RuntimeClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/SourceClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/SourceClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/TestCompileClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/TestCompileClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/TestRuntimeClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/TestRuntimeClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/classpath/TestSourceClassPathImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/TestSourceClassPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/configurations/ConfigurationPersistenceUtils.java
+++ b/maven/src/org/netbeans/modules/maven/configurations/ConfigurationPersistenceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/configurations/ConfigurationsPanel.java
+++ b/maven/src/org/netbeans/modules/maven/configurations/ConfigurationsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/configurations/ConfigurationsPanelProvider.java
+++ b/maven/src/org/netbeans/modules/maven/configurations/ConfigurationsPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
+++ b/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/configurations/M2Configuration.java
+++ b/maven/src/org/netbeans/modules/maven/configurations/M2Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/configurations/NewConfigurationPanel.java
+++ b/maven/src/org/netbeans/modules/maven/configurations/NewConfigurationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/configurations/ProjectProfileHandlerImpl.java
+++ b/maven/src/org/netbeans/modules/maven/configurations/ProjectProfileHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/cos/CoSAlternativeExecutor.java
+++ b/maven/src/org/netbeans/modules/maven/cos/CoSAlternativeExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/cos/CopyResourcesOnSave.java
+++ b/maven/src/org/netbeans/modules/maven/cos/CopyResourcesOnSave.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/cos/CosChecker.java
+++ b/maven/src/org/netbeans/modules/maven/cos/CosChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/cos/FilteredResourcesCoSSkipper.java
+++ b/maven/src/org/netbeans/modules/maven/cos/FilteredResourcesCoSSkipper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/cos/MainClassesCoSSkipper.java
+++ b/maven/src/org/netbeans/modules/maven/cos/MainClassesCoSSkipper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/cos/OldJavaRunnerCOS.java
+++ b/maven/src/org/netbeans/modules/maven/cos/OldJavaRunnerCOS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/ActionMappingsPanelProvider.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/ActionMappingsPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/AddPropertyDialog.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/AddPropertyDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/BasicInfoPanel.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/BasicInfoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/BasicPanelProvider.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/BasicPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/CompilePanelProvider.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/CompilePanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/LicenseHeaderPanelProvider.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/LicenseHeaderPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/MainClassChooser.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/MainClassChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/PropertySplitter.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/PropertySplitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/RunJarPanel.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/RunJarPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/RunJarPanelProvider.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/RunJarPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/SourcesPanel.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/SourcesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/SourcesPanelProvider.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/SourcesPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/WarnPanel.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/WarnPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/customizer/package-info.java
+++ b/maven/src/org/netbeans/modules/maven/customizer/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/debug/DebuggerChecker.java
+++ b/maven/src/org/netbeans/modules/maven/debug/DebuggerChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/debug/JPDAStart.java
+++ b/maven/src/org/netbeans/modules/maven/debug/JPDAStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/debug/MavenDebuggerImpl.java
+++ b/maven/src/org/netbeans/modules/maven/debug/MavenDebuggerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/debug/Utils.java
+++ b/maven/src/org/netbeans/modules/maven/debug/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/dependencies/CheckNode.java
+++ b/maven/src/org/netbeans/modules/maven/dependencies/CheckNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/dependencies/CheckNodeListener.java
+++ b/maven/src/org/netbeans/modules/maven/dependencies/CheckNodeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/dependencies/CheckRenderer.java
+++ b/maven/src/org/netbeans/modules/maven/dependencies/CheckRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/dependencies/DependencyExcludeNodeVisitor.java
+++ b/maven/src/org/netbeans/modules/maven/dependencies/DependencyExcludeNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/dependencies/ExcludeDependencyPanel.java
+++ b/maven/src/org/netbeans/modules/maven/dependencies/ExcludeDependencyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/AbstractMavenExecutor.java
+++ b/maven/src/org/netbeans/modules/maven/execute/AbstractMavenExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/AbstractOutputHandler.java
+++ b/maven/src/org/netbeans/modules/maven/execute/AbstractOutputHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ActionToGoalUtils.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ActionToGoalUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/BeanRunConfig.java
+++ b/maven/src/org/netbeans/modules/maven/execute/BeanRunConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
+++ b/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/DefaultActionGoalProvider.java
+++ b/maven/src/org/netbeans/modules/maven/execute/DefaultActionGoalProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
+++ b/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/MavenExecutor.java
+++ b/maven/src/org/netbeans/modules/maven/execute/MavenExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ModelRunConfig.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ModelRunConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/NbGlobalActionGoalProvider.java
+++ b/maven/src/org/netbeans/modules/maven/execute/NbGlobalActionGoalProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/OutputTabMaintainer.java
+++ b/maven/src/org/netbeans/modules/maven/execute/OutputTabMaintainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/PrereqCheckerMerger.java
+++ b/maven/src/org/netbeans/modules/maven/execute/PrereqCheckerMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ProxyNonSelectableInputOutput.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ProxyNonSelectableInputOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ReactorChecker.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ReactorChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/cmd/Constructor.java
+++ b/maven/src/org/netbeans/modules/maven/execute/cmd/Constructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/cmd/ExecMojo.java
+++ b/maven/src/org/netbeans/modules/maven/execute/cmd/ExecMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/cmd/ExecProject.java
+++ b/maven/src/org/netbeans/modules/maven/execute/cmd/ExecProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/cmd/ExecSession.java
+++ b/maven/src/org/netbeans/modules/maven/execute/cmd/ExecSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/cmd/ExecutionEventObject.java
+++ b/maven/src/org/netbeans/modules/maven/execute/cmd/ExecutionEventObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/cmd/ShellConstructor.java
+++ b/maven/src/org/netbeans/modules/maven/execute/cmd/ShellConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/model/ActionToGoalMapping.java
+++ b/maven/src/org/netbeans/modules/maven/execute/model/ActionToGoalMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionMapping.java
+++ b/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionProfile.java
+++ b/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionReader.java
+++ b/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/model/io/jdom/NetbeansBuildActionJDOMWriter.java
+++ b/maven/src/org/netbeans/modules/maven/execute/model/io/jdom/NetbeansBuildActionJDOMWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Reader.java
+++ b/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Reader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Writer.java
+++ b/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Writer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/navigator/GoalsNavigationPanel.java
+++ b/maven/src/org/netbeans/modules/maven/execute/navigator/GoalsNavigationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/navigator/GoalsNavigatorHint.java
+++ b/maven/src/org/netbeans/modules/maven/execute/navigator/GoalsNavigatorHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/navigator/GoalsPanel.java
+++ b/maven/src/org/netbeans/modules/maven/execute/navigator/GoalsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/navigator/TapPanel.java
+++ b/maven/src/org/netbeans/modules/maven/execute/navigator/TapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/navigator/TrivialLayout.java
+++ b/maven/src/org/netbeans/modules/maven/execute/navigator/TrivialLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ui/DebugPluginSourceAction.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ui/DebugPluginSourceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ui/GotoPluginSourceAction.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ui/GotoPluginSourceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ui/RunGoalsPanel.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ui/RunGoalsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/execute/ui/ShowExecutionPanel.java
+++ b/maven/src/org/netbeans/modules/maven/execute/ui/ShowExecutionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/modelcache/ActiveConfigurationProvider.java
+++ b/maven/src/org/netbeans/modules/maven/modelcache/ActiveConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
+++ b/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/ArchetypeTemplateHandler.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/ArchetypeTemplateHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/ArchetypeWizardUtils.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/ArchetypeWizardUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/BasicWizardPanel.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/BasicWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/CatalogRepoProvider.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/CatalogRepoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/ChooseArchetypePanel.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/ChooseArchetypePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/ChooseWizardPanel.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/ChooseWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/ExistingWizardIterator.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/ExistingWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/LocalRepoProvider.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/LocalRepoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/RemoteRepoProvider.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/RemoteRepoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/UseOpenPanel.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/UseOpenPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/UseOpenWizardPanel.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/UseOpenWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeMavenWizardIterator.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeMavenWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/idenative/PomJavaNativeMWI.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/idenative/PomJavaNativeMWI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/newproject/idenative/SimpleJavaNativeMWI.java
+++ b/maven/src/org/netbeans/modules/maven/newproject/idenative/SimpleJavaNativeMWI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/AddDependencyPanel.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/AddDependencyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/AnnotatedAbstractNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/AnnotatedAbstractNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/BootCPNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/BootCPNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/DependenciesNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/DependenciesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/DependenciesNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/DependenciesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/DependencyNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/DependencyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/GenSourcesNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/GenSourcesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/InstallDocSourcePanel.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/InstallDocSourcePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/InstallPanel.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/InstallPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/JarIcons.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/JarIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/MavenProjectNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/MavenProjectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/ModulesNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/ModulesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/ModulesNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/ModulesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/OtherRootNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/OtherRootNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/OthersRootChildren.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/OthersRootChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/OthersRootNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/OthersRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/PathFinders.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/PathFinders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/PomIcons.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/PomIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/ProjectFilesNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/ProjectFilesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/ProjectFilesNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/ProjectFilesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/SiteDocsNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/SiteDocsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/SiteDocsNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/SiteDocsNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/nodes/SourcesNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/SourcesNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/operations/Operations.java
+++ b/maven/src/org/netbeans/modules/maven/operations/Operations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/operations/OperationsImpl.java
+++ b/maven/src/org/netbeans/modules/maven/operations/OperationsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/operations/RenameProjectPanel.java
+++ b/maven/src/org/netbeans/modules/maven/operations/RenameProjectPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/DontShowAgainSettings.java
+++ b/maven/src/org/netbeans/modules/maven/options/DontShowAgainSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/GlobalOptionsPanel.java
+++ b/maven/src/org/netbeans/modules/maven/options/GlobalOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/MavenCommandSettings.java
+++ b/maven/src/org/netbeans/modules/maven/options/MavenCommandSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/MavenGroupCategory.java
+++ b/maven/src/org/netbeans/modules/maven/options/MavenGroupCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/MavenGroupPanel.java
+++ b/maven/src/org/netbeans/modules/maven/options/MavenGroupPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/MavenOptionController.java
+++ b/maven/src/org/netbeans/modules/maven/options/MavenOptionController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
+++ b/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/options/UnsetProxyChecker.java
+++ b/maven/src/org/netbeans/modules/maven/options/UnsetProxyChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/CompileAnnotation.java
+++ b/maven/src/org/netbeans/modules/maven/output/CompileAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/DefaultOutputProcessorFactory.java
+++ b/maven/src/org/netbeans/modules/maven/output/DefaultOutputProcessorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/DependencyAnalyzeOutputProcessor.java
+++ b/maven/src/org/netbeans/modules/maven/output/DependencyAnalyzeOutputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
+++ b/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/GlobalOutputProcessor.java
+++ b/maven/src/org/netbeans/modules/maven/output/GlobalOutputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/JavaOutputListenerProvider.java
+++ b/maven/src/org/netbeans/modules/maven/output/JavaOutputListenerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/JavadocOutputProcessor.java
+++ b/maven/src/org/netbeans/modules/maven/output/JavadocOutputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/SiteOutputProcessor.java
+++ b/maven/src/org/netbeans/modules/maven/output/SiteOutputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
+++ b/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/problems/BatchProblemNotifier.java
+++ b/maven/src/org/netbeans/modules/maven/problems/BatchProblemNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/problems/EnableParticipantsBuildAction.java
+++ b/maven/src/org/netbeans/modules/maven/problems/EnableParticipantsBuildAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/problems/JavaPlatformProblemProvider.java
+++ b/maven/src/org/netbeans/modules/maven/problems/JavaPlatformProblemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
+++ b/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/problems/MissingModulesProblemProvider.java
+++ b/maven/src/org/netbeans/modules/maven/problems/MissingModulesProblemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/problems/ProblemReporterImpl.java
+++ b/maven/src/org/netbeans/modules/maven/problems/ProblemReporterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/problems/SanityBuildAction.java
+++ b/maven/src/org/netbeans/modules/maven/problems/SanityBuildAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/AbstractMavenForBinaryQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/AbstractMavenForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/AspectJRootProvider.java
+++ b/maven/src/org/netbeans/modules/maven/queries/AspectJRootProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/ForeignClassBundlerMerger.java
+++ b/maven/src/org/netbeans/modules/maven/queries/ForeignClassBundlerMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/Info.java
+++ b/maven/src/org/netbeans/modules/maven/queries/Info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenAnnotationProcessingQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenAnnotationProcessingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenBinaryForSourceQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenBinaryForSourceQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenFileEncodingQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenFileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenFileLocator.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenFileLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenFileOwnerQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenFileOwnerQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenForBinaryQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenSharabilityQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenSharabilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenSourceJavadocAttacher.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenSourceJavadocAttacher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenSourceLevelImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenSourceLevelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/MavenTestForSourceImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/MavenTestForSourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/PomCompilerOptionsQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/PomCompilerOptionsQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/RecommendedTemplatesImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/RecommendedTemplatesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/RepositoryForBinaryQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/RepositoryForBinaryQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/RepositoryMavenCPProvider.java
+++ b/maven/src/org/netbeans/modules/maven/queries/RepositoryMavenCPProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/ShadePluginDetector.java
+++ b/maven/src/org/netbeans/modules/maven/queries/ShadePluginDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/SourceJavadocByHash.java
+++ b/maven/src/org/netbeans/modules/maven/queries/SourceJavadocByHash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/queries/UnitTestsCompilerOptionsQueryImpl.java
+++ b/maven/src/org/netbeans/modules/maven/queries/UnitTestsCompilerOptionsQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/runjar/MainClassChooser.java
+++ b/maven/src/org/netbeans/modules/maven/runjar/MainClassChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/runjar/RunJarPrereqChecker.java
+++ b/maven/src/org/netbeans/modules/maven/runjar/RunJarPrereqChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/runjar/RunJarStartupArgs.java
+++ b/maven/src/org/netbeans/modules/maven/runjar/RunJarStartupArgs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/IconResources.java
+++ b/maven/src/org/netbeans/modules/maven/spi/IconResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/PackagingProvider.java
+++ b/maven/src/org/netbeans/modules/maven/spi/PackagingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
+++ b/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/actions/ActionConvertor.java
+++ b/maven/src/org/netbeans/modules/maven/spi/actions/ActionConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/actions/MavenActionsProvider.java
+++ b/maven/src/org/netbeans/modules/maven/spi/actions/MavenActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/actions/ReplaceTokenProvider.java
+++ b/maven/src/org/netbeans/modules/maven/spi/actions/ReplaceTokenProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/cos/AdditionalDestination.java
+++ b/maven/src/org/netbeans/modules/maven/spi/cos/AdditionalDestination.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/cos/CoSAlternativeExecutorImplementation.java
+++ b/maven/src/org/netbeans/modules/maven/spi/cos/CoSAlternativeExecutorImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/cos/CompileOnSaveSkipper.java
+++ b/maven/src/org/netbeans/modules/maven/spi/cos/CompileOnSaveSkipper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/customizer/SelectedItemsTablePersister.java
+++ b/maven/src/org/netbeans/modules/maven/spi/customizer/SelectedItemsTablePersister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/customizer/TextToValueConversions.java
+++ b/maven/src/org/netbeans/modules/maven/spi/customizer/TextToValueConversions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/debug/AdditionalDebuggedProjects.java
+++ b/maven/src/org/netbeans/modules/maven/spi/debug/AdditionalDebuggedProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/debug/MavenDebugger.java
+++ b/maven/src/org/netbeans/modules/maven/spi/debug/MavenDebugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/grammar/DialogFactory.java
+++ b/maven/src/org/netbeans/modules/maven/spi/grammar/DialogFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/grammar/GoalsProvider.java
+++ b/maven/src/org/netbeans/modules/maven/spi/grammar/GoalsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/newproject/CreateProjectBuilder.java
+++ b/maven/src/org/netbeans/modules/maven/spi/newproject/CreateProjectBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/nodes/AbstractMavenNodeList.java
+++ b/maven/src/org/netbeans/modules/maven/spi/nodes/AbstractMavenNodeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/nodes/DependencyTypeIconBadge.java
+++ b/maven/src/org/netbeans/modules/maven/spi/nodes/DependencyTypeIconBadge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/nodes/MavenNodeFactory.java
+++ b/maven/src/org/netbeans/modules/maven/spi/nodes/MavenNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/nodes/NodeUtils.java
+++ b/maven/src/org/netbeans/modules/maven/spi/nodes/NodeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/nodes/OtherSourcesExclude.java
+++ b/maven/src/org/netbeans/modules/maven/spi/nodes/OtherSourcesExclude.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/nodes/SpecialIcon.java
+++ b/maven/src/org/netbeans/modules/maven/spi/nodes/SpecialIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/queries/ForeignClassBundler.java
+++ b/maven/src/org/netbeans/modules/maven/spi/queries/ForeignClassBundler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/src/org/netbeans/modules/maven/spi/queries/JavaLikeRootProvider.java
+++ b/maven/src/org/netbeans/modules/maven/spi/queries/JavaLikeRootProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/ActionProviderImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/ActionProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/MavenProjectPropsImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/MavenProjectPropsImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/NbArtifactFixerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/NbArtifactFixerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectFactoryTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/ProjectOpenedHookImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/ProjectOpenedHookImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/SubprojectProviderImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/SubprojectProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/TemplateAttrProviderTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/TemplateAttrProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/TransientRepositoriesTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/TransientRepositoriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/api/ModelUtilsTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/api/ModelUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/api/PluginPropertyUtilsTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/api/PluginPropertyUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/api/output/OutputUtilsTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/api/output/OutputUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/classpath/CPExtenderTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/classpath/CPExtenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/classpath/ClassPathProviderImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/classpath/ClassPathProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/classpath/MavenSourcesImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/classpath/MavenSourcesImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/configurations/NewConfigurationPanelTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/configurations/NewConfigurationPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/cos/CosCheckerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/cos/CosCheckerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/customizer/ActionMappingsTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/customizer/ActionMappingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/customizer/PropertySplitterTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/customizer/PropertySplitterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/customizer/RunJarPanelTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/customizer/RunJarPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/debug/DebuggerCheckerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/debug/DebuggerCheckerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/execute/CommandLineOutputHandlerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/execute/CommandLineOutputHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProviderTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/execute/ModelRunConfigTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/execute/ModelRunConfigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/execute/ReactorCheckerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/execute/ReactorCheckerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/execute/cmd/ShellConstructorTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/execute/cmd/ShellConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/execute/model/io/jdom/NetbeansBuildActionJDOMWriterTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/execute/model/io/jdom/NetbeansBuildActionJDOMWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/newproject/ArchetypeTemplateHandlerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/newproject/ArchetypeTemplateHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/newproject/ArchetypeWizardUtilsTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/newproject/ArchetypeWizardUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/newproject/simplewizard/SimpleWizardHandlerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/newproject/simplewizard/SimpleWizardHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/output/GlobalOutputProcessorTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/output/GlobalOutputProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/output/JavaOutputListenerProviderTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/output/JavaOutputListenerProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/output/MEVENIDE637Test.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/output/MEVENIDE637Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/output/TestOutputListenerProviderTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/output/TestOutputListenerProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/problems/ProblemReporterImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/problems/ProblemReporterImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenAnnotationProcessingQueryImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenAnnotationProcessingQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenBinaryForSourceQueryImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenBinaryForSourceQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenFileOwnerQueryImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenFileOwnerQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenForBinaryQueryImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenForBinaryQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenSharabilityQueryImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenSharabilityQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenSourceLevelImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenSourceLevelImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/queries/RepositoryForBinaryQueryImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/queries/RepositoryForBinaryQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/runjar/RunJarPrereqCheckerTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/runjar/RunJarPrereqCheckerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/maven/test/unit/src/org/netbeans/modules/maven/spi/nodes/NodeUtilsTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/spi/nodes/NodeUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ExceptionHandler.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/FileInformation.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/FileInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/FileStatus.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/FileStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/FileStatusCache.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/FileStatusCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/HgException.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/HgException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/HgFileNode.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/HgFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/HgHistoryProvider.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/HgHistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/HgModuleConfig.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/HgModuleConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/HgProgressSupport.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/HgProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/HistoryRegistry.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/HistoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/Mercurial.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/Mercurial.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/MercurialAnnotator.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/MercurialAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/MercurialInterceptor.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/MercurialInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/MercurialVCS.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/MercurialVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/OutputLogger.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/OutputLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/VersionsCache.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/VersionsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/WorkingCopyInfo.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/WorkingCopyInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/api/Mercurial.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/api/Mercurial.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/commands/RebaseCommand.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/commands/RebaseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/commands/StatusCommand.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/commands/StatusCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/config/HgConfigFiles.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/config/HgConfigFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/config/Scrambler.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/config/Scrambler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/kenai/HgKenaiAccessor.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/kenai/HgKenaiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/kenai/KenaiNotificationListener.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/kenai/KenaiNotificationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/AnnotationColorProvider.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/AnnotationColorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/HgExtProperties.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/HgExtProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/LabelsPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/LabelsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/MercurialAdvancedOption.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/MercurialAdvancedOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/MercurialOptionsPanelController.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/MercurialOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/MercurialPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/MercurialPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/PropertiesPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/PropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/PropertiesTable.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/PropertiesTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/options/PropertiesTableModel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/options/PropertiesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/actions/ContextAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/actions/ContextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/add/AddAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/add/AddAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotateAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotateLine.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotateLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationBar.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationBarManager.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationBarManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationMark.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationMarkInstaller.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationMarkInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationMarkProvider.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/AnnotationMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/LinesReader.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/LinesReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/TooltipWindow.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/annotate/TooltipWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/BranchSelector.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/BranchSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/BranchSelectorPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/BranchSelectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CloseBranchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CloseBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CreateBranch.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CreateBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CreateBranchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CreateBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CreateBranchPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/CreateBranchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/HgBranch.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/HgBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/branch/SwitchToBranchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/branch/SwitchToBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/clone/Clone.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/clone/Clone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/clone/CloneAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/clone/CloneAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/clone/CloneCompleted.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/clone/CloneCompleted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/clone/CloneExternalAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/clone/CloneExternalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/clone/ClonePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/clone/ClonePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitOptions.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitTable.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitTableModel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/commit/DeleteLocalAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/commit/DeleteLocalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/commit/ExcludeFromCommitAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/commit/ExcludeFromCommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/create/CreateAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/create/CreateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/create/CreatePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/create/CreatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ApplyDiffPatchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ApplyDiffPatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffFileTable.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffFileTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffFileTreeImpl.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffFileTreeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffNode.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffSetupSource.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffSetupSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffStreamSource.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffStreamSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffToRevision.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffToRevision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffToRevisionAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffToRevisionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffToRevisionPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffToRevisionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffTopComponent.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/DiffTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportAsFilePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportAsFilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportBundle.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportBundleAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportBundleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportBundlePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportBundlePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiff.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiffAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiffChangesAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiffChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiffPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ExportDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ImportDiffAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ImportDiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/MultiDiffPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/MultiDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/Setup.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/Setup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/diff/VerticalFlowLayout.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/diff/VerticalFlowLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/ignore/IgnoreAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/ignore/IgnoreAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/DiffResultsView.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/DiffResultsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/DiffResultsViewForLine.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/DiffResultsViewForLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/DiffTreeTable.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/DiffTreeTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/HgLogMessageChangedPath.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/HgLogMessageChangedPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/IncomingAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/IncomingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/LogAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/LogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/OutAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/OutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/RepositoryRevision.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/RepositoryRevision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/RevisionNode.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/RevisionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/RevisionNodeChildren.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/RevisionNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchCriteriaPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchCriteriaPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchExecutor.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryTopComponent.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/log/SummaryView.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/log/SummaryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/BranchMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/BranchMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/ConflictsMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/ConflictsMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/DiffMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/DiffMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/DynamicMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/DynamicMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/IgnoreMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/IgnoreMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/PatchesMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/PatchesMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/QueuesMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/QueuesMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/RecoverMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/RecoverMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/menu/RemoteMenu.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/menu/RemoteMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/merge/MergeAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/merge/MergeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/merge/MergeRevisions.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/merge/MergeRevisions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/merge/MergeRevisionsPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/merge/MergeRevisionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/properties/HgProperties.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/properties/HgProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/properties/HgPropertiesNode.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/properties/HgPropertiesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesTable.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesTableModel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/properties/PropertiesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/pull/FetchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/pull/FetchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/pull/PullAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/pull/PullAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/pull/PullCurrentBranchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/pull/PullCurrentBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/pull/PullOtherAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/pull/PullOtherAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/push/PushAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/push/PushAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/push/PushCurrentBranchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/push/PushCurrentBranchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/push/PushOtherAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/push/PushOtherAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/CommitPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/CommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/CreateRefreshAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/CreateRefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/FailedPatchResolver.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/FailedPatchResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/FinishPatch.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/FinishPatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/GoToPatch.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/GoToPatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/PatchSeriesPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/PatchSeriesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCommitPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCommitTable.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCommitTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCreatePatchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCreatePatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCreatePatchParameters.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QCreatePatchParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QDiffAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QDiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QFileNode.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QFinishPatchesAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QFinishPatchesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QGoToPatchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QGoToPatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QPatch.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QPatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QPopAllAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QPopAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QPushAllPatchesAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QPushAllPatchesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QRefreshPatchAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QRefreshPatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QUtils.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/QUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/Queue.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/Queue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/queues/RefreshPanelModifier.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/queues/RefreshPanelModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/BasicPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/BasicPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/Rebase.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/Rebase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/RebaseAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/RebaseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/RebaseKind.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/RebaseKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/RebasePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/RebasePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/SelectBasePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/SelectBasePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/SelectDestPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/SelectDestPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/SelectSourcePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rebase/SelectSourcePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPickerPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPickerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/HeadRevisionPicker.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/HeadRevisionPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/HgURL.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/HgURL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/Repository.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/Repository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/RepositoryConnection.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/RepositoryConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/RepositoryDialogPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/RepositoryDialogPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/RepositoryPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/RepositoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/UserCredentialsSupport.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/UserCredentialsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/repository/UserPasswordPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/repository/UserPasswordPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/Backout.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/Backout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/BackoutAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/BackoutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/BackoutPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/BackoutPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/RollbackAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/RollbackAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/Strip.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/Strip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/StripAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/StripAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/StripPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/StripPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/VerifyAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/rollback/VerifyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/shelve/ShelveChangesAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/shelve/ShelveChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/status/HgVersioningTopComponent.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/status/HgVersioningTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/status/OpenInEditorAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/status/OpenInEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/status/OpenVersioningAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/status/OpenVersioningAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/status/ShowAllChangesAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/status/ShowAllChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/status/StatusAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/status/StatusAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/status/SyncFileNode.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/status/SyncFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/status/SyncTable.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/status/SyncTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/CreateTag.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/CreateTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/CreateTagAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/CreateTagAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/CreateTagPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/CreateTagPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/HgTag.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/HgTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/ManageTagsAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/ManageTagsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/RemoveTagPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/RemoveTagPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/TagManager.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/TagManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/tag/TagManagerPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/tag/TagManagerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/ConflictResolvedAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/ConflictResolvedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/ResolveConflictsAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/ResolveConflictsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/ResolveConflictsExecutor.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/ResolveConflictsExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/RevertModifications.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/RevertModifications.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/RevertModificationsAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/RevertModificationsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/RevertModificationsPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/RevertModificationsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/Update.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/Update.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/UpdateAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/UpdateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/update/UpdatePanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/update/UpdatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/view/ViewAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/view/ViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneDestinationDirectoryPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneDestinationDirectoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneDestinationDirectoryWizardPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneDestinationDirectoryWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/ClonePathsPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/ClonePathsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/ClonePathsWizardPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/ClonePathsWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneRepositoryWizardPanel.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneRepositoryWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneWizardAction.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/CloneWizardAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/WizardStepProgressSupport.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/ui/wizards/WizardStepProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/util/HgCommand.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/util/HgCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/util/HgProjectUtils.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/util/HgProjectUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/util/HgRepositoryContextCache.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/util/HgRepositoryContextCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/util/HgSearchHistorySupport.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/util/HgSearchHistorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/src/org/netbeans/modules/mercurial/util/HgUtils.java
+++ b/mercurial/src/org/netbeans/modules/mercurial/util/HgUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/archeology/AnnotationsTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/archeology/AnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/CloneTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/CloneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/CommitDataTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/CommitDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/CommitUiTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/CommitUiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/IgnoreTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/IgnoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/InitializeTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/commit/InitializeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/delete/DeleteUpdateTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/delete/DeleteUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/properties/HgPropertiesTest.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/main/properties/HgPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/CommitOperator.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/CommitOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/HgPropertiesOperator.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/HgPropertiesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/RevertModificationsOperator.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/RevertModificationsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/VersioningOperator.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/VersioningOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/actions/CommitAction.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/actions/CommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/actions/HgPropertiesAction.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/actions/HgPropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/actions/RevertAction.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/operators/actions/RevertAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/MessageHandler.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/MessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/RepositoryMaintenance.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/RepositoryMaintenance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/StreamHandler.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/StreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/TestKit.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/TestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/hgExistsChecker.java
+++ b/mercurial/test/qa-functional/src/org/netbeans/test/mercurial/utils/hgExistsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/AbstractHgTestCase.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/AbstractHgTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/ExternalChangesTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/ExternalChangesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/FileStatusCacheTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/FileStatusCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/HgCommandTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/HgCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/HistoryTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/HistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/IgnoresTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/IgnoresTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/InterceptorTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/InterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/MercurialFileSystemTestCase.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/MercurialFileSystemTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/MercurialFileSystemTestStat.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/MercurialFileSystemTestStat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/StatusTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/StatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/actions/MergeTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/actions/MergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/api/MercurialApi.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/api/MercurialApi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/api/SearchHistoryTestCase.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/api/SearchHistoryTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/commands/RebaseCommandTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/commands/RebaseCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/commands/StatusCommandTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/commands/StatusCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/getTopmostTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/getTopmostTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mercurial/test/unit/src/org/netbeans/modules/mercurial/ui/repository/HgURLTest.java
+++ b/mercurial/test/unit/src/org/netbeans/modules/mercurial/ui/repository/HgURLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/AbstractNbTaskWrapper.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/AbstractNbTaskWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/AccessorImpl.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/BugtrackingCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/BugtrackingCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/CancelableProgressMonitor.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/CancelableProgressMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/GetAttachmentCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/GetAttachmentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/GetMultiTaskDataCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/GetMultiTaskDataCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/GetTaskDataCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/GetTaskDataCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/MylynSupport.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/MylynSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/MylynUtils.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/MylynUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/NbDateRange.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/NbDateRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTask.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTaskDataModel.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTaskDataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTaskDataState.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTaskDataState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTaskListener.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/NbTaskListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/PerformQueryCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/PerformQueryCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/PostAttachmentCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/PostAttachmentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/RepositoryConnectorProvider.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/RepositoryConnectorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/SubmitCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/SubmitCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/TaskDataListener.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/TaskDataListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/UnsubmittedTasksContainer.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/UnsubmittedTasksContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/WikiPanel.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/WikiPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/WikiUtils.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/WikiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/CommandFactory.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/CommandFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/CommandsAccessorImpl.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/CommandsAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/GetAttachmentCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/GetAttachmentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/GetRepositoryTasksCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/GetRepositoryTasksCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/PostAttachmentCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/PostAttachmentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SimpleQueryCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SimpleQueryCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SubmitTaskCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SubmitTaskCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SynchronizeQueryCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SynchronizeQueryCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SynchronizeTasksCommand.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/commands/SynchronizeTasksCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/Accessor.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/CommandsAccessor.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/CommandsAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/ModuleLifecycleManager.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/ModuleLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/TaskListener.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/internal/TaskListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/localtasks/AbstractLocalTask.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/localtasks/AbstractLocalTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/localtasks/IssueField.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/localtasks/IssueField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/localtasks/internal/LocalTaskDataHandler.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/localtasks/internal/LocalTaskDataHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/mylyn.util/src/org/netbeans/modules/mylyn/util/wiki/WikiEditPanel.java
+++ b/mylyn.util/src/org/netbeans/modules/mylyn/util/wiki/WikiEditPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/JSExecutor.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/JSExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/NashornPlatform.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/NashornPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/actions/DebugJSAction.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/actions/DebugJSAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/actions/ExecJSAction.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/actions/ExecJSAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/actions/RunJSAction.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/actions/RunJSAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/JavaScriptNashornOptionsPanelController.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/JavaScriptNashornOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/JavaScriptNashornPanel.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/JavaScriptNashornPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/NashornPlatformComboBoxModel.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/NashornPlatformComboBoxModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/Settings.java
+++ b/nashorn.execution/src/org/netbeans/modules/nashorn/execution/options/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Branding.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Branding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckBundles.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckBundles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSets.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLicense.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLicense.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckModuleConfigs.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckModuleConfigs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CleanAll.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CleanAll.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ConvertClusterPath.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ConvertClusterPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ConvertImport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ConvertImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CopyIcons.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CopyIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CreateModuleXML.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CreateModuleXML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/DeleteUnreferencedClusterFiles.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/DeleteUnreferencedClusterFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ExportedAPICondition.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ExportedAPICondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FindExecutables.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FindExecutables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FixDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FixDependencies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FixTestDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FixTestDependencies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/GetDependsClusters.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/GetDependsClusters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/GetModuleName.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/GetModuleName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/HgExec.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/HgExec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/HgId.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/HgId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/IncrementSpecificationVersions.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/IncrementSpecificationVersions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/InsertModuleAllTargets.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/InsertModuleAllTargets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/IsLocked.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/IsLocked.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JHIndexer.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JHIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JUnitReportWriter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JUnitReportWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JarWithModuleAttributes.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JarWithModuleAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JavadocIndex.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JavadocIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/L10nTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/L10nTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LayerIndex.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LayerIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LayerOptionsImport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LayerOptionsImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocFiles.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocJHIndexer.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocJHIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocMakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocMakeNBM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocalizedJar.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocalizedJar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeListOfNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeListOfNBM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeMasterJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeMasterJNLP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeOSGi.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeOSGi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleDependencies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleStateSelector.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleStateSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleTestDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleTestDependencies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleType.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/NbMerge.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/NbMerge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseManifest.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseManifest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/PathFileSet.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/PathFileSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ProcessJsAnnotationsTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ProcessJsAnnotationsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/RatReportTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/RatReportTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/RefreshDependencyVersions.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/RefreshDependencyVersions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Repeat.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Repeat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ResolveList.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ResolveList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SetCluster.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SetCluster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ShorterPaths.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ShorterPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Sigtest.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Sigtest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SubAntJUnitReport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SubAntJUnitReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SummarizeHgmail.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SummarizeHgmail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/TryElse.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/TryElse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ValidateHgConfiguration.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ValidateHgConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyClassLinkage.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyClassLinkage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyUpdateCenter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyUpdateCenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateDependencies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DeregisterExternalHook.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DeregisterExternalHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/PatchFile.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/PatchFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesCopy.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesCopy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesExtra.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesExtra.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesLicense.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesLicense.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/antsrc/org/netbeans/nbbuild/testdist/ValidatePath.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/testdist/ValidatePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/javadoctools/javadoc-generic.css
+++ b/nbbuild/javadoctools/javadoc-generic.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/javadoctools/javadoc.css
+++ b/nbbuild/javadoctools/javadoc.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/javadoctools/nb-docs-stability.css
+++ b/nbbuild/javadoctools/nb-docs-stability.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/javadoctools/nb-docs.css
+++ b/nbbuild/javadoctools/nb-docs.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/javadoctools/netbeans-lite.css
+++ b/nbbuild/javadoctools/netbeans-lite.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/javadoctools/netbeans.css
+++ b/nbbuild/javadoctools/netbeans.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/javadoctools/prose.css
+++ b/nbbuild/javadoctools/prose.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ArchQuestionsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ArchQuestionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/AutoUpdateTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/AutoUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/BrandingTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/BrandingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLicenseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLinksTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CheckLinksTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ConvertImportTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ConvertImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/CreateModuleXMLTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/CreateModuleXMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/FixDependenciesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/FixDependenciesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/InsertModuleAllTargetsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/InsertModuleAllTargetsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/IsLockedTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/IsLockedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/JarWithModuleAttributesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/JarWithModuleAttributesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/LocFilesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/LocFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeJNLPTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeJNLPTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeMasterJNLPTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeMasterJNLPTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeNBMTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeNBMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeOSGiTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeUpdateDescTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeUpdateDescTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleDependenciesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleDependenciesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleSelectorTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleSelectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleStateSelectorTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleStateSelectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ParseProjectXmlTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ParseProjectXmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/PathFileSetTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/PathFileSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/PrintIconTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/PrintIconTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/PublicPackagesInProjectizedXMLTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/PublicPackagesInProjectizedXMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/RecursiveDepsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/RecursiveDepsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ShorterPathsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ShorterPathsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/SortSuiteModulesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/SortSuiteModulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/TestBase.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/TestDepsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/TestDepsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/XMLUtilTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/XMLUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/CreateDependenciesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/CreateDependenciesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/DownloadBinariesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/DownloadBinariesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/TestDistFilterTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/TestDistFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/ValidatePathTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/ValidatePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/cleaner/windows/src/main.c
+++ b/nbi/engine/native/cleaner/windows/src/main.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/.common/src/CommonUtils.c
+++ b/nbi/engine/native/jnilib/.common/src/CommonUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/.common/src/CommonUtils.h
+++ b/nbi/engine/native/jnilib/.common/src/CommonUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/.unix/src/jni_UnixNativeUtils.c
+++ b/nbi/engine/native/jnilib/.unix/src/jni_UnixNativeUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/.unix/src/jni_UnixNativeUtils.h
+++ b/nbi/engine/native/jnilib/.unix/src/jni_UnixNativeUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/windows/src/WindowsUtils.c
+++ b/nbi/engine/native/jnilib/windows/src/WindowsUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/windows/src/WindowsUtils.h
+++ b/nbi/engine/native/jnilib/windows/src/WindowsUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/windows/src/jni_WindowsNativeUtils.c
+++ b/nbi/engine/native/jnilib/windows/src/jni_WindowsNativeUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/windows/src/jni_WindowsNativeUtils.h
+++ b/nbi/engine/native/jnilib/windows/src/jni_WindowsNativeUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/windows/src/jni_WindowsRegistry.c
+++ b/nbi/engine/native/jnilib/windows/src/jni_WindowsRegistry.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/jnilib/windows/src/jni_WindowsRegistry.h
+++ b/nbi/engine/native/jnilib/windows/src/jni_WindowsRegistry.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/resources/res.rc
+++ b/nbi/engine/native/launcher/windows/resources/res.rc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/Errors.h
+++ b/nbi/engine/native/launcher/windows/src/Errors.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/ExtractUtils.c
+++ b/nbi/engine/native/launcher/windows/src/ExtractUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/ExtractUtils.h
+++ b/nbi/engine/native/launcher/windows/src/ExtractUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/FileUtils.c
+++ b/nbi/engine/native/launcher/windows/src/FileUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/FileUtils.h
+++ b/nbi/engine/native/launcher/windows/src/FileUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/JavaUtils.c
+++ b/nbi/engine/native/launcher/windows/src/JavaUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/JavaUtils.h
+++ b/nbi/engine/native/launcher/windows/src/JavaUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/Launcher.c
+++ b/nbi/engine/native/launcher/windows/src/Launcher.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/Launcher.h
+++ b/nbi/engine/native/launcher/windows/src/Launcher.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/Main.c
+++ b/nbi/engine/native/launcher/windows/src/Main.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/Main.h
+++ b/nbi/engine/native/launcher/windows/src/Main.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/ProcessUtils.c
+++ b/nbi/engine/native/launcher/windows/src/ProcessUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/ProcessUtils.h
+++ b/nbi/engine/native/launcher/windows/src/ProcessUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/RegistryUtils.c
+++ b/nbi/engine/native/launcher/windows/src/RegistryUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/RegistryUtils.h
+++ b/nbi/engine/native/launcher/windows/src/RegistryUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/StringUtils.c
+++ b/nbi/engine/native/launcher/windows/src/StringUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/StringUtils.h
+++ b/nbi/engine/native/launcher/windows/src/StringUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/SystemUtils.c
+++ b/nbi/engine/native/launcher/windows/src/SystemUtils.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/SystemUtils.h
+++ b/nbi/engine/native/launcher/windows/src/SystemUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/native/launcher/windows/src/Types.h
+++ b/nbi/engine/native/launcher/windows/src/Types.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/com/apple/eawt/Application.java
+++ b/nbi/engine/src/com/apple/eawt/Application.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/com/apple/eawt/ApplicationAdapter.java
+++ b/nbi/engine/src/com/apple/eawt/ApplicationAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/com/apple/eawt/ApplicationBeanInfo.java
+++ b/nbi/engine/src/com/apple/eawt/ApplicationBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/com/apple/eawt/ApplicationEvent.java
+++ b/nbi/engine/src/com/apple/eawt/ApplicationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/com/apple/eawt/ApplicationListener.java
+++ b/nbi/engine/src/com/apple/eawt/ApplicationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/com/apple/eawt/CocoaComponent.java
+++ b/nbi/engine/src/com/apple/eawt/CocoaComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/Installer.java
+++ b/nbi/engine/src/org/netbeans/installer/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/DownloadConfig.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/DownloadConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/DownloadListener.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/DownloadListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/DownloadManager.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/DownloadManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/DownloadMode.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/DownloadMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/DownloadProgress.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/DownloadProgress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/Pumping.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/Pumping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/PumpingsQueue.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/PumpingsQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/connector/MyProxy.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/connector/MyProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/connector/MyProxySelector.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/connector/MyProxySelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/connector/MyProxyType.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/connector/MyProxyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/connector/URLConnector.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/connector/URLConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/LoadFactor.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/LoadFactor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/Process.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/Process.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/ProcessDispatcher.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/ProcessDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/impl/RoundRobinDispatcher.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/impl/RoundRobinDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/impl/Worker.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/impl/Worker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/impl/WorkersPool.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/dispatcher/impl/WorkersPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/impl/ChannelUtil.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/impl/ChannelUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/impl/Pump.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/impl/Pump.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/impl/PumpingImpl.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/impl/PumpingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/impl/PumpingUtil.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/impl/PumpingUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/impl/SectionImpl.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/impl/SectionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/queue/DispatchedQueue.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/queue/DispatchedQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/queue/QueueBase.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/queue/QueueBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/services/EmptyQueueListener.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/services/EmptyQueueListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/services/FileProvider.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/services/FileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/services/PersistentCache.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/services/PersistentCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/downloader/ui/ProxySettingsDialog.java
+++ b/nbi/engine/src/org/netbeans/installer/downloader/ui/ProxySettingsDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/Registry.java
+++ b/nbi/engine/src/org/netbeans/installer/product/Registry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/RegistryNode.java
+++ b/nbi/engine/src/org/netbeans/installer/product/RegistryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/RegistryType.java
+++ b/nbi/engine/src/org/netbeans/installer/product/RegistryType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/components/Group.java
+++ b/nbi/engine/src/org/netbeans/installer/product/components/Group.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/components/Product.java
+++ b/nbi/engine/src/org/netbeans/installer/product/components/Product.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/components/ProductConfigurationLogic.java
+++ b/nbi/engine/src/org/netbeans/installer/product/components/ProductConfigurationLogic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/components/StatusInterface.java
+++ b/nbi/engine/src/org/netbeans/installer/product/components/StatusInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/dependencies/Conflict.java
+++ b/nbi/engine/src/org/netbeans/installer/product/dependencies/Conflict.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/dependencies/InstallAfter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/dependencies/InstallAfter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/dependencies/Requirement.java
+++ b/nbi/engine/src/org/netbeans/installer/product/dependencies/Requirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/filters/AndFilter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/filters/AndFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/filters/GroupFilter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/filters/GroupFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/filters/OrFilter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/filters/OrFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/filters/ProductFilter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/filters/ProductFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/filters/RegistryFilter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/filters/RegistryFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/filters/SubTreeFilter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/filters/SubTreeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/product/filters/TrueFilter.java
+++ b/nbi/engine/src/org/netbeans/installer/product/filters/TrueFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/BrowserUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/BrowserUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/DateUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/DateUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/EngineUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/EngineUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/ErrorManager.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/ErrorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/FileProxy.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/FileProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/FileUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/LogManager.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/LogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/NetworkUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/NetworkUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/ResourceUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/ResourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/SecurityUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/SecurityUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/StreamUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/StreamUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/StringUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/SystemUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/SystemUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/UiUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/UiUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/UninstallUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/UninstallUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/XMLUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/XMLUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/applications/JavaUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/applications/JavaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/CLIArgumentsList.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/CLIArgumentsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/CLIHandler.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/CLIHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOptionOneArgument.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOptionOneArgument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOptionTwoArguments.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOptionTwoArguments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOptionZeroArguments.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/CLIOptionZeroArguments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/BundlePropertiesOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/BundlePropertiesOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/CreateBundleOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/CreateBundleOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/ForceInstallOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/ForceInstallOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/ForceUninstallOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/ForceUninstallOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/IgnoreLockOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/IgnoreLockOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/LocaleOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/LocaleOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/LookAndFeelOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/LookAndFeelOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/NoSpaceCheckOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/NoSpaceCheckOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/PlatformOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/PlatformOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/PropertiesOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/PropertiesOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/RecordOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/RecordOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/RegistryOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/RegistryOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/SilentOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/SilentOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/StateOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/StateOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/SuggestInstallOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/SuggestInstallOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/SuggestUninstallOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/SuggestUninstallOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/TargetOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/TargetOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/cli/options/UserdirOption.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/cli/options/UserdirOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/CLIOptionException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/CLIOptionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/DownloadException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/DownloadException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/FinalizationException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/FinalizationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/HTTPException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/HTTPException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/IgnoreAttributeException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/IgnoreAttributeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/InitializationException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/InitializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/InstallationException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/InstallationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/NativeException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/NativeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/NotImplementedException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/NotImplementedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/ParseException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnexpectedExceptionError.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnexpectedExceptionError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/UninstallationException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/UninstallationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnrecognizedObjectException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnrecognizedObjectException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnresolvedDependencyException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnresolvedDependencyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnsupportedActionException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/UnsupportedActionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/exceptions/XMLException.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/exceptions/XMLException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/ApplicationDescriptor.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/ApplicationDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Context.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Dependency.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Dependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/DependencyType.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/DependencyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/DetailedStatus.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/DetailedStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/EngineResources.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/EngineResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/EnvironmentScope.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/EnvironmentScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/ErrorLevel.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/ErrorLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/ExecutionMode.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/ExecutionMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/ExecutionResults.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/ExecutionResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/ExtendedUri.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/ExtendedUri.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Feature.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Feature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/FileEntry.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/FileEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/FilesList.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/FilesList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/FinishHandler.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/FinishHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/JavaCompatibleProperties.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/JavaCompatibleProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/MutualHashMap.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/MutualHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/MutualMap.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/MutualMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/NbiClassLoader.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/NbiClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/NbiProperties.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/NbiProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/NbiThread.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/NbiThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Pair.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Platform.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Platform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/PlatformConstants.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/PlatformConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/PropertyContainer.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/PropertyContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/RemovalMode.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/RemovalMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Shortcut.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Shortcut.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/ShortcutLocationType.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/ShortcutLocationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Status.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Text.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Text.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/UiMode.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/UiMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Version.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Version.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiButton.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiCheckBox.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiCheckBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiComboBox.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiDialog.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiDirectoryChooser.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiDirectoryChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiFileChooser.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiFileChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiFrame.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiLabel.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiList.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiPasswordField.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiPasswordField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiProgressBar.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiProgressBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiRadioButton.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiRadioButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiScrollPane.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiScrollPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiSeparator.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiSeparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTabbedPane.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTabbedPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextDialog.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextField.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextPane.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextsDialog.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTextsDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTree.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTable.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTableColumnCellRenderer.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTableColumnCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTableColumnRenderer.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTableColumnRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTableModel.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/swing/NbiTreeTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/progress/CompositeProgress.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/progress/CompositeProgress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/progress/Progress.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/progress/Progress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/progress/ProgressListener.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/progress/ProgressListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/LinuxNativeUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/LinuxNativeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/MacOsNativeUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/MacOsNativeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/NativeUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/NativeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/NativeUtilsFactory.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/NativeUtilsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/SolarisNativeUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/SolarisNativeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/UnixNativeUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/UnixNativeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/WindowsNativeUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/WindowsNativeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/JavaOnExitCleanerHandler.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/JavaOnExitCleanerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/OnExitCleanerHandler.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/OnExitCleanerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/ProcessOnExitCleanerHandler.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/ProcessOnExitCleanerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/SystemPropertyOnExitCleanerHandler.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/cleaner/SystemPropertyOnExitCleanerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/Launcher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/Launcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/LauncherFactory.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/LauncherFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/LauncherProperties.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/LauncherProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/LauncherResource.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/LauncherResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/CommandLauncher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/CommandLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/CommonLauncher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/CommonLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/ExeLauncher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/ExeLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/JarLauncher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/JarLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/ShLauncher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/ShLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/BundlePropertyResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/BundlePropertyResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/EnvironmentVariableResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/EnvironmentVariableResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/FieldResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/FieldResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/MethodResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/MethodResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/NameResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/NameResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/ResourceResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/ResourceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/StringResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/StringResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/StringResolverUtil.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/StringResolverUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/resolver/SystemPropertyResolver.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/resolver/SystemPropertyResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/FileShortcut.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/FileShortcut.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/InternetShortcut.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/InternetShortcut.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/LocationType.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/LocationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/Shortcut.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/shortcut/Shortcut.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/BourneShell.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/BourneShell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/CShell.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/CShell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/KornShell.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/KornShell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/Shell.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/Shell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/TCShell.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/unix/shell/TCShell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/windows/FileExtension.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/windows/FileExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/windows/PerceivedType.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/windows/PerceivedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/windows/SystemApplication.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/windows/SystemApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/system/windows/WindowsRegistry.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/windows/WindowsRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/xml/DomExternalizable.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/xml/DomExternalizable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/xml/DomUtil.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/xml/DomUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/xml/visitors/DomVisitor.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/xml/visitors/DomVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/utils/xml/visitors/RecursiveDomVisitor.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/xml/visitors/RecursiveDomVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/Wizard.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/Wizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/WizardAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/WizardAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/WizardComponent.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/WizardComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/WizardPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/WizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/WizardSequence.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/WizardSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CacheEngineAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CacheEngineAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CreateBundleAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CreateBundleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CreateMacOSAppLauncherAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CreateMacOSAppLauncherAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CreateNativeLauncherAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/CreateNativeLauncherAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/DownloadConfigurationLogicAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/DownloadConfigurationLogicAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/DownloadInstallationDataAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/DownloadInstallationDataAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/FinalizeRegistryAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/FinalizeRegistryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/InitializeRegistryAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/InitializeRegistryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/InstallAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/InstallAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/SearchForJavaAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/SearchForJavaAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/SetInstallationLocationAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/SetInstallationLocationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/UninstallAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/UninstallAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/ApplicationLocationPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/ApplicationLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/ComponentsSelectionPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/ComponentsSelectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/DestinationPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/DestinationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/ErrorMessagePanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/ErrorMessagePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/JdkLocationPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/JdkLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/LicensesPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/LicensesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PostCreateBundleSummaryPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PostCreateBundleSummaryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PostInstallSummaryPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PostInstallSummaryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PreCreateBundleSummaryPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PreCreateBundleSummaryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PreInstallSummaryPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PreInstallSummaryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/TextPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/TextPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/sequences/CreateBundleSequence.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/sequences/CreateBundleSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/sequences/MainSequence.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/sequences/MainSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/sequences/ProductWizardSequence.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/sequences/ProductWizardSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/containers/SilentContainer.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/containers/SilentContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/containers/SwingContainer.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/containers/SwingContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/containers/SwingFrameContainer.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/containers/SwingFrameContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/containers/WizardContainer.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/containers/WizardContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/ui/SwingUi.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/ui/SwingUi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/ui/WizardUi.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/ui/WizardUi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/utils/InstallationDetailsDialog.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/utils/InstallationDetailsDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/src/org/netbeans/installer/wizard/utils/InstallationLogDialog.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/utils/InstallationLogDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/MyTestCase.java
+++ b/nbi/engine/tests/org/MyTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/RunAllSuite.java
+++ b/nbi/engine/tests/org/RunAllSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/connector/ConnectionConfiguratorTest.java
+++ b/nbi/engine/tests/org/connector/ConnectionConfiguratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/connector/ConnectorTest.java
+++ b/nbi/engine/tests/org/connector/ConnectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/connector/ProxySelectorTest.java
+++ b/nbi/engine/tests/org/connector/ProxySelectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/connector/ProxyTest.java
+++ b/nbi/engine/tests/org/connector/ProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/dispatcher/DispatcherTest.java
+++ b/nbi/engine/tests/org/dispatcher/DispatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/dispatcher/DummyProcess.java
+++ b/nbi/engine/tests/org/dispatcher/DummyProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/downloader/ActionsTracer.java
+++ b/nbi/engine/tests/org/downloader/ActionsTracer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/downloader/QueueAndListenerWithServerTest.java
+++ b/nbi/engine/tests/org/downloader/QueueAndListenerWithServerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/downloader/QueueAndListenerWithoutServerTest.java
+++ b/nbi/engine/tests/org/downloader/QueueAndListenerWithoutServerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/downloader/RedirectTest.java
+++ b/nbi/engine/tests/org/downloader/RedirectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/downloader/VerboseTracer.java
+++ b/nbi/engine/tests/org/downloader/VerboseTracer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/downloader/WorkabilityTest.java
+++ b/nbi/engine/tests/org/downloader/WorkabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/registry/TestCircles.java
+++ b/nbi/engine/tests/org/registry/TestCircles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/server/AbstractServer.java
+++ b/nbi/engine/tests/org/server/AbstractServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/server/TestDataGenerator.java
+++ b/nbi/engine/tests/org/server/TestDataGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/server/WithServerTestCase.java
+++ b/nbi/engine/tests/org/server/WithServerTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/server/impl/DefaultJettyServer.java
+++ b/nbi/engine/tests/org/server/impl/DefaultJettyServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/server/impl/RedirectServlet.java
+++ b/nbi/engine/tests/org/server/impl/RedirectServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/util/DomVisitorTest.java
+++ b/nbi/engine/tests/org/util/DomVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/engine/tests/org/util/system/WindowsRegistryTest.java
+++ b/nbi/engine/tests/org/util/system/WindowsRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/AddPackage.java
+++ b/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/AddPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/CreateBundle.java
+++ b/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/CreateBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/ExportRegistry.java
+++ b/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/ExportRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/GenerateComponentsJs.java
+++ b/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/GenerateComponentsJs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/UpdateEngine.java
+++ b/nbi/infra/build/.ant-lib/src-registries-management/org/netbeans/installer/infra/build/ant/registries/UpdateEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Absolutize.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Absolutize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ForEach.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ForEach.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/GroupDescriptor.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/GroupDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/If.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/If.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/LoadLocales.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/LoadLocales.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Md5.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Md5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/NativeUntar.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/NativeUntar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/NativeUnzip.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/NativeUnzip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Package.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Package.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ProductDescriptor.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ProductDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ReleaseEngine.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ReleaseEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ReleasePackage.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/ReleasePackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/SetProperty.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/SetProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/SizeOf.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/SizeOf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Sum.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/Sum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/UriToPath.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/UriToPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/WriteFileList.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/WriteFileList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/utils/FileEntry.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/utils/FileEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/utils/Utils.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/utils/VerifyFile.java
+++ b/nbi/infra/build/.ant-lib/src/org/netbeans/installer/infra/build/ant/utils/VerifyFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/ManagerException.java
+++ b/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/ManagerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/RegistriesManager.java
+++ b/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/RegistriesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/impl/DummyFinishHandler.java
+++ b/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/impl/DummyFinishHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/impl/RegistriesManagerImpl.java
+++ b/nbi/infra/lib/registries-management/src/org/netbeans/installer/infra/lib/registries/impl/RegistriesManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/DummyFinishHandler.java
+++ b/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/DummyFinishHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/IconCorrectingFilter.java
+++ b/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/IconCorrectingFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/Manager.java
+++ b/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/Manager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/ManagerBean.java
+++ b/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/ManagerBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/ManagerException.java
+++ b/nbi/infra/server/modules/ejb/src/java/org/netbeans/installer/infra/server/ejb/ManagerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/AddPackage.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/AddPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/AddRegistry.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/AddRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/DeleteBundles.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/DeleteBundles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/ExportRegistry.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/ExportRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/GenerateBundles.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/GenerateBundles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/ManageRegistries.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/ManageRegistries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RemoveGroup.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RemoveGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RemoveProduct.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RemoveProduct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RemoveRegistry.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RemoveRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RunCommand.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/RunCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/UpdateEngine.java
+++ b/nbi/infra/server/modules/war-admin/src/java/org/netbeans/installer/infra/server/admin/servlets/UpdateEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/web/css/main.css
+++ b/nbi/infra/server/modules/war-admin/web/css/main.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-admin/web/js/main.js
+++ b/nbi/infra/server/modules/war-admin/web/js/main.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Components.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Components.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Components2.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Components2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/CreateBundle.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/CreateBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Feed.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Feed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/GetEngine.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/GetEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/GetFile.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/GetFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/GetRegistry.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/GetRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Install.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Install.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Registries.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Registries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Utils.java
+++ b/nbi/infra/server/modules/war-client/src/java/org/netbeans/installer/infra/server/client/servlets/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/server/modules/war-client/web/js/main.js
+++ b/nbi/infra/server/modules/war-client/web/js/main.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/BasicStyleCheckerEngine.java
+++ b/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/BasicStyleCheckerEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/ant/BasicStyleCheckerTask.java
+++ b/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/ant/BasicStyleCheckerTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/checkers/Checker.java
+++ b/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/checkers/Checker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/checkers/LineLengthChecker.java
+++ b/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/checkers/LineLengthChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/checkers/UnescapedStringChecker.java
+++ b/nbi/infra/utils/basic-style-checker/src/org/netbeans/installer/infra/utils/style/checkers/UnescapedStringChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/CommentCorrecter.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/CommentCorrecter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/ant/CommentCorrecterTask.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/ant/CommentCorrecterTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/BlockFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/BlockFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/FileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/FileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/HtmlFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/HtmlFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/JspFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/JspFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/LineFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/LineFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/MakefileFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/MakefileFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/PropertiesFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/PropertiesFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/ShellFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/ShellFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/SourcesFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/SourcesFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/XmlFileHandler.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/handlers/XmlFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/utils/Utils.java
+++ b/nbi/infra/utils/comment-correcter/src/org/netbeans/installer/infra/utils/comment/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/file-renamer/src/org/netbeans/installer/infra/utils/filerenamer/Main.java
+++ b/nbi/infra/utils/file-renamer/src/org/netbeans/installer/infra/utils/filerenamer/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/newline-correcter/src/org/netbeans/installer/infra/utils/newlinecorrecter/Main.java
+++ b/nbi/infra/utils/newline-correcter/src/org/netbeans/installer/infra/utils/newlinecorrecter/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/platform-tester/src/org/netbeans/installer/infra/utils/platformtester/Main.java
+++ b/nbi/infra/utils/platform-tester/src/org/netbeans/installer/infra/utils/platformtester/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbi/infra/utils/port-occupation/src/org/netbeans/installer/infra/utils/Main.java
+++ b/nbi/infra/utils/port-occupation/src/org/netbeans/installer/infra/utils/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/META-INF/upgrade/NbModuleSuite.hint
+++ b/nbjunit/src/META-INF/upgrade/NbModuleSuite.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/AssertionFailedErrorException.java
+++ b/nbjunit/src/org/netbeans/junit/AssertionFailedErrorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/AssertionFileFailedError.java
+++ b/nbjunit/src/org/netbeans/junit/AssertionFileFailedError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/AssertionKnownBugError.java
+++ b/nbjunit/src/org/netbeans/junit/AssertionKnownBugError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/ControlFlow.java
+++ b/nbjunit/src/org/netbeans/junit/ControlFlow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/Filter.java
+++ b/nbjunit/src/org/netbeans/junit/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/Log.java
+++ b/nbjunit/src/org/netbeans/junit/Log.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/Manager.java
+++ b/nbjunit/src/org/netbeans/junit/Manager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/MemoryFilter.java
+++ b/nbjunit/src/org/netbeans/junit/MemoryFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/MemoryMeasurement.java
+++ b/nbjunit/src/org/netbeans/junit/MemoryMeasurement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/MemoryMeasurementFailedException.java
+++ b/nbjunit/src/org/netbeans/junit/MemoryMeasurementFailedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/MethodOrder.java
+++ b/nbjunit/src/org/netbeans/junit/MethodOrder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/MockServices.java
+++ b/nbjunit/src/org/netbeans/junit/MockServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/MultiTestCase.java
+++ b/nbjunit/src/org/netbeans/junit/MultiTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/MultiTestSuite.java
+++ b/nbjunit/src/org/netbeans/junit/MultiTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
+++ b/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbPerformanceTest.java
+++ b/nbjunit/src/org/netbeans/junit/NbPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbPerformanceTestCase.java
+++ b/nbjunit/src/org/netbeans/junit/NbPerformanceTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbTest.java
+++ b/nbjunit/src/org/netbeans/junit/NbTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbTestCase.java
+++ b/nbjunit/src/org/netbeans/junit/NbTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbTestDecorator.java
+++ b/nbjunit/src/org/netbeans/junit/NbTestDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbTestSetup.java
+++ b/nbjunit/src/org/netbeans/junit/NbTestSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/NbTestSuite.java
+++ b/nbjunit/src/org/netbeans/junit/NbTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/ParametricTestCase.java
+++ b/nbjunit/src/org/netbeans/junit/ParametricTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/ParametricTestSuite.java
+++ b/nbjunit/src/org/netbeans/junit/ParametricTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/RandomlyFails.java
+++ b/nbjunit/src/org/netbeans/junit/RandomlyFails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/diff/Diff.java
+++ b/nbjunit/src/org/netbeans/junit/diff/Diff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/diff/DiffException.java
+++ b/nbjunit/src/org/netbeans/junit/diff/DiffException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/diff/LineDiff.java
+++ b/nbjunit/src/org/netbeans/junit/diff/LineDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/diff/NativeDiff.java
+++ b/nbjunit/src/org/netbeans/junit/diff/NativeDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/diff/SimpleDiff.java
+++ b/nbjunit/src/org/netbeans/junit/diff/SimpleDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/internal/MemoryPreferencesFactory.java
+++ b/nbjunit/src/org/netbeans/junit/internal/MemoryPreferencesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/internal/NbModuleLogHandler.java
+++ b/nbjunit/src/org/netbeans/junit/internal/NbModuleLogHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/src/org/netbeans/junit/internal/RandomlyFailsProcessor.java
+++ b/nbjunit/src/org/netbeans/junit/internal/RandomlyFailsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/AssertInstancesTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/AssertInstancesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/DummyService.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/DummyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/DummyServiceImpl.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/DummyServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/FlowControlTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/FlowControlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/FlowCountingTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/FlowCountingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/LinearSpeedTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/LinearSpeedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/LogAndTimeOutTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/LogAndTimeOutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/LogTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/LogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/LoggingExceptionTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/LoggingExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/LoggingTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/LoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/MockServicesTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/MockServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuite2Test.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuite2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteAddModuleTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteAddModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteClusterPathFinalTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteClusterPathFinalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteContextClassLoaderTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteContextClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteDebuggerTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteDebuggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteExceptionTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteHideExtraTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteHideExtraTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteOrderTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteStampTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteStampTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteTurnClassPathModulesTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteTurnClassPathModulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbTestCasePreferencesTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbTestCasePreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/NbTestCaseTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/NbTestCaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/OrderAZTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/OrderAZTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/OrderHid.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/OrderHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/OrderTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/OrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/OrderZATest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/OrderZATest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/RandomlyFailsTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/RandomlyFailsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/RunInEventQueueTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/RunInEventQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/StdOutLogTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/StdOutLogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/StdOutNoLogTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/StdOutNoLogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/TimeOutHasToPrintLogTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/TimeOutHasToPrintLogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/TimeOutTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/TimeOutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/diff/LineDiffTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/diff/LineDiffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/junit/internal/NbModuleLogHandlerTest.java
+++ b/nbjunit/test/unit/src/org/netbeans/junit/internal/NbModuleLogHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/org/netbeans/testjunit/AskForOrgOpenideUtilEnumClass.java
+++ b/nbjunit/test/unit/src/org/netbeans/testjunit/AskForOrgOpenideUtilEnumClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/BrandingAssignedTest.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/BrandingAssignedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSeekWinSys.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSeekWinSys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteClusterPath.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteClusterPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteClusters.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteClusters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteDebugger.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteDebugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteException.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteIns.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteIns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteMeta.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteMeta.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteMockServiceTest.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteMockServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteS.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteT.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteTUserDir.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteTUserDir.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteTimestamps.java
+++ b/nbjunit/test/unit/src/test/pkg/not/in/junit/NbModuleSuiteTimestamps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/EmptyBundleFile.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/EmptyBundleFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/JarBundleFile.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/JarBundleFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/ModuleEntry.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/ModuleEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/Netbinox.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/Netbinox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/NetbinoxFactory.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/NetbinoxFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/NetbinoxHooks.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/NetbinoxHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/NetbinoxLoader.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/NetbinoxLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/NetigsoBaseLoader.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/NetigsoBaseLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/NetigsoBundleFile.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/NetigsoBundleFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/src/org/netbeans/modules/netbinox/RootEntry.java
+++ b/netbinox/src/org/netbeans/modules/netbinox/RootEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/activate/org/activate/Main.java
+++ b/netbinox/test/unit/data/jars/activate/org/activate/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/agent/org/agent/HelloWorld.java
+++ b/netbinox/test/unit/data/jars/agent/org/agent/HelloWorld.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingElse.java
+++ b/netbinox/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingElse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingReflective.java
+++ b/netbinox/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingReflective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/hook/org/hook/Main.java
+++ b/netbinox/test/unit/data/jars/hook/org/hook/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/loading2/org/load2/Load.java
+++ b/netbinox/test/unit/data/jars/loading2/org/load2/Load.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/loading3/org/load3/Load.java
+++ b/netbinox/test/unit/data/jars/loading3/org/load3/Load.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/simple-module/org/foo/Something.java
+++ b/netbinox/test/unit/data/jars/simple-module/org/foo/Something.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/data/jars/uses-swing/org/barwing/Main.java
+++ b/netbinox/test/unit/data/jars/uses-swing/org/barwing/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/MockEvents.java
+++ b/netbinox/test/unit/src/org/netbeans/MockEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/MockModuleInstaller.java
+++ b/netbinox/test/unit/src/org/netbeans/MockModuleInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/SetupHid.java
+++ b/netbinox/test/unit/src/org/netbeans/SetupHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/AgentTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/AgentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleGetEntryTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleGetEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleResourceTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleURLConnectionTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleURLConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingAndExternalPathsTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingAndExternalPathsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingAndExternalURLTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingAndExternalURLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingPreventsFileTouchesTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingPreventsFileTouchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/ContextClassLoaderTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/ContextClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/CountingSecurityManager.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/CountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/EnabledAutoloadTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/EnabledAutoloadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/ExternalDirectoryTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/ExternalDirectoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/ExternalJARTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/ExternalJARTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/HookConfiguratorTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/HookConfiguratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/HookRaceTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/HookRaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/IntegrationTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/IntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/LoadedBytesTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/LoadedBytesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/LogReaderServiceTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/LogReaderServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxBuddyClassLoaderTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxBuddyClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxDuplicatedBuddyForNameTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxDuplicatedBuddyForNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxDuplicatedClassForNameTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxDuplicatedClassForNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxFactoryTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxLibraryTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxLibraryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxReloadTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxReloadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxUseSystemPropertiesTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxUseSystemPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoActivationTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoActivationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoActivationWithAllDirsTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoActivationWithAllDirsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoDashnamesTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoDashnamesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoHasSAXParserTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoHasSAXParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoHid.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoLayerTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoLayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoLoggingTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiActivationVisibleTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiActivationVisibleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiCanDependTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiCanDependTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiCanRequestTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiCanRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiIsNotFriendTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoOSGiIsNotFriendTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoUsesSwingTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoUsesSwingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/SingleThreadLoadsDeadlockTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/SingleThreadLoadsDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/SingleThreadLoadsDisabledOKTest.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/SingleThreadLoadsDisabledOKTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/BalloonManager.java
+++ b/notifications/src/org/netbeans/modules/notifications/BalloonManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/FlashingIcon.java
+++ b/notifications/src/org/netbeans/modules/notifications/FlashingIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/NotificationDisplayerImpl.java
+++ b/notifications/src/org/netbeans/modules/notifications/NotificationDisplayerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/NotificationImpl.java
+++ b/notifications/src/org/netbeans/modules/notifications/NotificationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/NotificationSettings.java
+++ b/notifications/src/org/netbeans/modules/notifications/NotificationSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/StatusLineElement.java
+++ b/notifications/src/org/netbeans/modules/notifications/StatusLineElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/Utils.java
+++ b/notifications/src/org/netbeans/modules/notifications/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/center/FiltersMenuButton.java
+++ b/notifications/src/org/netbeans/modules/notifications/center/FiltersMenuButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/center/MenuToggleButton.java
+++ b/notifications/src/org/netbeans/modules/notifications/center/MenuToggleButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/center/NotificationCenterManager.java
+++ b/notifications/src/org/netbeans/modules/notifications/center/NotificationCenterManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/center/NotificationCenterTopComponent.java
+++ b/notifications/src/org/netbeans/modules/notifications/center/NotificationCenterTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/center/NotificationTable.java
+++ b/notifications/src/org/netbeans/modules/notifications/center/NotificationTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/center/NotificationTableModel.java
+++ b/notifications/src/org/netbeans/modules/notifications/center/NotificationTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/center/SearchField.java
+++ b/notifications/src/org/netbeans/modules/notifications/center/SearchField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/checklist/AbstractCheckListModel.java
+++ b/notifications/src/org/netbeans/modules/notifications/checklist/AbstractCheckListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/checklist/CheckList.java
+++ b/notifications/src/org/netbeans/modules/notifications/checklist/CheckList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/checklist/CheckListModel.java
+++ b/notifications/src/org/netbeans/modules/notifications/checklist/CheckListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/checklist/DefaultCheckListCellRenderer.java
+++ b/notifications/src/org/netbeans/modules/notifications/checklist/DefaultCheckListCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/checklist/DefaultCheckListModel.java
+++ b/notifications/src/org/netbeans/modules/notifications/checklist/DefaultCheckListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/filter/CategoryFilter.java
+++ b/notifications/src/org/netbeans/modules/notifications/filter/CategoryFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/filter/CateogoriesPanel.java
+++ b/notifications/src/org/netbeans/modules/notifications/filter/CateogoriesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/filter/FilterEditor.java
+++ b/notifications/src/org/netbeans/modules/notifications/filter/FilterEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/filter/FilterRepository.java
+++ b/notifications/src/org/netbeans/modules/notifications/filter/FilterRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/filter/NotificationFilter.java
+++ b/notifications/src/org/netbeans/modules/notifications/filter/NotificationFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/filter/TitleFilter.java
+++ b/notifications/src/org/netbeans/modules/notifications/filter/TitleFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/src/org/netbeans/modules/notifications/filter/Util.java
+++ b/notifications/src/org/netbeans/modules/notifications/filter/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/notifications/test/unit/src/org/netbeans/modules/notifications/center/NotificationCenterManagerTest.java
+++ b/notifications/test/unit/src/org/netbeans/modules/notifications/center/NotificationCenterManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/BridgeImpl.java
+++ b/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/BridgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/ForkedJavaOverride.java
+++ b/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/ForkedJavaOverride.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/InputOverride.java
+++ b/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/InputOverride.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/IntrospectionHelperImpl.java
+++ b/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/IntrospectionHelperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbAntlib.java
+++ b/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbAntlib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbBuildLogger.java
+++ b/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbBuildLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbInputHandler.java
+++ b/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbInputHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntCustomizer.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntModule.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntPanelController.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntSettings.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/AntSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/AntProjectCookie.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/AntProjectCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/AntTargetExecutor.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/AntTargetExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/ElementCookie.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/ElementCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectionCookie.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectionCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/ActionUtils.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/ActionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/AntScriptUtils.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/AntScriptUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/TargetLister.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/TargetLister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/AntBridge.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/AntBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/AuxClassLoader.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/AuxClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/BridgeInterface.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/BridgeInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/DummyBridgeImpl.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/DummyBridgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/IntrospectionHelperProxy.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/IntrospectionHelperProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/loader/AntActionInstance.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/loader/AntActionInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/loader/AntProjectDataEditor.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/loader/AntProjectDataEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/loader/AntProjectDataObject.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/loader/AntProjectDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntNavigatorPanel.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntNavigatorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntProjectChildren.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntProjectChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntProjectNode.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntProjectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntProperty.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntTargetNode.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/nodes/AntTargetNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/AdvancedActionPanel.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/AdvancedActionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/Hyperlink.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/Hyperlink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/LastTargetExecuted.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/LastTargetExecuted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/LoggerTrampoline.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/LoggerTrampoline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/RunFileActionProvider.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/RunFileActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/RunTargetsAction.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/RunTargetsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/StandardLogger.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/StandardLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/TargetExecutor.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/TargetExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/VerticalGridLayout.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/VerticalGridLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntEvent.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntLogger.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntOutputStream.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntSession.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AutomaticExtraClasspath.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AutomaticExtraClasspath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AutomaticExtraClasspathProvider.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AutomaticExtraClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/TaskStructure.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/TaskStructure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/CreateShortcutAction.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/CreateShortcutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/CustomizeScriptPanel.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/CustomizeScriptPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/IntroPanel.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/IntroPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/RemoveShortcutAction.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/RemoveShortcutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/SelectFolderPanel.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/SelectFolderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/SelectKeyboardShortcutPanel.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/SelectKeyboardShortcutPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutIterator.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizard.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/src/org/apache/tools/ant/module/xml/AntProjectSupport.java
+++ b/o.apache.tools.ant.module/src/org/apache/tools/ant/module/xml/AntProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/IntrospectedInfoTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/IntrospectedInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/support/ActionUtilsTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/support/ActionUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/support/AntScriptUtilsTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/support/AntScriptUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/support/TargetListerTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/api/support/TargetListerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/nodes/AntProjectChildrenTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/nodes/AntProjectChildrenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/run/StandardLoggerTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/run/StandardLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/spi/AntLoggerTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/spi/AntLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/spi/AutomaticExtraClasspathTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/spi/AutomaticExtraClasspathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/wizards/shortcut/SelectFolderPanelTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/wizards/shortcut/SelectFolderPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizardTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizardTestBase.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizardTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/xml/AntProjectSupportTest.java
+++ b/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/xml/AntProjectSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/argnames.h
+++ b/o.n.bootstrap/launcher/windows/argnames.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/jvmlauncher.cpp
+++ b/o.n.bootstrap/launcher/windows/jvmlauncher.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/jvmlauncher.h
+++ b/o.n.bootstrap/launcher/windows/jvmlauncher.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/nbexec.cpp
+++ b/o.n.bootstrap/launcher/windows/nbexec.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/nbexec.rc
+++ b/o.n.bootstrap/launcher/windows/nbexec.rc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/nbexec_exe.rc
+++ b/o.n.bootstrap/launcher/windows/nbexec_exe.rc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/nbexecexe.cpp
+++ b/o.n.bootstrap/launcher/windows/nbexecexe.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/nbexecloader.h
+++ b/o.n.bootstrap/launcher/windows/nbexecloader.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/platformlauncher.cpp
+++ b/o.n.bootstrap/launcher/windows/platformlauncher.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/platformlauncher.h
+++ b/o.n.bootstrap/launcher/windows/platformlauncher.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/utilsfuncs.cpp
+++ b/o.n.bootstrap/launcher/windows/utilsfuncs.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/utilsfuncs.h
+++ b/o.n.bootstrap/launcher/windows/utilsfuncs.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/version.h
+++ b/o.n.bootstrap/launcher/windows/version.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/launcher/windows/version.rc
+++ b/o.n.bootstrap/launcher/windows/version.rc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/Archive.java
+++ b/o.n.bootstrap/src/org/netbeans/Archive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ArchiveResources.java
+++ b/o.n.bootstrap/src/org/netbeans/ArchiveResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/CLIHandler.java
+++ b/o.n.bootstrap/src/org/netbeans/CLIHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ChangeFirer.java
+++ b/o.n.bootstrap/src/org/netbeans/ChangeFirer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/Clusters.java
+++ b/o.n.bootstrap/src/org/netbeans/Clusters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/DuplicateException.java
+++ b/o.n.bootstrap/src/org/netbeans/DuplicateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/Events.java
+++ b/o.n.bootstrap/src/org/netbeans/Events.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ExitSecurityException.java
+++ b/o.n.bootstrap/src/org/netbeans/ExitSecurityException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/FixedModule.java
+++ b/o.n.bootstrap/src/org/netbeans/FixedModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/InvalidException.java
+++ b/o.n.bootstrap/src/org/netbeans/InvalidException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
+++ b/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/JaveleonModule.java
+++ b/o.n.bootstrap/src/org/netbeans/JaveleonModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/LocaleVariants.java
+++ b/o.n.bootstrap/src/org/netbeans/LocaleVariants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/Main.java
+++ b/o.n.bootstrap/src/org/netbeans/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/MainImpl.java
+++ b/o.n.bootstrap/src/org/netbeans/MainImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/Module.java
+++ b/o.n.bootstrap/src/org/netbeans/Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ModuleData.java
+++ b/o.n.bootstrap/src/org/netbeans/ModuleData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ModuleFactory.java
+++ b/o.n.bootstrap/src/org/netbeans/ModuleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ModuleInstaller.java
+++ b/o.n.bootstrap/src/org/netbeans/ModuleInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/NbClipboard.java
+++ b/o.n.bootstrap/src/org/netbeans/NbClipboard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/NbExecJavaStartTry.java
+++ b/o.n.bootstrap/src/org/netbeans/NbExecJavaStartTry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/NbInstrumentation.java
+++ b/o.n.bootstrap/src/org/netbeans/NbInstrumentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/NetigsoFramework.java
+++ b/o.n.bootstrap/src/org/netbeans/NetigsoFramework.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/NetigsoHandle.java
+++ b/o.n.bootstrap/src/org/netbeans/NetigsoHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/NetigsoLoader.java
+++ b/o.n.bootstrap/src/org/netbeans/NetigsoLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/NetigsoModule.java
+++ b/o.n.bootstrap/src/org/netbeans/NetigsoModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/PackageAttrsCache.java
+++ b/o.n.bootstrap/src/org/netbeans/PackageAttrsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/PatchByteCode.java
+++ b/o.n.bootstrap/src/org/netbeans/PatchByteCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
+++ b/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ProxyClassPackages.java
+++ b/o.n.bootstrap/src/org/netbeans/ProxyClassPackages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ProxyClassParents.java
+++ b/o.n.bootstrap/src/org/netbeans/ProxyClassParents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/ProxyURLStreamHandlerFactory.java
+++ b/o.n.bootstrap/src/org/netbeans/ProxyURLStreamHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/StandardModule.java
+++ b/o.n.bootstrap/src/org/netbeans/StandardModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/StandardModuleData.java
+++ b/o.n.bootstrap/src/org/netbeans/StandardModuleData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/TaskFuture.java
+++ b/o.n.bootstrap/src/org/netbeans/TaskFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/TopSecurityManager.java
+++ b/o.n.bootstrap/src/org/netbeans/TopSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/o.n.bootstrap/src/org/netbeans/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/agent/org/agent/HelloWorld.java
+++ b/o.n.bootstrap/test/unit/data/jars/agent/org/agent/HelloWorld.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/cyclic-1/org/foo/Something.java
+++ b/o.n.bootstrap/test/unit/data/jars/cyclic-1/org/foo/Something.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/cyclic-1/org/foo/SomethingElse.java
+++ b/o.n.bootstrap/test/unit/data/jars/cyclic-1/org/foo/SomethingElse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/cyclic-2/org/bar/Something.java
+++ b/o.n.bootstrap/test/unit/data/jars/cyclic-2/org/bar/Something.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/cyclic-2/org/bar/SomethingElse.java
+++ b/o.n.bootstrap/test/unit/data/jars/cyclic-2/org/bar/SomethingElse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/dep-on-dep-on-simple/org/baz/SomethingElseAgain.java
+++ b/o.n.bootstrap/test/unit/data/jars/dep-on-dep-on-simple/org/baz/SomethingElseAgain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/depends-on-cyclic-1/org/baz/Whatever.java
+++ b/o.n.bootstrap/test/unit/data/jars/depends-on-cyclic-1/org/baz/Whatever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/depends-on-library-src/org/dol/User.java
+++ b/o.n.bootstrap/test/unit/data/jars/depends-on-library-src/org/dol/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingElse.java
+++ b/o.n.bootstrap/test/unit/data/jars/depends-on-simple-module/org/bar/SomethingElse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/exposes-api/org/netbeans/api/foo/PublicClass.java
+++ b/o.n.bootstrap/test/unit/data/jars/exposes-api/org/netbeans/api/foo/PublicClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/exposes-api/org/netbeans/modules/foo/ImplClass.java
+++ b/o.n.bootstrap/test/unit/data/jars/exposes-api/org/netbeans/modules/foo/ImplClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/library-src/pkg/subpkg/Something.java
+++ b/o.n.bootstrap/test/unit/data/jars/library-src/pkg/subpkg/Something.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/look-for-myself/lookformyself/Loder.java
+++ b/o.n.bootstrap/test/unit/data/jars/look-for-myself/lookformyself/Loder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/patch/pkg/subpkg/B.java
+++ b/o.n.bootstrap/test/unit/data/jars/patch/pkg/subpkg/B.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/patchable/pkg/subpkg/A.java
+++ b/o.n.bootstrap/test/unit/data/jars/patchable/pkg/subpkg/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/patchable/pkg/subpkg/B.java
+++ b/o.n.bootstrap/test/unit/data/jars/patchable/pkg/subpkg/B.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/prov-foo/org/prov_foo/Clazz.java
+++ b/o.n.bootstrap/test/unit/data/jars/prov-foo/org/prov_foo/Clazz.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/simple-module/org/foo/Something.java
+++ b/o.n.bootstrap/test/unit/data/jars/simple-module/org/foo/Something.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/uses-api-transitively/usesapitrans/UsesDirectAPI.java
+++ b/o.n.bootstrap/test/unit/data/jars/uses-api-transitively/usesapitrans/UsesDirectAPI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/uses-api-transitively/usesapitrans/UsesIndirectAPI.java
+++ b/o.n.bootstrap/test/unit/data/jars/uses-api-transitively/usesapitrans/UsesIndirectAPI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/uses-api/usesapi/UsesImplClass.java
+++ b/o.n.bootstrap/test/unit/data/jars/uses-api/usesapi/UsesImplClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/data/jars/uses-api/usesapi/UsesPublicClass.java
+++ b/o.n.bootstrap/test/unit/data/jars/uses-api/usesapi/UsesPublicClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/fakepkg/FakeHandler.java
+++ b/o.n.bootstrap/test/unit/src/org/fakepkg/FakeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/fakepkg/FakeIfceHidden.java
+++ b/o.n.bootstrap/test/unit/src/org/fakepkg/FakeIfceHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/fakepkg/LoaderProbe.java
+++ b/o.n.bootstrap/test/unit/src/org/fakepkg/LoaderProbe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/fakepkg/LoaderProbe2.java
+++ b/o.n.bootstrap/test/unit/src/org/fakepkg/LoaderProbe2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/fakepkg/UserDirHandler.java
+++ b/o.n.bootstrap/test/unit/src/org/fakepkg/UserDirHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/AgentTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/AgentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ArchiveTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ArchiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLICanInfluenceMainClassTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLICanInfluenceMainClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerGrepTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerGrepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerMemoryUserDirTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerMemoryUserDirTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerNoServerTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerNoServerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerReadingOfInputTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerReadingOfInputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerRemembersSystemInOutErrTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerRemembersSystemInOutErrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerServerWaitsTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerServerWaitsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CLIHowHardIsToGuessKeyTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CLIHowHardIsToGuessKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/CountingSecurityManager.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/CountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/JarClassLoaderTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/JarClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/JarURLStreamHandlerTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/JarURLStreamHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/LoggedPCListener.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/LoggedPCListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/MetaInfServicesToken.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/MetaInfServicesToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/MockEvents.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/MockEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/MockModuleInstaller.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/MockModuleInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryAlienTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryAlienTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerPersistanceLocaleTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerPersistanceLocaleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerPersistanceTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerPersistanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ModuleMixedOnClasspathTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ModuleMixedOnClasspathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ModuleTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardDelayedTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardDelayedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardIsUsedByAlreadyInitializedComponentsTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardIsUsedByAlreadyInitializedComponentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardIsUsedBySwingComponentsTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardIsUsedBySwingComponentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardNativeTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardNativeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardTimeoutTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardTimeoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/NetigsoLoaderTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/NetigsoLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/PatchByteCodeTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/PatchByteCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassPackagesTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassPackagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/ProxyURLStreamHandlerFactoryTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/ProxyURLStreamHandlerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsClusterMovedTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsClusterMovedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsDifferentPopulateTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsDifferentPopulateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsExtraTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsExtraTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsIdeLessThanPlatformTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsIdeLessThanPlatformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsJDKChangeTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsJDKChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsNoFallbackTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsNoFallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsPopulateTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsPopulateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsRenameTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsRenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsTimeShiftTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsTimeShiftTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StampsWithDotDotTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StampsWithDotDotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/StandardModuleSpaceTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/StandardModuleSpaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/TaskFutureTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/TaskFutureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/TopSecurityManagerReplaceTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/TopSecurityManagerReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/TopSecurityManagerTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/TopSecurityManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/URLsAreEqualTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/URLsAreEqualTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/nbexec/MainCallback.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/nbexec/MainCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.bootstrap/test/unit/src/org/netbeans/nbexec/NbExecPassesCorrectlyQuotedArgsTest.java
+++ b/o.n.bootstrap/test/unit/src/org/netbeans/nbexec/NbExecPassesCorrectlyQuotedArgsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ArrayOfIntSupport.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ArrayOfIntSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/BoolEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/BoolEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/BooleanEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/BooleanEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ByteEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ByteEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/CharEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/CharEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/CharacterEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/CharacterEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ClassEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ClassEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ColorEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ColorEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/DateEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/DateEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/DimensionCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/DimensionCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/DimensionEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/DimensionEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/DoubleEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/DoubleEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ExPropertyEditorSupport.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ExPropertyEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/FileArrayEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/FileArrayEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/FileEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/FileEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/FloatEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/FloatEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/FontEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/FontEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/HtmlBrowser.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/HtmlBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/InsetsCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/InsetsCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/InsetsEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/InsetsEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/IntEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/IntEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/IntegerCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/IntegerCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/IntegerEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/IntegerEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ListImageEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ListImageEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/LongEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/LongEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ObjectEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ObjectEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/PointCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/PointCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/PointEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/PointEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/PropertiesCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/PropertiesCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/PropertiesEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/PropertiesEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/RectangleCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/RectangleCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/RectangleEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/RectangleEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/ShortEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/ShortEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/StringArrayCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/StringArrayCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/StringArrayCustomizable.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/StringArrayCustomizable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/StringArrayEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/StringArrayEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/StringCustomEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/StringCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/StringEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/StringEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/URLEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/URLEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/WrappersEditor.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/WrappersEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/editors/package-info.java
+++ b/o.n.core/src/org/netbeans/beaninfo/editors/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/beaninfo/package-info.java
+++ b/o.n.core/src/org/netbeans/beaninfo/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/CLIOptions2.java
+++ b/o.n.core/src/org/netbeans/core/CLIOptions2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/CoreBridgeImpl.java
+++ b/o.n.core/src/org/netbeans/core/CoreBridgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/ExitDialog.java
+++ b/o.n.core/src/org/netbeans/core/ExitDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/GuiRunLevel.java
+++ b/o.n.core/src/org/netbeans/core/GuiRunLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/HtmlBrowserComponent.java
+++ b/o.n.core/src/org/netbeans/core/HtmlBrowserComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/IDESettings.java
+++ b/o.n.core/src/org/netbeans/core/IDESettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/ModuleActions.java
+++ b/o.n.core/src/org/netbeans/core/ModuleActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbAuthenticator.java
+++ b/o.n.core/src/org/netbeans/core/NbAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbAuthenticatorPanel.java
+++ b/o.n.core/src/org/netbeans/core/NbAuthenticatorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbErrorManager.java
+++ b/o.n.core/src/org/netbeans/core/NbErrorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbKeymap.java
+++ b/o.n.core/src/org/netbeans/core/NbKeymap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbLifeExit.java
+++ b/o.n.core/src/org/netbeans/core/NbLifeExit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbLifecycleManager.java
+++ b/o.n.core/src/org/netbeans/core/NbLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbLoaderPool.java
+++ b/o.n.core/src/org/netbeans/core/NbLoaderPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbStatusDisplayer.java
+++ b/o.n.core/src/org/netbeans/core/NbStatusDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NbURLDisplayer.java
+++ b/o.n.core/src/org/netbeans/core/NbURLDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/NotifyExcPanel.java
+++ b/o.n.core/src/org/netbeans/core/NotifyExcPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/ProxySettings.java
+++ b/o.n.core/src/org/netbeans/core/ProxySettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/Services.java
+++ b/o.n.core/src/org/netbeans/core/Services.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/TimableEventQueue.java
+++ b/o.n.core/src/org/netbeans/core/TimableEventQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/UIExceptions.java
+++ b/o.n.core/src/org/netbeans/core/UIExceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/WindowSystem.java
+++ b/o.n.core/src/org/netbeans/core/WindowSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/AboutAction.java
+++ b/o.n.core/src/org/netbeans/core/actions/AboutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/HTMLViewAction.java
+++ b/o.n.core/src/org/netbeans/core/actions/HTMLViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/JumpNextAction.java
+++ b/o.n.core/src/org/netbeans/core/actions/JumpNextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/JumpPrevAction.java
+++ b/o.n.core/src/org/netbeans/core/actions/JumpPrevAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/LogAction.java
+++ b/o.n.core/src/org/netbeans/core/actions/LogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/LogViewerSupport.java
+++ b/o.n.core/src/org/netbeans/core/actions/LogViewerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/NextViewCallbackAction.java
+++ b/o.n.core/src/org/netbeans/core/actions/NextViewCallbackAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/PreviousViewCallbackAction.java
+++ b/o.n.core/src/org/netbeans/core/actions/PreviousViewCallbackAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/actions/SystemExit.java
+++ b/o.n.core/src/org/netbeans/core/actions/SystemExit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/impl/InitUI.java
+++ b/o.n.core/src/org/netbeans/core/impl/InitUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.java
+++ b/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/src/org/netbeans/core/ui/SwingBrowser.java
+++ b/o.n.core/src/org/netbeans/core/ui/SwingBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/perf/src/org/netbeans/core/MUCDataDescriptor.java
+++ b/o.n.core/test/perf/src/org/netbeans/core/MUCDataDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/perf/src/org/netbeans/core/MultiURLClassLoaderTest.java
+++ b/o.n.core/test/perf/src/org/netbeans/core/MultiURLClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/perf/src/org/netbeans/core/lookup/NbLookupBenchmark.java
+++ b/o.n.core/test/perf/src/org/netbeans/core/lookup/NbLookupBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/perf/src/org/netbeans/core/modules/ModuleInitTest.java
+++ b/o.n.core/test/perf/src/org/netbeans/core/modules/ModuleInitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/perf/src/org/netbeans/core/projects/XMLSettingsTest.java
+++ b/o.n.core/test/perf/src/org/netbeans/core/projects/XMLSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/data/SampleProject/src/sampleproject/FormFile.java
+++ b/o.n.core/test/qa-functional/data/SampleProject/src/sampleproject/FormFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/data/SampleProject/src/sampleproject/JavaFile.java
+++ b/o.n.core/test/qa-functional/data/SampleProject/src/sampleproject/JavaFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/data/SampleProject/src/sampleproject/Main.java
+++ b/o.n.core/test/qa-functional/data/SampleProject/src/sampleproject/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertiesTest.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyEditorsTest.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyEditorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_BooleanO.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_BooleanO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ByteO.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ByteO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Character.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Character.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Class.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Class.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Color.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Color.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Dimension.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Dimension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_DoubleO.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_DoubleO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ElementFormat.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ElementFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ExtensionList.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ExtensionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_File.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_File.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_FloatO.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_FloatO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Font.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Font.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_HTMLBrowser.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_HTMLBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Icon.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Icon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_IdentifierArray.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_IdentifierArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Insets.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Insets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Integer.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Integer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_LongO.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_LongO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_NbClassPath.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_NbClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_NbProcessDescriptor.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_NbProcessDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Point.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Point.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Properties.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Properties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Rectangle.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Rectangle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ShortO.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_ShortO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_String.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_String.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_StringArray.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_StringArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Type.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_Type.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_URL.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_URL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_boolean.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_boolean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_byte.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_byte.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_char.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_char.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_double.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_double.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_float.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_float.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_int.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_int.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_long.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_long.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_short.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/PropertyType_short.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/data/clear_Frame.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/data/clear_Frame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/data/clear_JFrame.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/data/clear_JFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/propertyeditors/utilities/CoreSupport.java
+++ b/o.n.core/test/qa-functional/src/gui/propertyeditors/utilities/CoreSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/windowsystem/MainMenu.java
+++ b/o.n.core/test/qa-functional/src/gui/windowsystem/MainMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/gui/windowsystem/MenuChecker.java
+++ b/o.n.core/test/qa-functional/src/gui/windowsystem/MenuChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/BytecodeTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/BytecodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/CannotFindAsmTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/CannotFindAsmTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ResourcesTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateClassLinkageTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateClassLinkageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateLayerConsistencyTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateLayerConsistencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateModulesTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateModulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateNbinstPlatformTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateNbinstPlatformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateNbinstTest.java
+++ b/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateNbinstTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/data/lookup/install-manifest-service/ims/Foo.java
+++ b/o.n.core/test/unit/data/lookup/install-manifest-service/ims/Foo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/data/lookup/services-jar-1/org/foo/Interface.java
+++ b/o.n.core/test/unit/data/lookup/services-jar-1/org/foo/Interface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/data/lookup/services-jar-1/org/foo/impl/Implementation1.java
+++ b/o.n.core/test/unit/data/lookup/services-jar-1/org/foo/impl/Implementation1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/data/lookup/services-jar-2/org/bar/Implementation2.java
+++ b/o.n.core/test/unit/data/lookup/services-jar-2/org/bar/Implementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/data/lookup/test1/test1/SomeAction.java
+++ b/o.n.core/test/unit/data/lookup/test1/test1/SomeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/data/lookup/test2/test2/SomeAction.java
+++ b/o.n.core/test/unit/data/lookup/test2/test2/SomeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/data/projects/sfs-attr-test/sfs_attr_test/Util.java
+++ b/o.n.core/test/unit/data/projects/sfs-attr-test/sfs_attr_test/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/ColorEditorTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/ColorEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/FileArrayEditorTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/FileArrayEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/StringArrayEditorTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/StringArrayEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/StringEditorTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/beaninfo/editors/StringEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/CanProxyToLocalhostTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/CanProxyToLocalhostTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/HtmlBrowserComponentTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/HtmlBrowserComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/ModuleActionsTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/ModuleActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbAuthenticatorTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbAuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbErrorManagerTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbErrorManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbErrorManagerUserQuestionTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbErrorManagerUserQuestionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbKeymapTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbKeymapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbLifecycleManagerEDTTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbLifecycleManagerEDTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbLifecycleManagerTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbLifecycleManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbLoaderPoolDeserTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbLoaderPoolDeserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbLoaderPoolResolverChangeTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbLoaderPoolResolverChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbLoaderPoolTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbLoaderPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NbStatusDisplayerTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NbStatusDisplayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NotifyExcPanelTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NotifyExcPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/NotifyExceptionTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/NotifyExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/TimableEventQueueSuppressTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/TimableEventQueueSuppressTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/TimableEventQueueTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/TimableEventQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/actions/ActionMapKeysTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/actions/ActionMapKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModule38420Test.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModule38420Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest1.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest2.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest3.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest4.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest5.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest6.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest7.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest8.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTest8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTestHid.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/InstanceDataObjectModuleTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/lookup/MetaInfServicesTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/lookup/MetaInfServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.core/test/unit/src/org/netbeans/core/projects/SystemFileSystemTest.java
+++ b/o.n.core/test/unit/src/org/netbeans/core/projects/SystemFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
+++ b/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
+++ b/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/impl/ObjectFoundException.java
+++ b/o.n.insane/src/org/netbeans/insane/impl/ObjectFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/impl/Root.java
+++ b/o.n.insane/src/org/netbeans/insane/impl/Root.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/impl/SmallObjectMap.java
+++ b/o.n.insane/src/org/netbeans/insane/impl/SmallObjectMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/impl/SmallObjectMap2.java
+++ b/o.n.insane/src/org/netbeans/insane/impl/SmallObjectMap2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/impl/Utils.java
+++ b/o.n.insane/src/org/netbeans/insane/impl/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/live/CancelException.java
+++ b/o.n.insane/src/org/netbeans/insane/live/CancelException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/live/LiveReferences.java
+++ b/o.n.insane/src/org/netbeans/insane/live/LiveReferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/live/Path.java
+++ b/o.n.insane/src/org/netbeans/insane/live/Path.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/model/BinaryHeapModel.java
+++ b/o.n.insane/src/org/netbeans/insane/model/BinaryHeapModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/model/HeapModel.java
+++ b/o.n.insane/src/org/netbeans/insane/model/HeapModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/model/InsaneConverter.java
+++ b/o.n.insane/src/org/netbeans/insane/model/InsaneConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/model/Item.java
+++ b/o.n.insane/src/org/netbeans/insane/model/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/model/ObjectSet.java
+++ b/o.n.insane/src/org/netbeans/insane/model/ObjectSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/model/Support.java
+++ b/o.n.insane/src/org/netbeans/insane/model/Support.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/model/XmlHeapModel.java
+++ b/o.n.insane/src/org/netbeans/insane/model/XmlHeapModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/scanner/CountingVisitor.java
+++ b/o.n.insane/src/org/netbeans/insane/scanner/CountingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/scanner/Filter.java
+++ b/o.n.insane/src/org/netbeans/insane/scanner/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/scanner/ObjectMap.java
+++ b/o.n.insane/src/org/netbeans/insane/scanner/ObjectMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/scanner/ScannerUtils.java
+++ b/o.n.insane/src/org/netbeans/insane/scanner/ScannerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/scanner/SimpleXmlVisitor.java
+++ b/o.n.insane/src/org/netbeans/insane/scanner/SimpleXmlVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/src/org/netbeans/insane/scanner/Visitor.java
+++ b/o.n.insane/src/org/netbeans/insane/scanner/Visitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.insane/test/unit/src/org/netbeans/insane/impl/LiveEngineTest.java
+++ b/o.n.insane/test/unit/src/org/netbeans/insane/impl/LiveEngineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DelegatingChooserUI.java
+++ b/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DelegatingChooserUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryCellEditor.java
+++ b/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
+++ b/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryNode.java
+++ b/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/FileCompletionPopup.java
+++ b/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/FileCompletionPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/InputBlocker.java
+++ b/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/InputBlocker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/Module.java
+++ b/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ETableColumn.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ETableColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ETableColumnModel.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ETableColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ETableHeader.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ETableHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ETableSelectionModel.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ETableSelectionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ETableTransferHandler.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ETableTransferHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/ETableTransferable.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/ETableTransferable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/QuickFilter.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/QuickFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/etable/TableColumnSelector.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/etable/TableColumnSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/CheckRenderDataProvider.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/CheckRenderDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/DefaultOutlineCellRenderer.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/DefaultOutlineCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/DefaultOutlineModel.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/DefaultOutlineModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/EventBroadcaster.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/EventBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/ExtTreeWillExpandListener.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/ExtTreeWillExpandListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/Outline.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/Outline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/OutlineModel.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/OutlineModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/ProxyTableModel.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/ProxyTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/RenderDataProvider.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/RenderDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/RowModel.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/RowModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/src/org/netbeans/swing/outline/TreePathSupport.java
+++ b/o.n.swing.outline/src/org/netbeans/swing/outline/TreePathSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/test/unit/src/org/netbeans/swing/etable/ETableColumnModelTest.java
+++ b/o.n.swing.outline/test/unit/src/org/netbeans/swing/etable/ETableColumnModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/test/unit/src/org/netbeans/swing/etable/ETableColumnTest.java
+++ b/o.n.swing.outline/test/unit/src/org/netbeans/swing/etable/ETableColumnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/test/unit/src/org/netbeans/swing/etable/ETableTest.java
+++ b/o.n.swing.outline/test/unit/src/org/netbeans/swing/etable/ETableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/test/unit/src/org/netbeans/swing/outline/DefaultOutlineCellRendererTest.java
+++ b/o.n.swing.outline/test/unit/src/org/netbeans/swing/outline/DefaultOutlineCellRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/test/unit/src/org/netbeans/swing/outline/EventBroadcasterTest.java
+++ b/o.n.swing.outline/test/unit/src/org/netbeans/swing/outline/EventBroadcasterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.outline/test/unit/src/org/netbeans/swing/outline/OutlineTest.java
+++ b/o.n.swing.outline/test/unit/src/org/netbeans/swing/outline/OutlineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/AllLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/AllLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaSeparatorUI.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaSeparatorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaToolBarButtonUI.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaToolBarButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/CleanSplitPaneUI.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/CleanSplitPaneUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/FakeDropShadowBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/FakeDropShadowBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/PlainAquaToolbarUI.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/PlainAquaToolbarUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/AdaptiveMatteBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/AdaptiveMatteBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkToolBarButtonUI.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkToolBarButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkToolbarUI.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkToolbarUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/InsetBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/InsetBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/PartialEdgeBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/PartialEdgeBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/ThemeValue.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/ThemeValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/EditorToolbarBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/EditorToolbarBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalScrollPaneBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalScrollPaneBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/StatusLineBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/StatusLineBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/EditorToolbarBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/EditorToolbarBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusScrollPaneBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusScrollPaneBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/StatusLineBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/StatusLineBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/GuaranteedValue.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/GuaranteedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/NbTheme.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/NbTheme.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/RelativeColor.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/RelativeColor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/UIBootstrapValue.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/UIBootstrapValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/UIUtils.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/UIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/EditorToolbarBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/EditorToolbarBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/StatusLineBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/StatusLineBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WinClassicCompBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WinClassicCompBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WinClassicTabBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WinClassicTabBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WindowsLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WindowsLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/EditorToolbarBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/EditorToolbarBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/StatusLineBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/StatusLineBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/EditorToolbarBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/EditorToolbarBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/StatusLineBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/StatusLineBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/VistaLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/VistaLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/EditorToolbarBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/EditorToolbarBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/StatusLineBorder.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/StatusLineBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/XPLFCustoms.java
+++ b/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/XPLFCustoms.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/beanstubs/org/openide/ErrorManager.java
+++ b/o.n.swing.tabcontrol/beanstubs/org/openide/ErrorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/beanstubs/org/openide/util/Utilities.java
+++ b/o.n.swing.tabcontrol/beanstubs/org/openide/util/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/demosrc/org/netbeans/swing/tabcontrol/demo/TestFrame.java
+++ b/o.n.swing.tabcontrol/demosrc/org/netbeans/swing/tabcontrol/demo/TestFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTable.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTableItem.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTableItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTableModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/ButtonPopupSwitcher.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/ButtonPopupSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/ComponentConverter.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/ComponentConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DefaultTabDataModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DefaultTabDataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DocumentSwitcherTable.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DocumentSwitcherTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/LocationInformer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/LocationInformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/SlideBarDataModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/SlideBarDataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/SlidingButton.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/SlidingButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/SlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/SlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabData.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDataModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDataModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDisplayer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabListPopupAction.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabListPopupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/WinsysInfoForTabbed.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/WinsysInfoForTabbed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/WinsysInfoForTabbedContainer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/WinsysInfoForTabbedContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/customtabs/Tabbed.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/customtabs/Tabbed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/customtabs/TabbedComponentFactory.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/customtabs/TabbedComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/customtabs/TabbedType.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/customtabs/TabbedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/ArrayDiff.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/ArrayDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/ComplexListDataEvent.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/ComplexListDataEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/ComplexListDataListener.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/ComplexListDataListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/TabActionEvent.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/TabActionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/VeryComplexListDataEvent.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/event/VeryComplexListDataEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractWinEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractWinEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractWinViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractWinViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaSlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaSlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BaseTabLayoutModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BaseTabLayoutModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicScrollingTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicScrollingTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicSlidingTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicSlidingTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BusyIcon.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BusyIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BusyTabsSupport.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BusyTabsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ChicletWrapper.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ChicletWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ColorUtil.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ColorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/DefaultTabLayoutModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/DefaultTabLayoutModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/DefaultTabSelectionModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/DefaultTabSelectionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/DefaultTabbedContainerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/DefaultTabbedContainerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/EqualPolygon.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/EqualPolygon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/FxProvider.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/FxProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GenericGlowingChiclet.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GenericGlowingChiclet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkEditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkEditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkSlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkSlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalEditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalEditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalSlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalSlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusSlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusSlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NonStretchingViewTabLayoutModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NonStretchingViewTabLayoutModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ScrollingTabLayoutModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ScrollingTabLayoutModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/SlidingTabDisplayerButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/SlidingTabDisplayerButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/StackLayout.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/StackLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabControlButton.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabControlButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabControlButtonFactory.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabControlButtonFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabLayoutModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabLayoutModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabPainter.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabState.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/TabState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ToolbarTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ToolbarTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ViewTabLayoutModel.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ViewTabLayoutModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ViewTabLayoutModel2.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ViewTabLayoutModel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicEditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicEditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaEditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaEditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaSlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaSlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinVistaViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPEditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPEditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPEditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPEditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPSlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPSlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8EditorTabCellRenderer.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8EditorTabCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8EditorTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8EditorTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8ViewTabDisplayerUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8ViewTabDisplayerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WindowsSlidingButtonUI.java
+++ b/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WindowsSlidingButtonUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/ButtonPopupSwitcherTestHid.java
+++ b/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/ButtonPopupSwitcherTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/DataModelTest.java
+++ b/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/DataModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/LayoutModelTest.java
+++ b/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/LayoutModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/SelectionModelTest.java
+++ b/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/SelectionModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/StackLayoutTest.java
+++ b/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/StackLayoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/TabStateTest.java
+++ b/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/TabStateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/license/AcceptLicense.java
+++ b/o.n.upgrader/src/org/netbeans/license/AcceptLicense.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/license/LicensePanel.java
+++ b/o.n.upgrader/src/org/netbeans/license/LicensePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgrade.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgrade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgradePanel.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgradePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/ColoringStorage.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/ColoringStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/Copy.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/Copy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/CopyFiles.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/CopyFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/IncludeExclude.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/IncludeExclude.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/PathTransformation.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/PathTransformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/XMLStorage.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/XMLStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/ColorProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/ColorProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/ContentProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/ContentProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/CvsSettingsProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/CvsSettingsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/DefaultResult.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/DefaultResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/DocumentationSettingsProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/DocumentationSettingsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/FileProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/FileProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/HashMapProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/HashMapProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/HashSetProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/HashSetProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/HostPropertyProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/HostPropertyProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Importer.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Importer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/IntrospectedInfoProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/IntrospectedInfoProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/JUnitContentProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/JUnitContentProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/ListProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/ListProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/NbClassPathProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/NbClassPathProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/PropertiesStorage.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/PropertiesStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/PropertyProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/PropertyProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Result.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SettingsRecognizer.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SettingsRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/StringPropertyProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/StringPropertyProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SystemOptionsParser.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SystemOptionsParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/TaskTagsProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/TaskTagsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/URLProcessor.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/URLProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Utils.java
+++ b/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/src/org/netbeans/util/Util.java
+++ b/o.n.upgrader/src/org/netbeans/util/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/AutoUpgradeTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/AutoUpgradeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/CopyFilesTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/CopyFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/CopyTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/CopyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/IncludeExcludeTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/IncludeExcludeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/launcher/MainCallback.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/launcher/MainCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/launcher/PlatformWithAbsolutePathTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/launcher/PlatformWithAbsolutePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/AntSettingsNullAntHomeTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/AntSettingsNullAntHomeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/AntSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/AntSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/BasicTestForImport.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/BasicTestForImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/CoreSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/CoreSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/CvsSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/CvsSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/DataBaseOptionTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/DataBaseOptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/DerbyOptionsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/DerbyOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/DocumentationSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/DocumentationSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/FormSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/FormSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/HttpServerSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/HttpServerSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/I18nOptionsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/I18nOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/IDESettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/IDESettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/JUnitSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/JUnitSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/JavaSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/JavaSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/ModuleUISettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/ModuleUISettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/PackageViewSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/PackageViewSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/ProjectUIOptionsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/ProjectUIOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/SvnSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/SvnSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/TaskListSettingsTest.java
+++ b/o.n.upgrader/test/unit/src/org/netbeans/upgrade/systemoptions/TaskListSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/CompoundSearchInfo.java
+++ b/o.openidex.util/src/org/openidex/search/CompoundSearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/CompoundSearchIterator.java
+++ b/o.openidex.util/src/org/openidex/search/CompoundSearchIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/DataObjectSearchGroup.java
+++ b/o.openidex.util/src/org/openidex/search/DataObjectSearchGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/FileObjectFilter.java
+++ b/o.openidex.util/src/org/openidex/search/FileObjectFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/FileObjectSearchGroup.java
+++ b/o.openidex.util/src/org/openidex/search/FileObjectSearchGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SearchGroup.java
+++ b/o.openidex.util/src/org/openidex/search/SearchGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SearchHistory.java
+++ b/o.openidex.util/src/org/openidex/search/SearchHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SearchInfo.java
+++ b/o.openidex.util/src/org/openidex/search/SearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SearchInfoFactory.java
+++ b/o.openidex.util/src/org/openidex/search/SearchInfoFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SearchPattern.java
+++ b/o.openidex.util/src/org/openidex/search/SearchPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SearchType.java
+++ b/o.openidex.util/src/org/openidex/search/SearchType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SharabilityFilter.java
+++ b/o.openidex.util/src/org/openidex/search/SharabilityFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SimpleSearchInfo.java
+++ b/o.openidex.util/src/org/openidex/search/SimpleSearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SimpleSearchIterator.java
+++ b/o.openidex.util/src/org/openidex/search/SimpleSearchIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/SubnodesSearchInfo.java
+++ b/o.openidex.util/src/org/openidex/search/SubnodesSearchInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/Utils.java
+++ b/o.openidex.util/src/org/openidex/search/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/VisibilityFilter.java
+++ b/o.openidex.util/src/org/openidex/search/VisibilityFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/src/org/openidex/search/impl/ProjectSearchingUtils.java
+++ b/o.openidex.util/src/org/openidex/search/impl/ProjectSearchingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/src/RootClass.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/src/RootClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_invisible.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_invisible.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_unsharable.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz/SampleClass_unsharable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz_unsharable/SomeClass.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar/baz_unsharable/SomeClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar_invisible/AnotherClass.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/src/foo/bar_invisible/AnotherClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/src/foo_sharable/DummyClass_unsharable.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/src/foo_sharable/DummyClass_unsharable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/data/projects/Project1/test/abc/xyz/SimpleTest.java
+++ b/o.openidex.util/test/unit/data/projects/Project1/test/abc/xyz/SimpleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/CompoundSearchInfoTest.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/CompoundSearchInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/DummyDataLoader.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/DummyDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/DummyDataObject.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/DummyDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/SearchGroupTest.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/SearchGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/SearchHistoryTest.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/SearchHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/SearchIteratorTest.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/SearchIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/SharabilityQueryImpl.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/SharabilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/o.openidex.util/test/unit/src/org/openidex/search/VisibilityQueryImpl.java
+++ b/o.openidex.util/test/unit/src/org/openidex/search/VisibilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/netbeans/modules/openide/actions/ActionsBridgeImpl.java
+++ b/openide.actions/src/org/netbeans/modules/openide/actions/ActionsBridgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/ActionManager.java
+++ b/openide.actions/src/org/openide/actions/ActionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/CloneViewAction.java
+++ b/openide.actions/src/org/openide/actions/CloneViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/CloseViewAction.java
+++ b/openide.actions/src/org/openide/actions/CloseViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/CopyAction.java
+++ b/openide.actions/src/org/openide/actions/CopyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/CustomizeAction.java
+++ b/openide.actions/src/org/openide/actions/CustomizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/CutAction.java
+++ b/openide.actions/src/org/openide/actions/CutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/DeleteAction.java
+++ b/openide.actions/src/org/openide/actions/DeleteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/EditAction.java
+++ b/openide.actions/src/org/openide/actions/EditAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/FindAction.java
+++ b/openide.actions/src/org/openide/actions/FindAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/GarbageCollectAction.java
+++ b/openide.actions/src/org/openide/actions/GarbageCollectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/GotoAction.java
+++ b/openide.actions/src/org/openide/actions/GotoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/HeapView.java
+++ b/openide.actions/src/org/openide/actions/HeapView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/MoveDownAction.java
+++ b/openide.actions/src/org/openide/actions/MoveDownAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/MoveUpAction.java
+++ b/openide.actions/src/org/openide/actions/MoveUpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/NewAction.java
+++ b/openide.actions/src/org/openide/actions/NewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/NextTabAction.java
+++ b/openide.actions/src/org/openide/actions/NextTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/OpenAction.java
+++ b/openide.actions/src/org/openide/actions/OpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/OpenLocalExplorerAction.java
+++ b/openide.actions/src/org/openide/actions/OpenLocalExplorerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/PageSetupAction.java
+++ b/openide.actions/src/org/openide/actions/PageSetupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/PasteAction.java
+++ b/openide.actions/src/org/openide/actions/PasteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/PopupAction.java
+++ b/openide.actions/src/org/openide/actions/PopupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/PreviousTabAction.java
+++ b/openide.actions/src/org/openide/actions/PreviousTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/PrintAction.java
+++ b/openide.actions/src/org/openide/actions/PrintAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/PropertiesAction.java
+++ b/openide.actions/src/org/openide/actions/PropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/RedoAction.java
+++ b/openide.actions/src/org/openide/actions/RedoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/RenameAction.java
+++ b/openide.actions/src/org/openide/actions/RenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/ReorderAction.java
+++ b/openide.actions/src/org/openide/actions/ReorderAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/ReplaceAction.java
+++ b/openide.actions/src/org/openide/actions/ReplaceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/SaveAction.java
+++ b/openide.actions/src/org/openide/actions/SaveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/ToolsAction.java
+++ b/openide.actions/src/org/openide/actions/ToolsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/UndoAction.java
+++ b/openide.actions/src/org/openide/actions/UndoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/UndoRedoAction.java
+++ b/openide.actions/src/org/openide/actions/UndoRedoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/UndockAction.java
+++ b/openide.actions/src/org/openide/actions/UndockAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/ViewAction.java
+++ b/openide.actions/src/org/openide/actions/ViewAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/src/org/openide/actions/WorkspaceSwitchAction.java
+++ b/openide.actions/src/org/openide/actions/WorkspaceSwitchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/AbstractCallbackActionTestHidden.java
+++ b/openide.actions/test/unit/src/org/openide/actions/AbstractCallbackActionTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/ActionsInfraHid.java
+++ b/openide.actions/test/unit/src/org/openide/actions/ActionsInfraHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/CloneViewActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/CloneViewActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/CloseViewActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/CloseViewActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/CopyActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/CopyActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/CustomizeActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/CustomizeActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/CutActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/CutActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/DeleteActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/DeleteActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/EditActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/EditActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/FindActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/FindActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/GotoActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/GotoActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/MoveUpActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/MoveUpActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/NewActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/NewActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/NextTabActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/NextTabActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/OpenActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/OpenActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/OpenLocalExplorerActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/OpenLocalExplorerActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/PageSetupActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/PageSetupActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/PasteActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/PasteActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/PopupActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/PopupActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/PreviousTabActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/PreviousTabActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/PrintActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/PrintActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/PropertiesActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/PropertiesActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/RenameActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/RenameActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/SaveActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/SaveActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/ToolsActionSlowTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/ToolsActionSlowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/ToolsActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/ToolsActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.actions/test/unit/src/org/openide/actions/UndoRedoActionTest.java
+++ b/openide.actions/test/unit/src/org/openide/actions/UndoRedoActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/api/actions/Closable.java
+++ b/openide.awt/src/org/netbeans/api/actions/Closable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/api/actions/Editable.java
+++ b/openide.awt/src/org/netbeans/api/actions/Editable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/api/actions/Openable.java
+++ b/openide.awt/src/org/netbeans/api/actions/Openable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/api/actions/Printable.java
+++ b/openide.awt/src/org/netbeans/api/actions/Printable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/api/actions/Savable.java
+++ b/openide.awt/src/org/netbeans/api/actions/Savable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/api/actions/Viewable.java
+++ b/openide.awt/src/org/netbeans/api/actions/Viewable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/modules/openide/awt/ActionProcessor.java
+++ b/openide.awt/src/org/netbeans/modules/openide/awt/ActionProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/modules/openide/awt/DefaultAWTBridge.java
+++ b/openide.awt/src/org/netbeans/modules/openide/awt/DefaultAWTBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/modules/openide/awt/SavableRegistry.java
+++ b/openide.awt/src/org/netbeans/modules/openide/awt/SavableRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/netbeans/spi/actions/AbstractSavable.java
+++ b/openide.awt/src/org/netbeans/spi/actions/AbstractSavable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/AcceleratorBinding.java
+++ b/openide.awt/src/org/openide/awt/AcceleratorBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ActionDefaultPerfomer.java
+++ b/openide.awt/src/org/openide/awt/ActionDefaultPerfomer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ActionID.java
+++ b/openide.awt/src/org/openide/awt/ActionID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ActionReference.java
+++ b/openide.awt/src/org/openide/awt/ActionReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ActionReferences.java
+++ b/openide.awt/src/org/openide/awt/ActionReferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ActionRegistration.java
+++ b/openide.awt/src/org/openide/awt/ActionRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/Actions.java
+++ b/openide.awt/src/org/openide/awt/Actions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/AlwaysEnabledAction.java
+++ b/openide.awt/src/org/openide/awt/AlwaysEnabledAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/CheckForUpdatesProvider.java
+++ b/openide.awt/src/org/openide/awt/CheckForUpdatesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/CloseButtonFactory.java
+++ b/openide.awt/src/org/openide/awt/CloseButtonFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ColorComboBox.java
+++ b/openide.awt/src/org/openide/awt/ColorComboBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ColorComboBoxRendererWrapper.java
+++ b/openide.awt/src/org/openide/awt/ColorComboBoxRendererWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ColorIcon.java
+++ b/openide.awt/src/org/openide/awt/ColorIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ColorValue.java
+++ b/openide.awt/src/org/openide/awt/ColorValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ContextAction.java
+++ b/openide.awt/src/org/openide/awt/ContextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ContextActionEnabler.java
+++ b/openide.awt/src/org/openide/awt/ContextActionEnabler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ContextActionPerformer.java
+++ b/openide.awt/src/org/openide/awt/ContextActionPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ContextManager.java
+++ b/openide.awt/src/org/openide/awt/ContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ContextSelection.java
+++ b/openide.awt/src/org/openide/awt/ContextSelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/DropDownButton.java
+++ b/openide.awt/src/org/openide/awt/DropDownButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/DropDownButtonFactory.java
+++ b/openide.awt/src/org/openide/awt/DropDownButtonFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/DropDownToggleButton.java
+++ b/openide.awt/src/org/openide/awt/DropDownToggleButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/DynamicMenuContent.java
+++ b/openide.awt/src/org/openide/awt/DynamicMenuContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/EqualFlowLayout.java
+++ b/openide.awt/src/org/openide/awt/EqualFlowLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/GeneralAction.java
+++ b/openide.awt/src/org/openide/awt/GeneralAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/GlobalManager.java
+++ b/openide.awt/src/org/openide/awt/GlobalManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/HtmlBrowser.java
+++ b/openide.awt/src/org/openide/awt/HtmlBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/HtmlLabelUI.java
+++ b/openide.awt/src/org/openide/awt/HtmlLabelUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/HtmlRenderer.java
+++ b/openide.awt/src/org/openide/awt/HtmlRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
+++ b/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/IconWithArrow.java
+++ b/openide.awt/src/org/openide/awt/IconWithArrow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/InjectorAny.java
+++ b/openide.awt/src/org/openide/awt/InjectorAny.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/InjectorExactlyOne.java
+++ b/openide.awt/src/org/openide/awt/InjectorExactlyOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/JInlineMenu.java
+++ b/openide.awt/src/org/openide/awt/JInlineMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/JMenuPlus.java
+++ b/openide.awt/src/org/openide/awt/JMenuPlus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/JPopupMenuPlus.java
+++ b/openide.awt/src/org/openide/awt/JPopupMenuPlus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/JPopupMenuUtils.java
+++ b/openide.awt/src/org/openide/awt/JPopupMenuUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ListPane.java
+++ b/openide.awt/src/org/openide/awt/ListPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/Mnemonics.java
+++ b/openide.awt/src/org/openide/awt/Mnemonics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/MouseUtils.java
+++ b/openide.awt/src/org/openide/awt/MouseUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/Notification.java
+++ b/openide.awt/src/org/openide/awt/Notification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/NotificationCategoryFactory.java
+++ b/openide.awt/src/org/openide/awt/NotificationCategoryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/NotificationDisplayer.java
+++ b/openide.awt/src/org/openide/awt/NotificationDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/QuickSearch.java
+++ b/openide.awt/src/org/openide/awt/QuickSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/SpinButton.java
+++ b/openide.awt/src/org/openide/awt/SpinButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/SpinButtonAdapter.java
+++ b/openide.awt/src/org/openide/awt/SpinButtonAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/SpinButtonListener.java
+++ b/openide.awt/src/org/openide/awt/SpinButtonListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/SplittedPanel.java
+++ b/openide.awt/src/org/openide/awt/SplittedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/StatusDisplayer.java
+++ b/openide.awt/src/org/openide/awt/StatusDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/StatusLineElementProvider.java
+++ b/openide.awt/src/org/openide/awt/StatusLineElementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/SwingBrowserImpl.java
+++ b/openide.awt/src/org/openide/awt/SwingBrowserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/TabbedPaneFactory.java
+++ b/openide.awt/src/org/openide/awt/TabbedPaneFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ToolbarButton.java
+++ b/openide.awt/src/org/openide/awt/ToolbarButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ToolbarToggleButton.java
+++ b/openide.awt/src/org/openide/awt/ToolbarToggleButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/ToolbarWithOverflow.java
+++ b/openide.awt/src/org/openide/awt/ToolbarWithOverflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/src/org/openide/awt/UndoRedo.java
+++ b/openide.awt/src/org/openide/awt/UndoRedo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/netbeans/api/actions/SavableTest.java
+++ b/openide.awt/test/unit/src/org/netbeans/api/actions/SavableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/ActionProcessorTest.java
+++ b/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/ActionProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/DefaultAWTBridgeTest.java
+++ b/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/DefaultAWTBridgeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/package-info.java
+++ b/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/ActionsInfraHid.java
+++ b/openide.awt/test/unit/src/org/openide/awt/ActionsInfraHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/ActionsTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/ActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/AlwaysEnabledActionTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/AlwaysEnabledActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/AsynchronousTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/AsynchronousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/CallbackActionTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/CallbackActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/CallbackSystemActionTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/CallbackSystemActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/ContextActionInjectTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/ContextActionInjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/ContextActionNonAWTTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/ContextActionNonAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/ContextActionTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/ContextActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/ContextManagerTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/ContextManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/GeneralActionTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/GeneralActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/GlobalManagerTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/GlobalManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/HtmlRendererTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/HtmlRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/MnemonicsTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/MnemonicsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/NotificationCategoryFactoryTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/NotificationCategoryFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/QuickSearchTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/QuickSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/SwingBrowserTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/SwingBrowserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/ToolbarWithOverflowTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/ToolbarWithOverflowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/UndoRedoTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/UndoRedoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.awt/test/unit/src/org/openide/awt/UtilitiesActionsTest.java
+++ b/openide.awt/test/unit/src/org/openide/awt/UtilitiesActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/src/org/openide/explorer/ExplorerActions.java
+++ b/openide.compat/src/org/openide/explorer/ExplorerActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/src/org/openide/explorer/ExplorerPanel.java
+++ b/openide.compat/src/org/openide/explorer/ExplorerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/src/org/openide/util/HttpServer.java
+++ b/openide.compat/src/org/openide/util/HttpServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/src/org/openide/util/WeakListener.java
+++ b/openide.compat/src/org/openide/util/WeakListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/ActionsInfraHid.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/ActionsInfraHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/ExplorerActionsCompatTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/ExplorerActionsCompatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/ExplorerActionsTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/ExplorerActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/ExplorerPanelTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/ExplorerPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/FindHelpTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/FindHelpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/propertysheet/ComboTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/propertysheet/ComboTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/propertysheet/CustomEditorDisplayerTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/propertysheet/CustomEditorDisplayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/propertysheet/NewPropertyPanelTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/propertysheet/NewPropertyPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/propertysheet/PropertyPanelTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/propertysheet/PropertyPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/view/DefaultActionTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/view/DefaultActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/view/ListViewTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/view/ListViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/view/ListViewTopComponentTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/view/ListViewTopComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/view/RootContextTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/view/RootContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/view/SelectNodeInListViewTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/view/SelectNodeInListViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/view/SelectionModeTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/view/SelectionModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/view/TTVTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/view/TTVTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/explorer/windows/TopComponentActivatedNodesTest.java
+++ b/openide.compat/test/unit/src/org/openide/explorer/windows/TopComponentActivatedNodesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.compat/test/unit/src/org/openide/util/WeakListenerTest.java
+++ b/openide.compat/test/unit/src/org/openide/util/WeakListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/src/org/openide/DialogDescriptor.java
+++ b/openide.dialogs/src/org/openide/DialogDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/src/org/openide/DialogDisplayer.java
+++ b/openide.dialogs/src/org/openide/DialogDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/src/org/openide/NotificationLineSupport.java
+++ b/openide.dialogs/src/org/openide/NotificationLineSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/src/org/openide/NotifyDescriptor.java
+++ b/openide.dialogs/src/org/openide/NotifyDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/src/org/openide/WizardDescriptor.java
+++ b/openide.dialogs/src/org/openide/WizardDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/src/org/openide/WizardValidationException.java
+++ b/openide.dialogs/src/org/openide/WizardValidationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/AsynchronousInstantiatingIteratorTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/AsynchronousInstantiatingIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/AsynchronousValidatingPanelTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/AsynchronousValidatingPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/InstantiatingIteratorTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/InstantiatingIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/LoggingTestCaseHid.java
+++ b/openide.dialogs/test/unit/src/org/openide/LoggingTestCaseHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/NotificationLineSupportTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/NotificationLineSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/NotifyDescriptorTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/NotifyDescriptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/ProgressInstantiatingIteratorTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/ProgressInstantiatingIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/PropertiesTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/PropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/WizardDescTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/WizardDescTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/WizardDescriptorOrderTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/WizardDescriptorOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/WizardDescriptorWhenClosedWindowTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/WizardDescriptorWhenClosedWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.dialogs/test/unit/src/org/openide/WizardSetDataAndIteratorTest.java
+++ b/openide.dialogs/test/unit/src/org/openide/WizardSetDataAndIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
+++ b/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution.compat8/test/unit/src/org/openide/execution/NbClassPathCompatTest.java
+++ b/openide.execution.compat8/test/unit/src/org/openide/execution/NbClassPathCompatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/src/org/openide/execution/ExecutionEngine.java
+++ b/openide.execution/src/org/openide/execution/ExecutionEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/src/org/openide/execution/ExecutorTask.java
+++ b/openide.execution/src/org/openide/execution/ExecutorTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/src/org/openide/execution/NbClassLoader.java
+++ b/openide.execution/src/org/openide/execution/NbClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/src/org/openide/execution/NbClassPath.java
+++ b/openide.execution/src/org/openide/execution/NbClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/src/org/openide/execution/NbProcessDescriptor.java
+++ b/openide.execution/src/org/openide/execution/NbProcessDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/src/org/openide/execution/ScriptType.java
+++ b/openide.execution/src/org/openide/execution/ScriptType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/test/unit/src/org/openide/execution/ExecutionCompatibilityTest.java
+++ b/openide.execution/test/unit/src/org/openide/execution/ExecutionCompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/test/unit/src/org/openide/execution/ExecutionEngineHid.java
+++ b/openide.execution/test/unit/src/org/openide/execution/ExecutionEngineHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.execution/test/unit/src/org/openide/execution/NbClassLoaderTest.java
+++ b/openide.execution/test/unit/src/org/openide/execution/NbClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/META-INF/upgrade/TreeView.hint
+++ b/openide.explorer/src/META-INF/upgrade/TreeView.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/netbeans/modules/openide/explorer/ExplorerActionsImpl.java
+++ b/openide.explorer/src/org/netbeans/modules/openide/explorer/ExplorerActionsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/netbeans/modules/openide/explorer/ExternalDragAndDrop.java
+++ b/openide.explorer/src/org/netbeans/modules/openide/explorer/ExternalDragAndDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/netbeans/modules/openide/explorer/NodeOperationImpl.java
+++ b/openide.explorer/src/org/netbeans/modules/openide/explorer/NodeOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/netbeans/modules/openide/explorer/PropertyPanelBridge.java
+++ b/openide.explorer/src/org/netbeans/modules/openide/explorer/PropertyPanelBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/netbeans/modules/openide/explorer/TTVEnvBridge.java
+++ b/openide.explorer/src/org/netbeans/modules/openide/explorer/TTVEnvBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/netbeans/modules/openide/explorer/TabbedContainerBridge.java
+++ b/openide.explorer/src/org/netbeans/modules/openide/explorer/TabbedContainerBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/netbeans/modules/openide/explorer/TabbedContainerBridgeImpl.java
+++ b/openide.explorer/src/org/netbeans/modules/openide/explorer/TabbedContainerBridgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
+++ b/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/ExplorerManager.java
+++ b/openide.explorer/src/org/openide/explorer/ExplorerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/ExplorerUtils.java
+++ b/openide.explorer/src/org/openide/explorer/ExplorerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/ExtendedDelete.java
+++ b/openide.explorer/src/org/openide/explorer/ExtendedDelete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/AutoGridLayout.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/AutoGridLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/BaseTable.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/BaseTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/Boolean3WayEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/Boolean3WayEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ButtonPanel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ButtonPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/CellEditorActionEvent.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/CellEditorActionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/CheckboxInplaceEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/CheckboxInplaceEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/CleanComboUI.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/CleanComboUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ComboBoxAutoCompleteSupport.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ComboBoxAutoCompleteSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ComboInplaceEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ComboInplaceEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/CustomEditorAccessorImpl.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/CustomEditorAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/CustomEditorAction.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/CustomEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/CustomEditorDisplayer.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/CustomEditorDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/DefaultPropertyModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/DefaultPropertyModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/DescriptionComponent.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/DescriptionComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/EditablePropertyDisplayer.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/EditablePropertyDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/EditorPropertyDisplayer.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/EditorPropertyDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/EnumPropertyEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/EnumPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ExPropertyEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ExPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ExPropertyModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ExPropertyModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/IconPanel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/IconPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/IncrementPropertyValueSupport.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/IncrementPropertyValueSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/IndexedEditorPanel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/IndexedEditorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/InplaceEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/InplaceEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/InplaceEditorFactory.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/InplaceEditorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/MarginViewportUI.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/MarginViewportUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ModelProperty.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ModelProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/NodePropertyModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/NodePropertyModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PSheet.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PSheet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDialogManager.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDialogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer_Editable.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer_Editable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer_Inline.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer_Inline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer_Mutable.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDisplayer_Mutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyEnv.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModelEvent.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModelEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModelImpl.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModelListener.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertySetModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertySheet.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertySheet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/PropertySheetView.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/PropertySheetView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ProxyNode.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ProxyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/RendererPropertyDisplayer.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/RendererPropertyDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ReusablePropertyEnv.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ReusablePropertyEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/ReusablePropertyModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/ReusablePropertyModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/SelectionAndScrollPositionManager.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/SelectionAndScrollPositionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/SheetCellEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/SheetCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/SheetCellRenderer.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/SheetCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/SheetColumnModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/SheetColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/SheetTable.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/SheetTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/SheetTableModel.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/SheetTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/StringInplaceEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/StringInplaceEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/WrapperInplaceEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/WrapperInplaceEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/editors/EnhancedCustomPropertyEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/editors/EnhancedCustomPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/editors/EnhancedPropertyEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/editors/EnhancedPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/editors/NodeCustomizer.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/editors/NodeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/editors/NodePropertyEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/editors/NodePropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/editors/XMLPropertyEditor.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/editors/XMLPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/propertysheet/editors/package-info.java
+++ b/openide.explorer/src/org/openide/explorer/propertysheet/editors/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/AutoscrollSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/AutoscrollSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/BeanTreeView.java
+++ b/openide.explorer/src/org/openide/explorer/view/BeanTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/CheckableNode.java
+++ b/openide.explorer/src/org/openide/explorer/view/CheckableNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ChoiceView.java
+++ b/openide.explorer/src/org/openide/explorer/view/ChoiceView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ContextTreeView.java
+++ b/openide.explorer/src/org/openide/explorer/view/ContextTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/CustomPopupFactory.java
+++ b/openide.explorer/src/org/openide/explorer/view/CustomPopupFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/DragDropUtilities.java
+++ b/openide.explorer/src/org/openide/explorer/view/DragDropUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/DropGlassPane.java
+++ b/openide.explorer/src/org/openide/explorer/view/DropGlassPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ExplorerDnDManager.java
+++ b/openide.explorer/src/org/openide/explorer/view/ExplorerDnDManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ExplorerDragSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/ExplorerDragSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/IconPanel.java
+++ b/openide.explorer/src/org/openide/explorer/view/IconPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/IconView.java
+++ b/openide.explorer/src/org/openide/explorer/view/IconView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ListTableView.java
+++ b/openide.explorer/src/org/openide/explorer/view/ListTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ListView.java
+++ b/openide.explorer/src/org/openide/explorer/view/ListView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ListViewDragSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/ListViewDragSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ListViewDropSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/ListViewDropSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/MenuView.java
+++ b/openide.explorer/src/org/openide/explorer/view/MenuView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/NodeListModel.java
+++ b/openide.explorer/src/org/openide/explorer/view/NodeListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/NodeModel.java
+++ b/openide.explorer/src/org/openide/explorer/view/NodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/NodePopupFactory.java
+++ b/openide.explorer/src/org/openide/explorer/view/NodePopupFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/NodeRenderDataProvider.java
+++ b/openide.explorer/src/org/openide/explorer/view/NodeRenderDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/NodeRenderer.java
+++ b/openide.explorer/src/org/openide/explorer/view/NodeRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/NodeTableModel.java
+++ b/openide.explorer/src/org/openide/explorer/view/NodeTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/NodeTreeModel.java
+++ b/openide.explorer/src/org/openide/explorer/view/NodeTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/OutlineView.java
+++ b/openide.explorer/src/org/openide/explorer/view/OutlineView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/OutlineViewDragSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/OutlineViewDragSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/OutlineViewDropSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/OutlineViewDropSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/PropertiesRowModel.java
+++ b/openide.explorer/src/org/openide/explorer/view/PropertiesRowModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/QuickSearchTableFilter.java
+++ b/openide.explorer/src/org/openide/explorer/view/QuickSearchTableFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/SheetCell.java
+++ b/openide.explorer/src/org/openide/explorer/view/SheetCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TableQuickSearchSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/TableQuickSearchSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TableSheet.java
+++ b/openide.explorer/src/org/openide/explorer/view/TableSheet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TableSheetCell.java
+++ b/openide.explorer/src/org/openide/explorer/view/TableSheetCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TableView.java
+++ b/openide.explorer/src/org/openide/explorer/view/TableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TableViewDragSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/TableViewDragSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TableViewDropSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/TableViewDropSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TreeTable.java
+++ b/openide.explorer/src/org/openide/explorer/view/TreeTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TreeTableModelAdapter.java
+++ b/openide.explorer/src/org/openide/explorer/view/TreeTableModelAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TreeTableView.java
+++ b/openide.explorer/src/org/openide/explorer/view/TreeTableView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TreeView.java
+++ b/openide.explorer/src/org/openide/explorer/view/TreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TreeViewCellEditor.java
+++ b/openide.explorer/src/org/openide/explorer/view/TreeViewCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TreeViewDragSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/TreeViewDragSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/TreeViewDropSupport.java
+++ b/openide.explorer/src/org/openide/explorer/view/TreeViewDropSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ViewTooltips.java
+++ b/openide.explorer/src/org/openide/explorer/view/ViewTooltips.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/ViewUtil.java
+++ b/openide.explorer/src/org/openide/explorer/view/ViewUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/Visualizer.java
+++ b/openide.explorer/src/org/openide/explorer/view/Visualizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/VisualizerChildren.java
+++ b/openide.explorer/src/org/openide/explorer/view/VisualizerChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/VisualizerEvent.java
+++ b/openide.explorer/src/org/openide/explorer/view/VisualizerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/src/org/openide/explorer/view/VisualizerNode.java
+++ b/openide.explorer/src/org/openide/explorer/view/VisualizerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/ExplorerActionsImplTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/ExplorerActionsImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/ExplorerManagerTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/ExplorerManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/ExplorerUtilsTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/ExplorerUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ComboTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ComboTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/CustomInplaceEditorTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/CustomInplaceEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/DefaultPropertyModelTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/DefaultPropertyModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EditableDisplayerTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EditableDisplayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EditorDisplayerTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EditorDisplayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EnumPropertyEditorTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EnumPropertyEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ExtTestCase.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ExtTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/FindHelpTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/FindHelpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/FocusAfterBadEditTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/FocusAfterBadEditTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/GraphicsTestCase.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/GraphicsTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/IndexedPropertyEditorTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/IndexedPropertyEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/IndexedPropertyTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/IndexedPropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorFactoryTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorNoModifyOnTextChangeContractBooleanEditorTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorNoModifyOnTextChangeContractBooleanEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorNoModifyOnTextChangeContractComboEditorTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorNoModifyOnTextChangeContractComboEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorNoModifyOnTextChangeContractStringEditorTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/InplaceEditorNoModifyOnTextChangeContractStringEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/MorePropertySheetTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/MorePropertySheetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/NodeDeletionTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/NodeDeletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/NodeOperationImplTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/NodeOperationImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/NonEditabilityTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/NonEditabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropUtilsTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertiesFlushTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertiesFlushTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyEnvTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyEnvTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyMarkingTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyMarkingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyPanelInDialogTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyPanelInDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyPanelTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertyPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertySheetQuickSearchEnablementTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertySheetQuickSearchEnablementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertySheetTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/PropertySheetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ProxyNodeTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ProxyNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/RendererDisplayerTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/RendererDisplayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/RestoreDefaultValueTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/RestoreDefaultValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ReusablePropertyEnvTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/ReusablePropertyEnvTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/SheetTableTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/SheetTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/TagsAndEditorsTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/TagsAndEditorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/AnotherSetKeysBeforeEventsProcessedTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/AnotherSetKeysBeforeEventsProcessedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/AreVisualizersSynchronizedTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/AreVisualizersSynchronizedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/BeanTreeViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/BeanTreeViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/ChoiceViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/ChoiceViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/ContextTreeViewModelTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/ContextTreeViewModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/ContextTreeViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/ContextTreeViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/DragDropUtilitiesTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/DragDropUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/EQFriendlyGC.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/EQFriendlyGC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/ListViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/ListViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/ListViewWithUpTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/ListViewWithUpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/NavigationTreeViewLazyTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/NavigationTreeViewLazyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/NavigationTreeViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/NavigationTreeViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/NodeListModelTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/NodeListModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/NodeRendererTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/NodeRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/NodeTableModelTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/NodeTableModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/NodeTreeModelTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/NodeTreeModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineView152857Test.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineView152857Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineView218096Test.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineView218096Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineViewOrderingTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineViewOrderingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/OutlineViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TableSheetCellTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TableSheetCellTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TableViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TableViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeNodeLeakTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeNodeLeakTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableMemoryLeakTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableMemoryLeakTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableView126560Test.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableView126560Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableView152857Test.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableView152857Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableViewMemoryLeak2Test.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableViewMemoryLeak2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeTableViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeView72765Test.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeView72765Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeViewExpandAllTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeViewExpandAllTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeViewQuickSearchTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeViewQuickSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/TreeViewTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/TreeViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/ViewUtilTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/ViewUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerNodeEventsOrderTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerNodeEventsOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerNodeQueueTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerNodeQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerNodeTest.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerSpeed95364Test.java
+++ b/openide.explorer/test/unit/src/org/openide/explorer/view/VisualizerSpeed95364Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/AbstractFileSystemCompat.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/AbstractFileSystemCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/CompatFileExtrasLkp.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/CompatFileExtrasLkp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/EnvironmentNotSupportedException.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/EnvironmentNotSupportedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/FileSystem$HtmlStatus.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/FileSystem$HtmlStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/FileSystem$Status.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/FileSystem$Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCapability.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCapability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCompat.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/JarFileSystemCompat.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/JarFileSystemCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/LocalFileSystemCompat.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/LocalFileSystemCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/MultiFileSystemCompat.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/MultiFileSystemCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/src/org/openide/filesystems/XMLFileSystemCompat.java
+++ b/openide.filesystems.compat8/src/org/openide/filesystems/XMLFileSystemCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.compat8/test/unit/src/org/openide/filesystems/FilesystemsAPICompatTest.java
+++ b/openide.filesystems.compat8/test/unit/src/org/openide/filesystems/FilesystemsAPICompatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/FileFilterSupport.java
+++ b/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/FileFilterSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/FileSystemStatus.java
+++ b/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/FileSystemStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/SharedClassObjectFactory.java
+++ b/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/SharedClassObjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/src/org/openide/filesystem/spi/FileChooserBuilderProvider.java
+++ b/openide.filesystems.nb/src/org/openide/filesystem/spi/FileChooserBuilderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/src/org/openide/filesystems/FileChooserBuilder.java
+++ b/openide.filesystems.nb/src/org/openide/filesystems/FileChooserBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/src/org/openide/filesystems/FileUIUtils.java
+++ b/openide.filesystems.nb/src/org/openide/filesystems/FileUIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/src/org/openide/filesystems/ImageDecorator.java
+++ b/openide.filesystems.nb/src/org/openide/filesystems/ImageDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/test/unit/src/org/netbeans/modules/openide/filesystems/FileFilterSupportTest.java
+++ b/openide.filesystems.nb/test/unit/src/org/netbeans/modules/openide/filesystems/FileFilterSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/test/unit/src/org/netbeans/modules/openide/filesystems/SharedClassObjectFactoryTest.java
+++ b/openide.filesystems.nb/test/unit/src/org/netbeans/modules/openide/filesystems/SharedClassObjectFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems.nb/test/unit/src/org/openide/filesystems/FileChooserBuilderTest.java
+++ b/openide.filesystems.nb/test/unit/src/org/openide/filesystems/FileChooserBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/META-INF/upgrade/FileObject.hint
+++ b/openide.filesystems/src/META-INF/upgrade/FileObject.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/META-INF/upgrade/FileUtil.hint
+++ b/openide.filesystems/src/META-INF/upgrade/FileUtil.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/META-INF/upgrade/Repository.hint
+++ b/openide.filesystems/src/META-INF/upgrade/Repository.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/DefaultURLMapperProxy.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/DefaultURLMapperProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/RecognizeInstanceFiles.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/RecognizeInstanceFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/DefaultParser.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/DefaultParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/FileElement.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/FileElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverImpl.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/Util.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/XMLMIMEComponent.java
+++ b/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/XMLMIMEComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/AbstractFileObject.java
+++ b/openide.filesystems/src/org/openide/filesystems/AbstractFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/AbstractFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/AbstractFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
+++ b/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/DeepListener.java
+++ b/openide.filesystems/src/org/openide/filesystems/DeepListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
+++ b/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/EventControl.java
+++ b/openide.filesystems/src/org/openide/filesystems/EventControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/ExternalUtil.java
+++ b/openide.filesystems/src/org/openide/filesystems/ExternalUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FCLSupport.java
+++ b/openide.filesystems/src/org/openide/filesystems/FCLSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FSException.java
+++ b/openide.filesystems/src/org/openide/filesystems/FSException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileAlreadyLockedException.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileAlreadyLockedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileAttributeEvent.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileAttributeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileChangeAdapter.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileChangeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileChangeImpl.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileChangeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileChangeListener.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileEvent.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileExtrasLkp.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileExtrasLkp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileLock.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileObject.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileObjectLineIterator.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileObjectLineIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileObjectLines.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileObjectLines.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileObjectLkp.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileObjectLkp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileRenameEvent.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileRenameEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileStateInvalidException.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileStateInvalidException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileStatusEvent.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileStatusEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileStatusListener.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileStatusListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileURL.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileURL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/JarArchiveRootProvider.java
+++ b/openide.filesystems/src/org/openide/filesystems/JarArchiveRootProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/ListenerList.java
+++ b/openide.filesystems/src/org/openide/filesystems/ListenerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/LocalFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/LocalFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/MIMEResolver.java
+++ b/openide.filesystems/src/org/openide/filesystems/MIMEResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/MIMESupport.java
+++ b/openide.filesystems/src/org/openide/filesystems/MIMESupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/MemoryFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/MemoryFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
+++ b/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/MultiFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/MultiFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/NbfsUtil.java
+++ b/openide.filesystems/src/org/openide/filesystems/NbfsUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/Ordering.java
+++ b/openide.filesystems/src/org/openide/filesystems/Ordering.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/PathElements.java
+++ b/openide.filesystems/src/org/openide/filesystems/PathElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/RecursiveListener.java
+++ b/openide.filesystems/src/org/openide/filesystems/RecursiveListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/RefreshRequest.java
+++ b/openide.filesystems/src/org/openide/filesystems/RefreshRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/Repository.java
+++ b/openide.filesystems/src/org/openide/filesystems/Repository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/RepositoryAdapter.java
+++ b/openide.filesystems/src/org/openide/filesystems/RepositoryAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/RepositoryEvent.java
+++ b/openide.filesystems/src/org/openide/filesystems/RepositoryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/RepositoryListener.java
+++ b/openide.filesystems/src/org/openide/filesystems/RepositoryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/RepositoryReorderedEvent.java
+++ b/openide.filesystems/src/org/openide/filesystems/RepositoryReorderedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/StatusDecorator.java
+++ b/openide.filesystems/src/org/openide/filesystems/StatusDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/StreamPool.java
+++ b/openide.filesystems/src/org/openide/filesystems/StreamPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/URLMapper.java
+++ b/openide.filesystems/src/org/openide/filesystems/URLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/annotations/LayerBuilder.java
+++ b/openide.filesystems/src/org/openide/filesystems/annotations/LayerBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
+++ b/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/annotations/LayerGenerationException.java
+++ b/openide.filesystems/src/org/openide/filesystems/annotations/LayerGenerationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/annotations/package-info.java
+++ b/openide.filesystems/src/org/openide/filesystems/annotations/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/spi/ArchiveRootProvider.java
+++ b/openide.filesystems/src/org/openide/filesystems/spi/ArchiveRootProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/src/org/openide/filesystems/spi/CustomInstanceFactory.java
+++ b/openide.filesystems/src/org/openide/filesystems/spi/CustomInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/META-INF/upgrade/FileObject.test
+++ b/openide.filesystems/test/unit/src/META-INF/upgrade/FileObject.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/META-INF/upgrade/FileUtil.test
+++ b/openide.filesystems/test/unit/src/META-INF/upgrade/FileUtil.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/FSFoldersInLookupTest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/FSFoldersInLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/RecognizeInstanceFilesTest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/RecognizeInstanceFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverImplTest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverMarshallTest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverMarshallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessorTest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMESupportLoggingTest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/MIMESupportLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/ReadJustOnceTest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/ReadJustOnceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/UserDefinedMIMETest.java
+++ b/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/UserDefinedMIMETest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/AbstractFolderTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/AbstractFolderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/AtomicActionTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/AtomicActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/AttrTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/AttrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/AttributesTestHidden.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/AttributesTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/ContentProviderTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/ContentProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/Count.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/Count.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/DeepListenerTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/DeepListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileChangeImplTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileChangeImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileObject227200Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileObject227200Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileObject75826Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileObject75826Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileSystemFactoryHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileSystemFactoryHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileSystemSuite.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileSystemSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileSystemTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileSystemTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileUtilJavaIOFileHidden.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileUtilJavaIOFileHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileUtilTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FileUtilTestHidden.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FileUtilTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FilesystemBugsTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FilesystemBugsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/FsMimeResolverTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/FsMimeResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/IsArchiveFileTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/IsArchiveFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/JarFileSystemHidden.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/JarFileSystemHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/JarFileSystemTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/JarFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemAttrTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemAttrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemExternalTouchTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemExternalTouchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/LocalFileSystemTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport48486Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport48486Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport49418Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport49418Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport68318Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport68318Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport69049Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupport69049Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupportHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupportHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupportResolversTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupportResolversTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupportTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MIMESupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MemoryFSTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MemoryFSTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MemoryFileSystemTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MemoryFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MfoOnSFSTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MfoOnSFSTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileObjectTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileObjectTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystem1Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystem1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystem2Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystem2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystem3Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystem3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemGetAttrTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemGetAttrTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemMaskTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemMaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemRefreshTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemRefreshTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemRevealTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemRevealTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemXMLTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiFileSystemXMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MultiThreadedTestCaseHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MultiThreadedTestCaseHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/MutilFileSystemLayeredDeliveryTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/MutilFileSystemLayeredDeliveryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/NoAWTTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/NoAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/OrderingTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/OrderingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryGetDefaultTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryGetDefaultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryIncludeTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryIncludeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/RepositoryTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/StreamPool50137Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/StreamPool50137Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/StreamPoolTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/StreamPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/SystemFileSystemTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/SystemFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/TempFileObjectTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/TempFileObjectTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/TestBaseHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/TestBaseHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/TestUtilHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/TestUtilHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapper50852Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapper50852Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapper50984Test.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapper50984Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperLookupTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTestHidden.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTestInternalHidden.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTestInternalHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/VoidValueTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/VoidValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/XMLFileSystemTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/XMLFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/XMLFileSystemTestHid.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/XMLFileSystemTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGeneratingProcessorTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGeneratingProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGenerationExceptionTest.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGenerationExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/test/StatFiles.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/test/StatFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.filesystems/test/unit/src/org/openide/filesystems/test/TestFileUtils.java
+++ b/openide.filesystems/test/unit/src/org/openide/filesystems/test/TestFileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/io/BridgingGetter.java
+++ b/openide.io/src/org/openide/io/BridgingGetter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/io/BridgingIOProvider.java
+++ b/openide.io/src/org/openide/io/BridgingIOProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/io/BridgingInputOutputProvider.java
+++ b/openide.io/src/org/openide/io/BridgingInputOutputProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/FoldHandle.java
+++ b/openide.io/src/org/openide/windows/FoldHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOColorLines.java
+++ b/openide.io/src/org/openide/windows/IOColorLines.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOColorPrint.java
+++ b/openide.io/src/org/openide/windows/IOColorPrint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOColors.java
+++ b/openide.io/src/org/openide/windows/IOColors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOContainer.java
+++ b/openide.io/src/org/openide/windows/IOContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOFolding.java
+++ b/openide.io/src/org/openide/windows/IOFolding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOPosition.java
+++ b/openide.io/src/org/openide/windows/IOPosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOProvider.java
+++ b/openide.io/src/org/openide/windows/IOProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOSelect.java
+++ b/openide.io/src/org/openide/windows/IOSelect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/IOTab.java
+++ b/openide.io/src/org/openide/windows/IOTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/InputOutput.java
+++ b/openide.io/src/org/openide/windows/InputOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/OutputEvent.java
+++ b/openide.io/src/org/openide/windows/OutputEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/OutputListener.java
+++ b/openide.io/src/org/openide/windows/OutputListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/src/org/openide/windows/OutputWriter.java
+++ b/openide.io/src/org/openide/windows/OutputWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.io/test/unit/src/org/openide/windows/IOFoldingTest.java
+++ b/openide.io/test/unit/src/org/openide/windows/IOFoldingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/META-INF/upgrade/org.openide.loaders.DataObject.hint
+++ b/openide.loaders/src/META-INF/upgrade/org.openide.loaders.DataObject.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/AWTTask.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/AWTTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/DataNodeUtils.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/DataNodeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectAccessor.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectEncodingQueryImplementation.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectEncodingQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectFactoryProcessor.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectFactoryProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/EntityCatalogImpl.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/EntityCatalogImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/FileEntityResolver.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/FileEntityResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/RuntimeCatalog.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/RuntimeCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/SimpleES.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/SimpleES.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/UIException.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/UIException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/openide/loaders/Unmodify.java
+++ b/openide.loaders/src/org/netbeans/modules/openide/loaders/Unmodify.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/templates/AttributeHandlerBridge.java
+++ b/openide.loaders/src/org/netbeans/modules/templates/AttributeHandlerBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/netbeans/modules/templates/DesktopTemplateAttributes.java
+++ b/openide.loaders/src/org/netbeans/modules/templates/DesktopTemplateAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/actions/FileSystemAction.java
+++ b/openide.loaders/src/org/openide/actions/FileSystemAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/actions/FileSystemRefreshAction.java
+++ b/openide.loaders/src/org/openide/actions/FileSystemRefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/actions/InstantiateAction.java
+++ b/openide.loaders/src/org/openide/actions/InstantiateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/actions/NewTemplateAction.java
+++ b/openide.loaders/src/org/openide/actions/NewTemplateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/actions/SaveAllAction.java
+++ b/openide.loaders/src/org/openide/actions/SaveAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/actions/SaveAsAction.java
+++ b/openide.loaders/src/org/openide/actions/SaveAsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/actions/SaveAsTemplateAction.java
+++ b/openide.loaders/src/org/openide/actions/SaveAsTemplateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/awt/DynaMenuModel.java
+++ b/openide.loaders/src/org/openide/awt/DynaMenuModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/awt/MenuBar.java
+++ b/openide.loaders/src/org/openide/awt/MenuBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/awt/Toolbar.java
+++ b/openide.loaders/src/org/openide/awt/Toolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/awt/ToolbarPool.java
+++ b/openide.loaders/src/org/openide/awt/ToolbarPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/BrokenDataShadow.java
+++ b/openide.loaders/src/org/openide/loaders/BrokenDataShadow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/ChangeableDataFilter.java
+++ b/openide.loaders/src/org/openide/loaders/ChangeableDataFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/ConnectionSupport.java
+++ b/openide.loaders/src/org/openide/loaders/ConnectionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/CreateFromTemplateAttributesProvider.java
+++ b/openide.loaders/src/org/openide/loaders/CreateFromTemplateAttributesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/CreateFromTemplateHandler.java
+++ b/openide.loaders/src/org/openide/loaders/CreateFromTemplateHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataFilter.java
+++ b/openide.loaders/src/org/openide/loaders/DataFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataFilterAll.java
+++ b/openide.loaders/src/org/openide/loaders/DataFilterAll.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataFolder.java
+++ b/openide.loaders/src/org/openide/loaders/DataFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataLdrActions.java
+++ b/openide.loaders/src/org/openide/loaders/DataLdrActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataLoader.java
+++ b/openide.loaders/src/org/openide/loaders/DataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataLoaderPool.java
+++ b/openide.loaders/src/org/openide/loaders/DataLoaderPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataNode.java
+++ b/openide.loaders/src/org/openide/loaders/DataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataObject.java
+++ b/openide.loaders/src/org/openide/loaders/DataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataObjectAccessorImpl.java
+++ b/openide.loaders/src/org/openide/loaders/DataObjectAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataObjectExistsException.java
+++ b/openide.loaders/src/org/openide/loaders/DataObjectExistsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataObjectNotFoundException.java
+++ b/openide.loaders/src/org/openide/loaders/DataObjectNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataObjectPool.java
+++ b/openide.loaders/src/org/openide/loaders/DataObjectPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataShadow.java
+++ b/openide.loaders/src/org/openide/loaders/DataShadow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DataTransferSupport.java
+++ b/openide.loaders/src/org/openide/loaders/DataTransferSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DefaultDataObject.java
+++ b/openide.loaders/src/org/openide/loaders/DefaultDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DefaultES.java
+++ b/openide.loaders/src/org/openide/loaders/DefaultES.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/DefaultSettingsContext.java
+++ b/openide.loaders/src/org/openide/loaders/DefaultSettingsContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/Environment.java
+++ b/openide.loaders/src/org/openide/loaders/Environment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/ExtensionList.java
+++ b/openide.loaders/src/org/openide/loaders/ExtensionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FileEntry.java
+++ b/openide.loaders/src/org/openide/loaders/FileEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FilesSet.java
+++ b/openide.loaders/src/org/openide/loaders/FilesSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderChildren.java
+++ b/openide.loaders/src/org/openide/loaders/FolderChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderChildrenPair.java
+++ b/openide.loaders/src/org/openide/loaders/FolderChildrenPair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderComparator.java
+++ b/openide.loaders/src/org/openide/loaders/FolderComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderInstance.java
+++ b/openide.loaders/src/org/openide/loaders/FolderInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderList.java
+++ b/openide.loaders/src/org/openide/loaders/FolderList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderListListener.java
+++ b/openide.loaders/src/org/openide/loaders/FolderListListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderLookup.java
+++ b/openide.loaders/src/org/openide/loaders/FolderLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderOrder.java
+++ b/openide.loaders/src/org/openide/loaders/FolderOrder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/FolderRenameHandler.java
+++ b/openide.loaders/src/org/openide/loaders/FolderRenameHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
+++ b/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/InstanceNode.java
+++ b/openide.loaders/src/org/openide/loaders/InstanceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/InstanceSupport.java
+++ b/openide.loaders/src/org/openide/loaders/InstanceSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/LoaderTransfer.java
+++ b/openide.loaders/src/org/openide/loaders/LoaderTransfer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/MimeFactory.java
+++ b/openide.loaders/src/org/openide/loaders/MimeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/MultiDOEditor.java
+++ b/openide.loaders/src/org/openide/loaders/MultiDOEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/MultiDataObject.java
+++ b/openide.loaders/src/org/openide/loaders/MultiDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/MultiFileLoader.java
+++ b/openide.loaders/src/org/openide/loaders/MultiFileLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/NewObjectPanel.java
+++ b/openide.loaders/src/org/openide/loaders/NewObjectPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/OpenSupport.java
+++ b/openide.loaders/src/org/openide/loaders/OpenSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/OperationAdapter.java
+++ b/openide.loaders/src/org/openide/loaders/OperationAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/OperationEvent.java
+++ b/openide.loaders/src/org/openide/loaders/OperationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/OperationListener.java
+++ b/openide.loaders/src/org/openide/loaders/OperationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/RepositoryNodeFactory.java
+++ b/openide.loaders/src/org/openide/loaders/RepositoryNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/SaveAsCapable.java
+++ b/openide.loaders/src/org/openide/loaders/SaveAsCapable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/ShadowChangeAdapter.java
+++ b/openide.loaders/src/org/openide/loaders/ShadowChangeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/SortModeEditor.java
+++ b/openide.loaders/src/org/openide/loaders/SortModeEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/TemplateWizard.java
+++ b/openide.loaders/src/org/openide/loaders/TemplateWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/TemplateWizard1.java
+++ b/openide.loaders/src/org/openide/loaders/TemplateWizard1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/TemplateWizardIterImpl.java
+++ b/openide.loaders/src/org/openide/loaders/TemplateWizardIterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/TemplateWizardIteratorWrapper.java
+++ b/openide.loaders/src/org/openide/loaders/TemplateWizardIteratorWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/UniFileLoader.java
+++ b/openide.loaders/src/org/openide/loaders/UniFileLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/XMLDataObject.java
+++ b/openide.loaders/src/org/openide/loaders/XMLDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/XMLDataObjectInfoParser.java
+++ b/openide.loaders/src/org/openide/loaders/XMLDataObjectInfoParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/loaders/XMLEntityResolverChain.java
+++ b/openide.loaders/src/org/openide/loaders/XMLEntityResolverChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/text/DataEditorSupport.java
+++ b/openide.loaders/src/org/openide/text/DataEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/src/org/openide/text/EditorSupport.java
+++ b/openide.loaders/src/org/openide/text/EditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/AWTTaskTest.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/AWTTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/DataObjectFactoryProcessorTest.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/DataObjectFactoryProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/DataShadowTranslateTest.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/DataShadowTranslateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/FileEntityResolver66438Test.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/FileEntityResolver66438Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/FileEntityResolverDeadlock54971Test.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/FileEntityResolverDeadlock54971Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/UIExceptionTest.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/UIExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPCustomLoader.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPCustomLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPDataObject.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPDataObjectCustomLoader.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPDataObjectCustomLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPDataObjectMultiple.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPDataObjectMultiple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPMIMEType.java
+++ b/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/data/DoFPMIMEType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/actions/FileSystemActionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/actions/FileSystemActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/actions/NewTemplateActionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/actions/NewTemplateActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/actions/SaveActionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/actions/SaveActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/actions/SaveAllActionGCTest.java
+++ b/openide.loaders/test/unit/src/org/openide/actions/SaveAllActionGCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/actions/SaveAllActionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/actions/SaveAllActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/actions/SaveAsActionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/actions/SaveAsActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/AWTTaskTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/AWTTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/CNFCompo.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/CNFCompo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/DynaMenuModelTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/DynaMenuModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/EmptyToolbarPoolTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/EmptyToolbarPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/MenuBarCNFETest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/MenuBarCNFETest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/MenuBarDeadlock163201Test.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/MenuBarDeadlock163201Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/MenuBarFastFromAWTTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/MenuBarFastFromAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/MenuBarNotInAWTTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/MenuBarNotInAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/MenuBarSeparatorInAWTTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/MenuBarSeparatorInAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/MenuBarTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/MenuBarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/ToolbarConfigurationDeadlockTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/ToolbarConfigurationDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/ToolbarPoolDeadlockTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/ToolbarPoolDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/ToolbarPoolTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/ToolbarPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/awt/ToolbarTest.java
+++ b/openide.loaders/test/unit/src/org/openide/awt/ToolbarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/AddLoaderManuallyHid.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/AddLoaderManuallyHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/AntProjectDataObjectProblemTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/AntProjectDataObjectProblemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/BasicDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/BasicDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindSlowVersionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindSlowVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFolderLookupFromHandleFindTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFolderLookupFromHandleFindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFromRenameTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFromRenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/ConnectionSupportTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/ConnectionSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/CreateFromTemplateHandlerTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/CreateFromTemplateHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/CreateFromTemplateTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/CreateFromTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderCopyMoreWindowsLikeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderCopyMoreWindowsLikeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderIndexTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderMoveTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderMoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderPasteTypesTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderPasteTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderRefreshTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderRefreshTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderSetOrderTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderSetOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderSlowDeletionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderSlowDeletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataFolderTimeOrderTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataFolderTimeOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataGetModifiedTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataGetModifiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderGetActionsCompatibilityTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderGetActionsCompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderGetActionsTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderGetActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderInLayerOnSFSTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderInLayerOnSFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderInLayerTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderInLayerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderOrigTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderOrigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderPoolOnlyEventsTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderPoolOnlyEventsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderPoolTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataMoveTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataMoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataNodeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataObjectInvalidationOneFileTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataObjectInvalidationOneFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataObjectInvalidationTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataObjectInvalidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataObjectPoolTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataObjectPoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataObjectSaveAsTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataObjectSaveAsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataObjectSizeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataObjectSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataReadOnlyTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataReadOnlyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataRenameTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataRenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataShadowBrokenAreNotQueriedTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataShadowBrokenAreNotQueriedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataShadowBrokenAreNotTestedTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataShadowBrokenAreNotTestedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataShadowLookupTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataShadowLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataShadowSlowness39981Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataShadowSlowness39981Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DataShadowTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DataShadowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/Deadlock35847Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/Deadlock35847Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/Deadlock38554Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/Deadlock38554Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/Deadlock51637Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/Deadlock51637Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/Deadlock59522Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/Deadlock59522Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/Deadlock60917Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/Deadlock60917Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectHasNodeInLookupTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectHasNodeInLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectHasOpenActionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectHasOpenActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectHasOpenTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectHasOpenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectLookupTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectMissingBinaryTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectMissingBinaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DefaultDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DefaultVersusXMLDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DefaultVersusXMLDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/DragAndDropDataNodeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/DragAndDropDataNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/ErrorThrownInFolderRecognizerTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/ErrorThrownInFolderRecognizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/ExtensionListTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/ExtensionListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FightWithWrongOrderInPathsTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FightWithWrongOrderInPathsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FightWithWrongOrderOfLoadersTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FightWithWrongOrderOfLoadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FileLookupViaDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FileLookupViaDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FileObjectInLookupByMatteoTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FileObjectInLookupByMatteoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FileObjectInLookupByMatteoWithInitializedCookieSetTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FileObjectInLookupByMatteoWithInitializedCookieSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FileObjectInLookupTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FileObjectInLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenFindTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenFindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenGCRaceConditionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenGCRaceConditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenInEQTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenInEQTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderChildrenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderComparatorTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderComparatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderInstanceListenersWithCookieTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderInstanceListenersWithCookieTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderInstanceTaskOrderTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderInstanceTaskOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderInstanceTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderInstanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderListTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderLookupBrokenListenersDontPreventQueriesTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderLookupBrokenListenersDontPreventQueriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderLookupTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderOrderIllegalTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderOrderIllegalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/FolderRenameHandlerTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/FolderRenameHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceCookieViaNodeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceCookieViaNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectGetNameTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectGetNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectHasEditorTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectHasEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectIssue47707Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectIssue47707Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectIssue71433Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectIssue71433Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectLookupWarningTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectLookupWarningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectRefreshesOnFileChangeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectRefreshesOnFileChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectSynchronizedTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectSynchronizedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/InstanceNodeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/InstanceNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/Issue136931Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/Issue136931Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/LoggingControlTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/LoggingControlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/LoggingTestCaseHid.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/LoggingTestCaseHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectContinuousTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectContinuousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectDeleteSecondaryEntryTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectDeleteSecondaryEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectFilesTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectVersion1Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/MultiDataObjectVersion1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/MultiFileLoaderHid.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/MultiFileLoaderHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/NewObjectPanelTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/NewObjectPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/NullPointer35897Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/NullPointer35897Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/OperationListenerTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/OperationListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/RefusesInvalidationTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/RefusesInvalidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/RejectOnCopyCreatesDefaultTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/RejectOnCopyCreatesDefaultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/Sample60M7ProblemWithGetDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/Sample60M7ProblemWithGetDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/SavableDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/SavableDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/SeparationOfThreadsTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/SeparationOfThreadsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/SlowNodeDelegateTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/SlowNodeDelegateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/SortModeEditorTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/SortModeEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/TemplateWizardTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/TemplateWizardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/TestUtilHid.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/TestUtilHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/UniFileLoaderSndEntryTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/UniFileLoaderSndEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectGetCookieTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectGetCookieTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectGetNoCookieTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectGetNoCookieTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectLifeLock68934Test.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectLifeLock68934Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectMimeTypeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectMimeTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectNodeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectSubclassTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectSubclassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectTest.java
+++ b/openide.loaders/test/unit/src/org/openide/loaders/XMLDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/AnnotationProviderTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/AnnotationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/DataEditorReadOnlyTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/DataEditorReadOnlyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportEncodingTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportEncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportMoveTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportMoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportSaveAsTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportSaveAsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/DataEditorSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/DocumentTitlePropertyTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/DocumentTitlePropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/EvenIfReadonlyItNeedsToThrowExceptionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/EvenIfReadonlyItNeedsToThrowExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/ExternalChangeOfModifiedFileTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/ExternalChangeOfModifiedFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/ExternalDeleteOfModifiedBigFileTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/ExternalDeleteOfModifiedBigFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/ExternalDeleteOfModifiedFileTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/ExternalDeleteOfModifiedFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/FileEncodingQueryDataEditorSupportTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/FileEncodingQueryDataEditorSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/FileSizeThreshholdExceptionTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/FileSizeThreshholdExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/PeterZMoveTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/PeterZMoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/PropertyChangeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/PropertyChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/RenameWithTimestampChangeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/RenameWithTimestampChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/SaveDocumentTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/SaveDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/SimpleCESHidden.java
+++ b/openide.loaders/test/unit/src/org/openide/text/SimpleCESHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/SimpleDESFactoryTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/SimpleDESFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/SimpleDESTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/SimpleDESTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/SimpleFactoryTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/SimpleFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/TemplatesMimeTypeTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/TemplatesMimeTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/TestFileSystem.java
+++ b/openide.loaders/test/unit/src/org/openide/text/TestFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.loaders/test/unit/src/org/openide/text/XMLCESTest.java
+++ b/openide.loaders/test/unit/src/org/openide/text/XMLCESTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/netbeans/modules/openide/modules/PatchedPublicProcessor.java
+++ b/openide.modules/src/org/netbeans/modules/openide/modules/PatchedPublicProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/ConstructorDelegate.java
+++ b/openide.modules/src/org/openide/modules/ConstructorDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/Dependency.java
+++ b/openide.modules/src/org/openide/modules/Dependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/InstalledFileLocator.java
+++ b/openide.modules/src/org/openide/modules/InstalledFileLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/ModuleInfo.java
+++ b/openide.modules/src/org/openide/modules/ModuleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/ModuleInstall.java
+++ b/openide.modules/src/org/openide/modules/ModuleInstall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/Modules.java
+++ b/openide.modules/src/org/openide/modules/Modules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/OnStart.java
+++ b/openide.modules/src/org/openide/modules/OnStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/OnStop.java
+++ b/openide.modules/src/org/openide/modules/OnStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/PatchFor.java
+++ b/openide.modules/src/org/openide/modules/PatchFor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/PatchedPublic.java
+++ b/openide.modules/src/org/openide/modules/PatchedPublic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/Places.java
+++ b/openide.modules/src/org/openide/modules/Places.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/src/org/openide/modules/SpecificationVersion.java
+++ b/openide.modules/src/org/openide/modules/SpecificationVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/test/unit/src/org/openide/modules/DependencyTest.java
+++ b/openide.modules/test/unit/src/org/openide/modules/DependencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/test/unit/src/org/openide/modules/PlacesTest.java
+++ b/openide.modules/test/unit/src/org/openide/modules/PlacesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/test/unit/src/org/openide/modules/SpecificationVersionTest.java
+++ b/openide.modules/test/unit/src/org/openide/modules/SpecificationVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.modules/test/unit/src/org/openide/modules/api/PlacesTestUtils.java
+++ b/openide.modules/test/unit/src/org/openide/modules/api/PlacesTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/META-INF/upgrade/org.openides.nodes.Node.hint
+++ b/openide.nodes/src/META-INF/upgrade/org.openides.nodes.Node.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
+++ b/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesRegistrationSupport.java
+++ b/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesRegistrationSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/CloseCookie.java
+++ b/openide.nodes/src/org/openide/cookies/CloseCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/ConnectionCookie.java
+++ b/openide.nodes/src/org/openide/cookies/ConnectionCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/EditCookie.java
+++ b/openide.nodes/src/org/openide/cookies/EditCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/FilterCookie.java
+++ b/openide.nodes/src/org/openide/cookies/FilterCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/InstanceCookie.java
+++ b/openide.nodes/src/org/openide/cookies/InstanceCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/OpenCookie.java
+++ b/openide.nodes/src/org/openide/cookies/OpenCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/PrintCookie.java
+++ b/openide.nodes/src/org/openide/cookies/PrintCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/SaveCookie.java
+++ b/openide.nodes/src/org/openide/cookies/SaveCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/cookies/ViewCookie.java
+++ b/openide.nodes/src/org/openide/cookies/ViewCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/AbstractNode.java
+++ b/openide.nodes/src/org/openide/nodes/AbstractNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/AsynchChildren.java
+++ b/openide.nodes/src/org/openide/nodes/AsynchChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/BeanChildren.java
+++ b/openide.nodes/src/org/openide/nodes/BeanChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/BeanInfoSearchPath.java
+++ b/openide.nodes/src/org/openide/nodes/BeanInfoSearchPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/BeanNode.java
+++ b/openide.nodes/src/org/openide/nodes/BeanNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/ChildFactory.java
+++ b/openide.nodes/src/org/openide/nodes/ChildFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/Children.java
+++ b/openide.nodes/src/org/openide/nodes/Children.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/ChildrenArray.java
+++ b/openide.nodes/src/org/openide/nodes/ChildrenArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/CookieSet.java
+++ b/openide.nodes/src/org/openide/nodes/CookieSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/CookieSetLkp.java
+++ b/openide.nodes/src/org/openide/nodes/CookieSetLkp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/DefaultHandle.java
+++ b/openide.nodes/src/org/openide/nodes/DefaultHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/DestroyableNodesFactory.java
+++ b/openide.nodes/src/org/openide/nodes/DestroyableNodesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/EntrySupport.java
+++ b/openide.nodes/src/org/openide/nodes/EntrySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
+++ b/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/EntrySupportLazy.java
+++ b/openide.nodes/src/org/openide/nodes/EntrySupportLazy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/EntrySupportLazyState.java
+++ b/openide.nodes/src/org/openide/nodes/EntrySupportLazyState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/FilterNode.java
+++ b/openide.nodes/src/org/openide/nodes/FilterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/Index.java
+++ b/openide.nodes/src/org/openide/nodes/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/IndexedCustomizer.java
+++ b/openide.nodes/src/org/openide/nodes/IndexedCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/IndexedNode.java
+++ b/openide.nodes/src/org/openide/nodes/IndexedNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/IndexedPropertySupport.java
+++ b/openide.nodes/src/org/openide/nodes/IndexedPropertySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/LazyNode.java
+++ b/openide.nodes/src/org/openide/nodes/LazyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/Node.java
+++ b/openide.nodes/src/org/openide/nodes/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeAcceptor.java
+++ b/openide.nodes/src/org/openide/nodes/NodeAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeAdapter.java
+++ b/openide.nodes/src/org/openide/nodes/NodeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeEvent.java
+++ b/openide.nodes/src/org/openide/nodes/NodeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeListener.java
+++ b/openide.nodes/src/org/openide/nodes/NodeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeLookup.java
+++ b/openide.nodes/src/org/openide/nodes/NodeLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeMemberEvent.java
+++ b/openide.nodes/src/org/openide/nodes/NodeMemberEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeNotFoundException.java
+++ b/openide.nodes/src/org/openide/nodes/NodeNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeOp.java
+++ b/openide.nodes/src/org/openide/nodes/NodeOp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeOperation.java
+++ b/openide.nodes/src/org/openide/nodes/NodeOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeReorderEvent.java
+++ b/openide.nodes/src/org/openide/nodes/NodeReorderEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/NodeTransfer.java
+++ b/openide.nodes/src/org/openide/nodes/NodeTransfer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/PropertyEditorRegistration.java
+++ b/openide.nodes/src/org/openide/nodes/PropertyEditorRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/PropertyEditorSearchPath.java
+++ b/openide.nodes/src/org/openide/nodes/PropertyEditorSearchPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/PropertySupport.java
+++ b/openide.nodes/src/org/openide/nodes/PropertySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/Sheet.java
+++ b/openide.nodes/src/org/openide/nodes/Sheet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/SynchChildren.java
+++ b/openide.nodes/src/org/openide/nodes/SynchChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/nodes/TMUtil.java
+++ b/openide.nodes/src/org/openide/nodes/TMUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/util/actions/CookieAction.java
+++ b/openide.nodes/src/org/openide/util/actions/CookieAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/src/org/openide/util/actions/NodeAction.java
+++ b/openide.nodes/src/org/openide/util/actions/NodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/META-INF/upgrade/org.openides.nodes.Node.test
+++ b/openide.nodes/test/unit/src/META-INF/upgrade/org.openides.nodes.Node.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PEAnnotationProcessorTest.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PEAnnotationProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PELookupTest.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PELookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PERegistrationSupportTest.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PERegistrationSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/TestPropertyEditor.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/TestPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/package-info.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/AbstractNodeTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/AbstractNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/AddRemoveNotifyRaceConditionTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/AddRemoveNotifyRaceConditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/AntProjectCookieSetProblemTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/AntProjectCookieSetProblemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/BadBeanHidden.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/BadBeanHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/Bean21341Hidden.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/Bean21341Hidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/Bean21341HiddenBeanInfo.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/Bean21341HiddenBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/BeanChildrenTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/BeanChildrenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/BeanNodeBug21285.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/BeanNodeBug21285.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/BeanNodeBug21341.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/BeanNodeBug21341.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/BeanNodeTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/BeanNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildFactoryTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayLazyTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayLazyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayNodeAtShouldNotBeSlowTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayNodeAtShouldNotBeSlowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenAsUsedInExplorerTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenAsUsedInExplorerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsArrayTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsKeysArrayTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsKeysArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsKeysTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsLazyArrayTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsLazyArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsLazyKeysTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenFilterAsLazyKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenInitializedMeanwhileTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenInitializedMeanwhileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysAsArrayTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysAsArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysAsLazyArrayTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysAsLazyArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysGarbageCollectTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysGarbageCollectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysIssue30907Test.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysIssue30907Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenLazyAsUsedInExplorerTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenLazyAsUsedInExplorerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenLazyKeysTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenLazyKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenMapTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/ChildrenTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/ChildrenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/CookieSetCompatibilityTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/CookieSetCompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/CookieSetTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/CookieSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/EntrySupportLazyStateTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/EntrySupportLazyStateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/FilterChildrenEventsTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/FilterChildrenEventsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/FilterNodeTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/FilterNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/IndexedNodeTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/IndexedNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/Issue147465Test.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/Issue147465Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/LazyChildrenKeysTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/LazyChildrenKeysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/LazyNodeTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/LazyNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/NodeHtmlTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/NodeHtmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/NodeListenerTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/NodeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/NodeLookupDelayedTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/NodeLookupDelayedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/NodeLookupTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/NodeLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/NodeOpTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/NodeOpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/NodeProperty51907Test.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/NodeProperty51907Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/NodeTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/NodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/OpenAction.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/OpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/PropertiesTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/PropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/PropertySupportTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/PropertySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/SetChildrenTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/SetChildrenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/nodes/SheetTest.java
+++ b/openide.nodes/test/unit/src/org/openide/nodes/SheetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/util/actions/CookieAction2Test.java
+++ b/openide.nodes/test/unit/src/org/openide/util/actions/CookieAction2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/util/actions/CookieAction84636Test.java
+++ b/openide.nodes/test/unit/src/org/openide/util/actions/CookieAction84636Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/util/actions/CookieActionIsTooSlowTest.java
+++ b/openide.nodes/test/unit/src/org/openide/util/actions/CookieActionIsTooSlowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/util/actions/CookieActionTest.java
+++ b/openide.nodes/test/unit/src/org/openide/util/actions/CookieActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/util/actions/Issue71764Test.java
+++ b/openide.nodes/test/unit/src/org/openide/util/actions/Issue71764Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/util/actions/NodeActionTest.java
+++ b/openide.nodes/test/unit/src/org/openide/util/actions/NodeActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.nodes/test/unit/src/org/openide/util/actions/NodeActionsInfraHid.java
+++ b/openide.nodes/test/unit/src/org/openide/util/actions/NodeActionsInfraHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/explorer/propertysheet/PropertySheetSettings.java
+++ b/openide.options/src/org/openide/explorer/propertysheet/PropertySheetSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/options/ContextSystemOption.java
+++ b/openide.options/src/org/openide/options/ContextSystemOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/options/ContextSystemOptionBeanInfo.java
+++ b/openide.options/src/org/openide/options/ContextSystemOptionBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/options/SystemOption.java
+++ b/openide.options/src/org/openide/options/SystemOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/options/SystemOptionBeanInfo.java
+++ b/openide.options/src/org/openide/options/SystemOptionBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/options/VetoSystemOption.java
+++ b/openide.options/src/org/openide/options/VetoSystemOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/text/NbDocument$Colors.java
+++ b/openide.options/src/org/openide/text/NbDocument$Colors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/text/PrintSettings.java
+++ b/openide.options/src/org/openide/text/PrintSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/src/org/openide/text/PrintSettingsBeanInfo.java
+++ b/openide.options/src/org/openide/text/PrintSettingsBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.options/test/unit/src/org/openide/options/SystemOptionTest.java
+++ b/openide.options/test/unit/src/org/openide/options/SystemOptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/netbeans/modules/openide/text/Installer.java
+++ b/openide.text/src/org/netbeans/modules/openide/text/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/cookies/EditorCookie.java
+++ b/openide.text/src/org/openide/cookies/EditorCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/cookies/LineCookie.java
+++ b/openide.text/src/org/openide/cookies/LineCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/ActiveEditorDrop.java
+++ b/openide.text/src/org/openide/text/ActiveEditorDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/Annotatable.java
+++ b/openide.text/src/org/openide/text/Annotatable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/Annotation.java
+++ b/openide.text/src/org/openide/text/Annotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/AnnotationProvider.java
+++ b/openide.text/src/org/openide/text/AnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/AttributedCharacters.java
+++ b/openide.text/src/org/openide/text/AttributedCharacters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/BackwardPosition.java
+++ b/openide.text/src/org/openide/text/BackwardPosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/CloneableEditor.java
+++ b/openide.text/src/org/openide/text/CloneableEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/CloneableEditorInitializer.java
+++ b/openide.text/src/org/openide/text/CloneableEditorInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/CloneableEditorSupport.java
+++ b/openide.text/src/org/openide/text/CloneableEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/CloneableEditorSupportRedirector.java
+++ b/openide.text/src/org/openide/text/CloneableEditorSupportRedirector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/DefaultPrintable.java
+++ b/openide.text/src/org/openide/text/DefaultPrintable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/DocumentLine.java
+++ b/openide.text/src/org/openide/text/DocumentLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/DocumentOpenClose.java
+++ b/openide.text/src/org/openide/text/DocumentOpenClose.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/DocumentStatus.java
+++ b/openide.text/src/org/openide/text/DocumentStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/EditorSupportLineSet.java
+++ b/openide.text/src/org/openide/text/EditorSupportLineSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/EnhancedChangeEvent.java
+++ b/openide.text/src/org/openide/text/EnhancedChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/FilterDocument.java
+++ b/openide.text/src/org/openide/text/FilterDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/FilterStyledDocument.java
+++ b/openide.text/src/org/openide/text/FilterStyledDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/IndentEngine.java
+++ b/openide.text/src/org/openide/text/IndentEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/LazyLines.java
+++ b/openide.text/src/org/openide/text/LazyLines.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/Line.java
+++ b/openide.text/src/org/openide/text/Line.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/LineListener.java
+++ b/openide.text/src/org/openide/text/LineListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/LineStruct.java
+++ b/openide.text/src/org/openide/text/LineStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/LineVector.java
+++ b/openide.text/src/org/openide/text/LineVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/NbDocument.java
+++ b/openide.text/src/org/openide/text/NbDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/PositionBounds.java
+++ b/openide.text/src/org/openide/text/PositionBounds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/PositionRef.java
+++ b/openide.text/src/org/openide/text/PositionRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/PrintPreferences.java
+++ b/openide.text/src/org/openide/text/PrintPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/QuietEditorPane.java
+++ b/openide.text/src/org/openide/text/QuietEditorPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/StableCompoundEdit.java
+++ b/openide.text/src/org/openide/text/StableCompoundEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/UndoRedoManager.java
+++ b/openide.text/src/org/openide/text/UndoRedoManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/UserQuestionExceptionHandler.java
+++ b/openide.text/src/org/openide/text/UserQuestionExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/src/org/openide/text/WrapUndoEdit.java
+++ b/openide.text/src/org/openide/text/WrapUndoEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditor143143Test.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditor143143Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorAssociateTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorAssociateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorCreationFinishedTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorCreationFinishedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorDocumentGCTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorDocumentGCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorDoubleLoadingTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorDoubleLoadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorNeverendingLoadingAsync2Test.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorNeverendingLoadingAsync2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorNeverendingLoadingAsyncTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorNeverendingLoadingAsyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorNeverendingLoadingTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorNeverendingLoadingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorRecentPaneTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorRecentPaneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportCOSRedirectorTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportCOSRedirectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportDoubleSaveTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportDoubleSaveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportOpenCloseTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportOpenCloseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportPaneAsyncTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportPaneAsyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportPaneTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportPaneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportRedirectorTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportRedirectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportSaveTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportSaveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorUserQuestionAsync2Test.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorUserQuestionAsync2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorUserQuestionAsyncTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorUserQuestionAsyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/CloneableEditorUserQuestionTest.java
+++ b/openide.text/test/unit/src/org/openide/text/CloneableEditorUserQuestionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Deadlock169717Test.java
+++ b/openide.text/test/unit/src/org/openide/text/Deadlock169717Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Deadlock207571Test.java
+++ b/openide.text/test/unit/src/org/openide/text/Deadlock207571Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Deadlock40766Test.java
+++ b/openide.text/test/unit/src/org/openide/text/Deadlock40766Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Deadlock47515Test.java
+++ b/openide.text/test/unit/src/org/openide/text/Deadlock47515Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Deadlock49178Test.java
+++ b/openide.text/test/unit/src/org/openide/text/Deadlock49178Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Deadlock56413Test.java
+++ b/openide.text/test/unit/src/org/openide/text/Deadlock56413Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/DocumentCannotBeClosedWhenAWTBlockedTest.java
+++ b/openide.text/test/unit/src/org/openide/text/DocumentCannotBeClosedWhenAWTBlockedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/DocumentCannotBeClosedWhenReadLockedTest.java
+++ b/openide.text/test/unit/src/org/openide/text/DocumentCannotBeClosedWhenReadLockedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/EditToBeUndoneRedoneTest.java
+++ b/openide.text/test/unit/src/org/openide/text/EditToBeUndoneRedoneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/EmptyCESHidden.java
+++ b/openide.text/test/unit/src/org/openide/text/EmptyCESHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/ExternalChangeOfModifiedContentTest.java
+++ b/openide.text/test/unit/src/org/openide/text/ExternalChangeOfModifiedContentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/ExternalDeleteOfModifiedContentTest.java
+++ b/openide.text/test/unit/src/org/openide/text/ExternalDeleteOfModifiedContentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/InitializeBug132662Test.java
+++ b/openide.text/test/unit/src/org/openide/text/InitializeBug132662Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/InitializeInAWTTest.java
+++ b/openide.text/test/unit/src/org/openide/text/InitializeInAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/InitializeOnBackgroundTest.java
+++ b/openide.text/test/unit/src/org/openide/text/InitializeOnBackgroundTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/LineSetTest.java
+++ b/openide.text/test/unit/src/org/openide/text/LineSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/LoadMultipleDocsTest.java
+++ b/openide.text/test/unit/src/org/openide/text/LoadMultipleDocsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/NbDocumentTest.java
+++ b/openide.text/test/unit/src/org/openide/text/NbDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/NbLikeEditorKit.java
+++ b/openide.text/test/unit/src/org/openide/text/NbLikeEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/NetworkConnectionLostTest.java
+++ b/openide.text/test/unit/src/org/openide/text/NetworkConnectionLostTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/NotifyModifiedOnNbEditorLikeKitTest.java
+++ b/openide.text/test/unit/src/org/openide/text/NotifyModifiedOnNbEditorLikeKitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/NotifyModifiedTest.java
+++ b/openide.text/test/unit/src/org/openide/text/NotifyModifiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/PositionRefTest.java
+++ b/openide.text/test/unit/src/org/openide/text/PositionRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/PrintPreferencesTest.java
+++ b/openide.text/test/unit/src/org/openide/text/PrintPreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/ReloadOnNbLikeEditorKitTest.java
+++ b/openide.text/test/unit/src/org/openide/text/ReloadOnNbLikeEditorKitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/ReloadTest.java
+++ b/openide.text/test/unit/src/org/openide/text/ReloadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/ReusableEditor2Test.java
+++ b/openide.text/test/unit/src/org/openide/text/ReusableEditor2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/ReusableEditorTest.java
+++ b/openide.text/test/unit/src/org/openide/text/ReusableEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Starvation37045SecondTest.java
+++ b/openide.text/test/unit/src/org/openide/text/Starvation37045SecondTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/Starvation37045Test.java
+++ b/openide.text/test/unit/src/org/openide/text/Starvation37045Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/TextTest.java
+++ b/openide.text/test/unit/src/org/openide/text/TextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/UndoRedoCooperationTest.java
+++ b/openide.text/test/unit/src/org/openide/text/UndoRedoCooperationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/UndoRedoTest.java
+++ b/openide.text/test/unit/src/org/openide/text/UndoRedoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/UndoRedoWrappingCooperationTest.java
+++ b/openide.text/test/unit/src/org/openide/text/UndoRedoWrappingCooperationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/UndoRedoWrappingExampleTest.java
+++ b/openide.text/test/unit/src/org/openide/text/UndoRedoWrappingExampleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/WrapEditorComponentTest.java
+++ b/openide.text/test/unit/src/org/openide/text/WrapEditorComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.text/test/unit/src/org/openide/text/XMLCESTest.java
+++ b/openide.text/test/unit/src/org/openide/text/XMLCESTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/AlterEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/AlterEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/ArrayEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/ArrayEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/EmptyEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/EmptyEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/FilterEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/FilterEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/QueueEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/QueueEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/RemoveDuplicatesEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/RemoveDuplicatesEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/SequenceEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/SequenceEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/src/org/openide/util/enum/SingletonEnumeration.java
+++ b/openide.util.enumerations/src/org/openide/util/enum/SingletonEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.enumerations/test/unit/src/org/openide/util/enum/OldEnumerationsTest.java
+++ b/openide.util.enumerations/test/unit/src/org/openide/util/enum/OldEnumerationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/META-INF/upgrade/org.openide.util.Lookup.hint
+++ b/openide.util.lookup/src/META-INF/upgrade/org.openide.util.Lookup.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/netbeans/modules/openide/util/GlobalLookup.java
+++ b/openide.util.lookup/src/org/netbeans/modules/openide/util/GlobalLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
+++ b/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/netbeans/modules/openide/util/ServiceProviderProcessor.java
+++ b/openide.util.lookup/src/org/netbeans/modules/openide/util/ServiceProviderProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/Lookup.java
+++ b/openide.util.lookup/src/org/openide/util/Lookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/LookupEvent.java
+++ b/openide.util.lookup/src/org/openide/util/LookupEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/LookupListener.java
+++ b/openide.util.lookup/src/org/openide/util/LookupListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/ALPairComparator.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/ALPairComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/AbstractLookup.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/AbstractLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/ArrayStorage.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/ArrayStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/DelegatingStorage.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/DelegatingStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/ExcludingLookup.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/ExcludingLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/InheritanceTree.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/InheritanceTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/InstanceContent.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/InstanceContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/LookupListenerList.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/LookupListenerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/Lookups.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/Lookups.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/MetaInfCache.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/MetaInfCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/MetaInfServicesLookup.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/MetaInfServicesLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/NamedServiceDefinition.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/NamedServiceDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/ServiceProvider.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/ServiceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/ServiceProviders.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/ServiceProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/SimpleLookup.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/SimpleLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/SimpleProxyLookup.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/SimpleProxyLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/SingletonLookup.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/SingletonLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/WaitableResult.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/WaitableResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/implspi/AbstractServiceProviderProcessor.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/implspi/AbstractServiceProviderProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/implspi/ActiveQueue.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/implspi/ActiveQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/implspi/NamedServicesProvider.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/implspi/NamedServicesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/implspi/ServiceLoaderLine.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/implspi/ServiceLoaderLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/implspi/SharedClassObjectBridge.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/implspi/SharedClassObjectBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/src/org/openide/util/lookup/implspi/package-info.java
+++ b/openide.util.lookup/src/org/openide/util/lookup/implspi/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/META-INF/upgrade/org.openide.util.Lookup.test
+++ b/openide.util.lookup/test/unit/src/META-INF/upgrade/org.openide.util.Lookup.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/bar/Comparator2.java
+++ b/openide.util.lookup/test/unit/src/org/bar/Comparator2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/bar/Comparator3.java
+++ b/openide.util.lookup/test/unit/src/org/bar/Comparator3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/bar/Implementation2.java
+++ b/openide.util.lookup/test/unit/src/org/bar/Implementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/bar/Iterator2.java
+++ b/openide.util.lookup/test/unit/src/org/bar/Iterator2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/Filling.java
+++ b/openide.util.lookup/test/unit/src/org/baz/Filling.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/MyService.java
+++ b/openide.util.lookup/test/unit/src/org/baz/MyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/Padding.java
+++ b/openide.util.lookup/test/unit/src/org/baz/Padding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/MyServiceImpl.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/MyServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/OtherServiceImpl.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/OtherServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl1.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl2.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl3.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl4.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl5.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl5.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl6.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl6.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl7.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl7.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl8.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl8.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl9.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImpl9.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplA.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplB.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplC.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplD.java
+++ b/openide.util.lookup/test/unit/src/org/baz/impl/PaddingImplD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/foo/Interface.java
+++ b/openide.util.lookup/test/unit/src/org/foo/Interface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/foo/impl/Comparator1.java
+++ b/openide.util.lookup/test/unit/src/org/foo/impl/Comparator1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/foo/impl/Implementation1.java
+++ b/openide.util.lookup/test/unit/src/org/foo/impl/Implementation1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/foo/impl/Iterator1.java
+++ b/openide.util.lookup/test/unit/src/org/foo/impl/Iterator1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/foo/impl/Runnable1.java
+++ b/openide.util.lookup/test/unit/src/org/foo/impl/Runnable1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/ActiveQueueTest.java
+++ b/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/ActiveQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/NamedServiceProcessorTest.java
+++ b/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/NamedServiceProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/ServiceProviderProcessorTest.java
+++ b/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/ServiceProviderProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupArrayStorageTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupArrayStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupAsynchExecutorTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupAsynchExecutorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupBaseHid.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupBaseHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupExecutorTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupExecutorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupMemoryTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ExcludingLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ExcludingLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/InheritanceTreeTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/InheritanceTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/InitializationBug44134Test.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/InitializationBug44134Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/KomrskaLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/KomrskaLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ListenersIgnoredTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ListenersIgnoredTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupBugTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupBugTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupGetDefaultTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupGetDefaultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupListenerListTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupListenerListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupPermGenLeakTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupPermGenLeakTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupsProxyTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/LookupsProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfCacheTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTestRunnable.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTestRunnable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesOrderingTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesOrderingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesProxyTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/NamedServicesLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/NamedServicesLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/PathInLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/PathInLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/PrefixServicesLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/PrefixServicesLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookup173975Test.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookup173975Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupAvoidBeforeTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupAvoidBeforeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupEventIssue136866Test.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupEventIssue136866Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupResultListenerTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupResultListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyProxyLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyProxyLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleProxyLookupIssue42244Test.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleProxyLookupIssue42244Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleProxyLookupSpeedIssue42244Test.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleProxyLookupSpeedIssue42244Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleProxyLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/SimpleProxyLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/SingletonLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/SingletonLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/lookup/implspi/ServiceLoaderLineTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/lookup/implspi/ServiceLoaderLineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/test/AnnotationProcessorTestUtils.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/test/AnnotationProcessorTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/test/MockLookup.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/test/MockLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.lookup/test/unit/src/org/openide/util/test/MockLookupTest.java
+++ b/openide.util.lookup/test/unit/src/org/openide/util/test/MockLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/META-INF/upgrade/ImageUtilities.hint
+++ b/openide.util.ui/src/META-INF/upgrade/ImageUtilities.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/META-INF/upgrade/NbBundle.hint
+++ b/openide.util.ui/src/META-INF/upgrade/NbBundle.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/META-INF/upgrade/Utilities.hint
+++ b/openide.util.ui/src/META-INF/upgrade/Utilities.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
+++ b/openide.util.ui/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/netbeans/modules/openide/util/NbMutexEventProvider.java
+++ b/openide.util.ui/src/org/netbeans/modules/openide/util/NbMutexEventProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/ErrorManager.java
+++ b/openide.util.ui/src/org/openide/ErrorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/LifecycleManager.java
+++ b/openide.util.ui/src/org/openide/LifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/ServiceType.java
+++ b/openide.util.ui/src/org/openide/ServiceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/AsyncGUIJob.java
+++ b/openide.util.ui/src/org/openide/util/AsyncGUIJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/AsyncInitSupport.java
+++ b/openide.util.ui/src/org/openide/util/AsyncInitSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/ContextAwareAction.java
+++ b/openide.util.ui/src/org/openide/util/ContextAwareAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/ContextGlobalProvider.java
+++ b/openide.util.ui/src/org/openide/util/ContextGlobalProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/HelpCtx.java
+++ b/openide.util.ui/src/org/openide/util/HelpCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/NetworkSettings.java
+++ b/openide.util.ui/src/org/openide/util/NetworkSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/Queue.java
+++ b/openide.util.ui/src/org/openide/util/Queue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/SharedClassObject.java
+++ b/openide.util.ui/src/org/openide/util/SharedClassObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/UserCancelException.java
+++ b/openide.util.ui/src/org/openide/util/UserCancelException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/UserQuestionException.java
+++ b/openide.util.ui/src/org/openide/util/UserQuestionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/openide.util.ui/src/org/openide/util/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/UtilitiesCompositeActionMap.java
+++ b/openide.util.ui/src/org/openide/util/UtilitiesCompositeActionMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/ActionInvoker.java
+++ b/openide.util.ui/src/org/openide/util/actions/ActionInvoker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/ActionPerformer.java
+++ b/openide.util.ui/src/org/openide/util/actions/ActionPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/ActionPresenterProvider.java
+++ b/openide.util.ui/src/org/openide/util/actions/ActionPresenterProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/BooleanStateAction.java
+++ b/openide.util.ui/src/org/openide/util/actions/BooleanStateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/CallableSystemAction.java
+++ b/openide.util.ui/src/org/openide/util/actions/CallableSystemAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
+++ b/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/Presenter.java
+++ b/openide.util.ui/src/org/openide/util/actions/Presenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/actions/SystemAction.java
+++ b/openide.util.ui/src/org/openide/util/actions/SystemAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/ClipboardEvent.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/ClipboardEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/ClipboardListener.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/ClipboardListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/ExClipboard.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/ExClipboard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/ExTransferable.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/ExTransferable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/MultiTransferObject.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/MultiTransferObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/NewType.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/NewType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/PasteType.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/PasteType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/src/org/openide/util/datatransfer/TransferListener.java
+++ b/openide.util.ui/src/org/openide/util/datatransfer/TransferListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/META-INF/upgrade/NbBundle.test
+++ b/openide.util.ui/test/unit/src/META-INF/upgrade/NbBundle.test
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/netbeans/modules/openide/util/NbBundleProcessorTest.java
+++ b/openide.util.ui/test/unit/src/org/netbeans/modules/openide/util/NbBundleProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/netbeans/modules/openide/util/ProxyURLStreamHandlerFactoryTest.java
+++ b/openide.util.ui/test/unit/src/org/netbeans/modules/openide/util/ProxyURLStreamHandlerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/ErrorManagerCyclicDepTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/ErrorManagerCyclicDepTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/ErrorManagerDelegatesToLoggingTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/ErrorManagerDelegatesToLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/ErrorManagerTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/ErrorManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/LifecycleManagerEDTTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/LifecycleManagerEDTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/LifecycleManagerTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/LifecycleManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesGetLoaderTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesGetLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/MutexTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/MutexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/NetworkSettingsTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/NetworkSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/RequestProcessorLookupGetDefaultTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/RequestProcessorLookupGetDefaultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/SharedClassObjectTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/SharedClassObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/UtilitiesActionsTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/UtilitiesActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/UtilitiesFileURLConvertorTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/UtilitiesFileURLConvertorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/UtilitiesProgressCursorTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/UtilitiesProgressCursorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/UtilitiesTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/UtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/UtilitiesTranslateTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/UtilitiesTranslateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/actions/ActionsInfraHid.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/actions/ActionsInfraHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/actions/AsynchronousTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/actions/AsynchronousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/actions/BooleanStateActionTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/actions/BooleanStateActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/actions/CallbackSystemActionConcurrentTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/actions/CallbackSystemActionConcurrentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/actions/CallbackSystemActionTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/actions/CallbackSystemActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/actions/SystemActionTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/actions/SystemActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/datatransfer/ExClipboardTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/datatransfer/ExClipboardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/datatransfer/ExTransferableTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/datatransfer/ExTransferableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/io/ReaderInputStreamTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/io/ReaderInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/io/SafeExceptionTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/io/SafeExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/io/SerializationEnumTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/io/SerializationEnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/JarBuilder.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/JarBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/MockChangeListener.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/MockChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/MockChangeListenerTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/MockChangeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/MockPropertyChangeListenerTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/MockPropertyChangeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/RestrictThreadCreation.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/RestrictThreadCreation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/TestFileUtils.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/TestFileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/util/test/package-info.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/test/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilReflectionTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilReflectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/netbeans/modules/openide/util/Compact2MutexEventProvider.java
+++ b/openide.util/src/org/netbeans/modules/openide/util/Compact2MutexEventProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/netbeans/modules/openide/util/DefaultMutexImplementation.java
+++ b/openide.util/src/org/netbeans/modules/openide/util/DefaultMutexImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/netbeans/modules/openide/util/LazyMutexImplementation.java
+++ b/openide.util/src/org/netbeans/modules/openide/util/LazyMutexImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
+++ b/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/netbeans/modules/openide/util/ProxyURLStreamHandlerFactory.java
+++ b/openide.util/src/org/netbeans/modules/openide/util/ProxyURLStreamHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/BaseUtilities.java
+++ b/openide.util/src/org/openide/util/BaseUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Cancellable.java
+++ b/openide.util/src/org/openide/util/Cancellable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/ChangeSupport.java
+++ b/openide.util/src/org/openide/util/ChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/CharSequences.java
+++ b/openide.util/src/org/openide/util/CharSequences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/EditableProperties.java
+++ b/openide.util/src/org/openide/util/EditableProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Enumerations.java
+++ b/openide.util/src/org/openide/util/Enumerations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Exceptions.java
+++ b/openide.util/src/org/openide/util/Exceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/MapFormat.java
+++ b/openide.util/src/org/openide/util/MapFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Mutex.java
+++ b/openide.util/src/org/openide/util/Mutex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/MutexException.java
+++ b/openide.util/src/org/openide/util/MutexException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/NbBundle.java
+++ b/openide.util/src/org/openide/util/NbBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/NbCollections.java
+++ b/openide.util/src/org/openide/util/NbCollections.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/NbPreferences.java
+++ b/openide.util/src/org/openide/util/NbPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/NotImplementedException.java
+++ b/openide.util/src/org/openide/util/NotImplementedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Pair.java
+++ b/openide.util/src/org/openide/util/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Parameters.java
+++ b/openide.util/src/org/openide/util/Parameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/RE13.java
+++ b/openide.util/src/org/openide/util/RE13.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/RequestProcessor.java
+++ b/openide.util/src/org/openide/util/RequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Task.java
+++ b/openide.util/src/org/openide/util/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/TaskListener.java
+++ b/openide.util/src/org/openide/util/TaskListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/TimedSoftReference.java
+++ b/openide.util/src/org/openide/util/TimedSoftReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/TopologicalSortException.java
+++ b/openide.util/src/org/openide/util/TopologicalSortException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/URLStreamHandlerRegistration.java
+++ b/openide.util/src/org/openide/util/URLStreamHandlerRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/Union2.java
+++ b/openide.util/src/org/openide/util/Union2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/WeakListenerImpl.java
+++ b/openide.util/src/org/openide/util/WeakListenerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/WeakListeners.java
+++ b/openide.util/src/org/openide/util/WeakListeners.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/WeakSet.java
+++ b/openide.util/src/org/openide/util/WeakSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/FoldingIOException.java
+++ b/openide.util/src/org/openide/util/io/FoldingIOException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/NbMarshalledObject.java
+++ b/openide.util/src/org/openide/util/io/NbMarshalledObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/NbObjectInputStream.java
+++ b/openide.util/src/org/openide/util/io/NbObjectInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
+++ b/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/NullInputStream.java
+++ b/openide.util/src/org/openide/util/io/NullInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/NullOutputStream.java
+++ b/openide.util/src/org/openide/util/io/NullOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/OperationException.java
+++ b/openide.util/src/org/openide/util/io/OperationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/ReaderInputStream.java
+++ b/openide.util/src/org/openide/util/io/ReaderInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/io/SafeException.java
+++ b/openide.util/src/org/openide/util/io/SafeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/spi/MutexEventProvider.java
+++ b/openide.util/src/org/openide/util/spi/MutexEventProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/util/spi/MutexImplementation.java
+++ b/openide.util/src/org/openide/util/spi/MutexImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/xml/EntityCatalog.java
+++ b/openide.util/src/org/openide/xml/EntityCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/src/org/openide/xml/XMLUtil.java
+++ b/openide.util/src/org/openide/xml/XMLUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/BaseUtilitiesTest.java
+++ b/openide.util/test/unit/src/org/openide/util/BaseUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/ChangeSupportTest.java
+++ b/openide.util/test/unit/src/org/openide/util/ChangeSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/CharSequencesTest.java
+++ b/openide.util/test/unit/src/org/openide/util/CharSequencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/EditablePropertiesTest.java
+++ b/openide.util/test/unit/src/org/openide/util/EditablePropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/EnumerationsTest.java
+++ b/openide.util/test/unit/src/org/openide/util/EnumerationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/ExceptionsTest.java
+++ b/openide.util/test/unit/src/org/openide/util/ExceptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/LookupAndRPLeaksPermGenTest.java
+++ b/openide.util/test/unit/src/org/openide/util/LookupAndRPLeaksPermGenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/LookupUsesRequestProcessorTest.java
+++ b/openide.util/test/unit/src/org/openide/util/LookupUsesRequestProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/LookupUsesRequestProcessorThread.java
+++ b/openide.util/test/unit/src/org/openide/util/LookupUsesRequestProcessorThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/MapFormatTest.java
+++ b/openide.util/test/unit/src/org/openide/util/MapFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/MutexTryTest.java
+++ b/openide.util/test/unit/src/org/openide/util/MutexTryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/MutexWrapTest.java
+++ b/openide.util/test/unit/src/org/openide/util/MutexWrapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/NbBundleTest.java
+++ b/openide.util/test/unit/src/org/openide/util/NbBundleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/NbCollectionsTest.java
+++ b/openide.util/test/unit/src/org/openide/util/NbCollectionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/PairTest.java
+++ b/openide.util/test/unit/src/org/openide/util/PairTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/ParametersTest.java
+++ b/openide.util/test/unit/src/org/openide/util/ParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/ReadWriteAccessTest.java
+++ b/openide.util/test/unit/src/org/openide/util/ReadWriteAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/RequestProcessor180386Test.java
+++ b/openide.util/test/unit/src/org/openide/util/RequestProcessor180386Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/RequestProcessor226051Test.java
+++ b/openide.util/test/unit/src/org/openide/util/RequestProcessor226051Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/RequestProcessorHrebejkBugTest.java
+++ b/openide.util/test/unit/src/org/openide/util/RequestProcessorHrebejkBugTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/RequestProcessorLoggingTest.java
+++ b/openide.util/test/unit/src/org/openide/util/RequestProcessorLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/RequestProcessorMemoryTest.java
+++ b/openide.util/test/unit/src/org/openide/util/RequestProcessorMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/RequestProcessorParallelTest.java
+++ b/openide.util/test/unit/src/org/openide/util/RequestProcessorParallelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/RequestProcessorTest.java
+++ b/openide.util/test/unit/src/org/openide/util/RequestProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/TaskTest.java
+++ b/openide.util/test/unit/src/org/openide/util/TaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/Union2Test.java
+++ b/openide.util/test/unit/src/org/openide/util/Union2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/UtilitiesActiveQueueTest.java
+++ b/openide.util/test/unit/src/org/openide/util/UtilitiesActiveQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/UtilitiesTopologicalSortTest.java
+++ b/openide.util/test/unit/src/org/openide/util/UtilitiesTopologicalSortTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/WeakListenersTest.java
+++ b/openide.util/test/unit/src/org/openide/util/WeakListenersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/WeakSetTest.java
+++ b/openide.util/test/unit/src/org/openide/util/WeakSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/base/BundleClass.java
+++ b/openide.util/test/unit/src/org/openide/util/base/BundleClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/JarBuilder.java
+++ b/openide.util/test/unit/src/org/openide/util/test/JarBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/MockChangeListener.java
+++ b/openide.util/test/unit/src/org/openide/util/test/MockChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/MockChangeListenerTest.java
+++ b/openide.util/test/unit/src/org/openide/util/test/MockChangeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
+++ b/openide.util/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/MockPropertyChangeListenerTest.java
+++ b/openide.util/test/unit/src/org/openide/util/test/MockPropertyChangeListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/RestrictThreadCreation.java
+++ b/openide.util/test/unit/src/org/openide/util/test/RestrictThreadCreation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/TestFileUtils.java
+++ b/openide.util/test/unit/src/org/openide/util/test/TestFileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.util/test/unit/src/org/openide/util/test/package-info.java
+++ b/openide.util/test/unit/src/org/openide/util/test/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/netbeans/modules/openide/windows/GlobalActionContextImpl.java
+++ b/openide.windows/src/org/netbeans/modules/openide/windows/GlobalActionContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/netbeans/modules/openide/windows/TopComponentProcessor.java
+++ b/openide.windows/src/org/netbeans/modules/openide/windows/TopComponentProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/CloneableOpenSupport.java
+++ b/openide.windows/src/org/openide/windows/CloneableOpenSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/CloneableOpenSupportRedirector.java
+++ b/openide.windows/src/org/openide/windows/CloneableOpenSupportRedirector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/CloneableTopComponent.java
+++ b/openide.windows/src/org/openide/windows/CloneableTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/DefaultTopComponentLookup.java
+++ b/openide.windows/src/org/openide/windows/DefaultTopComponentLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/DelegateActionMap.java
+++ b/openide.windows/src/org/openide/windows/DelegateActionMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/DummyWindowManager.java
+++ b/openide.windows/src/org/openide/windows/DummyWindowManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/ExternalDropHandler.java
+++ b/openide.windows/src/org/openide/windows/ExternalDropHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/Mode.java
+++ b/openide.windows/src/org/openide/windows/Mode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/ModeSelector.java
+++ b/openide.windows/src/org/openide/windows/ModeSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/OnShowing.java
+++ b/openide.windows/src/org/openide/windows/OnShowing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/OnShowingHandler.java
+++ b/openide.windows/src/org/openide/windows/OnShowingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/OpenComponentAction.java
+++ b/openide.windows/src/org/openide/windows/OpenComponentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/RetainLocation.java
+++ b/openide.windows/src/org/openide/windows/RetainLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/TopComponent.java
+++ b/openide.windows/src/org/openide/windows/TopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/TopComponentGroup.java
+++ b/openide.windows/src/org/openide/windows/TopComponentGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/WindowManager.java
+++ b/openide.windows/src/org/openide/windows/WindowManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/WindowSystemEvent.java
+++ b/openide.windows/src/org/openide/windows/WindowSystemEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/WindowSystemListener.java
+++ b/openide.windows/src/org/openide/windows/WindowSystemListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/src/org/openide/windows/Workspace.java
+++ b/openide.windows/src/org/openide/windows/Workspace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/netbeans/modules/openide/windows/GlobalActionContextImplTest.java
+++ b/openide.windows/test/unit/src/org/netbeans/modules/openide/windows/GlobalActionContextImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/netbeans/modules/openide/windows/TopComponentProcessorTest.java
+++ b/openide.windows/test/unit/src/org/netbeans/modules/openide/windows/TopComponentProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/CloneableOpenSupportTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/CloneableOpenSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/CloneableTopComponentTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/CloneableTopComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/ContextAwareActionInTopComponentTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/ContextAwareActionInTopComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/DelegateActionMapTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/DelegateActionMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/GlobalContextImplTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/GlobalContextImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/OnShowingTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/OnShowingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/OpenComponentActionTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/OpenComponentActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/PreventNeedlessChangesOfActionMapTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/PreventNeedlessChangesOfActionMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/TopComponentGetLookupTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/TopComponentGetLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/TopComponentLookupToNodesBridge.java
+++ b/openide.windows/test/unit/src/org/openide/windows/TopComponentLookupToNodesBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/TopComponentRegistryTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/TopComponentRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/TopComponentTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/TopComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/WindowManagerHid.java
+++ b/openide.windows/test/unit/src/org/openide/windows/WindowManagerHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/openide.windows/test/unit/src/org/openide/windows/WindowSystemCompatibilityTest.java
+++ b/openide.windows/test/unit/src/org/openide/windows/WindowSystemCompatibilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/api/options/OptionsDisplayer.java
+++ b/options.api/src/org/netbeans/api/options/OptionsDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/AdvancedOptionImpl.java
+++ b/options.api/src/org/netbeans/modules/options/AdvancedOptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/CategoryModel.java
+++ b/options.api/src/org/netbeans/modules/options/CategoryModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/OptionsCategoryImpl.java
+++ b/options.api/src/org/netbeans/modules/options/OptionsCategoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/OptionsDisplayerImpl.java
+++ b/options.api/src/org/netbeans/modules/options/OptionsDisplayerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/OptionsPanelControllerAccessor.java
+++ b/options.api/src/org/netbeans/modules/options/OptionsPanelControllerAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/OptionsPanelControllerProcessor.java
+++ b/options.api/src/org/netbeans/modules/options/OptionsPanelControllerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/OptionsWindowAction.java
+++ b/options.api/src/org/netbeans/modules/options/OptionsWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/QuickSearchProvider.java
+++ b/options.api/src/org/netbeans/modules/options/QuickSearchProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/TabbedController.java
+++ b/options.api/src/org/netbeans/modules/options/TabbedController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/Utils.java
+++ b/options.api/src/org/netbeans/modules/options/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/advanced/Advanced.java
+++ b/options.api/src/org/netbeans/modules/options/advanced/Advanced.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/advanced/AdvancedPanel.java
+++ b/options.api/src/org/netbeans/modules/options/advanced/AdvancedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/advanced/AdvancedPanelController.java
+++ b/options.api/src/org/netbeans/modules/options/advanced/AdvancedPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/advanced/Model.java
+++ b/options.api/src/org/netbeans/modules/options/advanced/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/EnvironmentNode.java
+++ b/options.api/src/org/netbeans/modules/options/classic/EnvironmentNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/ExplorerPanel.java
+++ b/options.api/src/org/netbeans/modules/options/classic/ExplorerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/FileStateEditor.java
+++ b/options.api/src/org/netbeans/modules/options/classic/FileStateEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/FileStateManager.java
+++ b/options.api/src/org/netbeans/modules/options/classic/FileStateManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/InitPanel.java
+++ b/options.api/src/org/netbeans/modules/options/classic/InitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/LookupNode.java
+++ b/options.api/src/org/netbeans/modules/options/classic/LookupNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/NbMainExplorer.java
+++ b/options.api/src/org/netbeans/modules/options/classic/NbMainExplorer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/NbPlaces.java
+++ b/options.api/src/org/netbeans/modules/options/classic/NbPlaces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/OptionsAction.java
+++ b/options.api/src/org/netbeans/modules/options/classic/OptionsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/classic/SettingChildren.java
+++ b/options.api/src/org/netbeans/modules/options/classic/SettingChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/export/ExportConfirmationPanel.java
+++ b/options.api/src/org/netbeans/modules/options/export/ExportConfirmationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/export/ImportConfirmationPanel.java
+++ b/options.api/src/org/netbeans/modules/options/export/ImportConfirmationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/export/OptionsChooserPanel.java
+++ b/options.api/src/org/netbeans/modules/options/export/OptionsChooserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
+++ b/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/ui/DashedBorder.java
+++ b/options.api/src/org/netbeans/modules/options/ui/DashedBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/ui/LoweredBorder.java
+++ b/options.api/src/org/netbeans/modules/options/ui/LoweredBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/ui/TabbedPanelModel.java
+++ b/options.api/src/org/netbeans/modules/options/ui/TabbedPanelModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/modules/options/ui/VariableBorder.java
+++ b/options.api/src/org/netbeans/modules/options/ui/VariableBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/spi/options/AdvancedOption.java
+++ b/options.api/src/org/netbeans/spi/options/AdvancedOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/spi/options/OptionsCategory.java
+++ b/options.api/src/org/netbeans/spi/options/OptionsCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/src/org/netbeans/spi/options/OptionsPanelController.java
+++ b/options.api/src/org/netbeans/spi/options/OptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/qa-functional/src/org/netbeans/modules/options/FoDSearchInOptionsTest.java
+++ b/options.api/test/qa-functional/src/org/netbeans/modules/options/FoDSearchInOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/qa-functional/src/org/netbeans/modules/options/SaveOptionsOffEDTTest.java
+++ b/options.api/test/qa-functional/src/org/netbeans/modules/options/SaveOptionsOffEDTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/qa-functional/src/org/netbeans/modules/options/SearchInOptionsTest.java
+++ b/options.api/test/qa-functional/src/org/netbeans/modules/options/SearchInOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/api/options/IDEInitializer.java
+++ b/options.api/test/unit/src/org/netbeans/api/options/IDEInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/api/options/MyAdvancedCategory.java
+++ b/options.api/test/unit/src/org/netbeans/api/options/MyAdvancedCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/api/options/OptionsDisplayerOpenTest.java
+++ b/options.api/test/unit/src/org/netbeans/api/options/OptionsDisplayerOpenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/api/options/RegisteredCategory.java
+++ b/options.api/test/unit/src/org/netbeans/api/options/RegisteredCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/api/options/Subcategory1.java
+++ b/options.api/test/unit/src/org/netbeans/api/options/Subcategory1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/api/options/Subcategory2.java
+++ b/options.api/test/unit/src/org/netbeans/api/options/Subcategory2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/modules/options/OptionsPanelControllerProcessorTest.java
+++ b/options.api/test/unit/src/org/netbeans/modules/options/OptionsPanelControllerProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/modules/options/classic/FileStatePropertyTest.java
+++ b/options.api/test/unit/src/org/netbeans/modules/options/classic/FileStatePropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.api/test/unit/src/org/netbeans/modules/options/export/OptionsExportModelTest.java
+++ b/options.api/test/unit/src/org/netbeans/modules/options/export/OptionsExportModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/AllLanguageHierarchy.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/AllLanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/AllLanguageProvider.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/AllLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/AllLanguagesLexer.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/AllLanguagesLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/AllLanguagesTokenId.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/AllLanguagesTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/AnnotationsPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/AnnotationsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/CategoryComparator.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/CategoryComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/CategoryRenderer.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/CategoryRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/ColorComboBoxSupport.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/ColorComboBoxSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/ColorModel.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/ColorModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/ColorValue.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/ColorValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/FontAndColorsPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/FontAndColorsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/FontAndColorsPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/FontAndColorsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/HighlightingPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/HighlightingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/HighlightingPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/HighlightingPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/colors/spi/FontsColorsController.java
+++ b/options.editor/src/org/netbeans/modules/options/colors/spi/FontsColorsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/FolderBasedController.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/FolderBasedController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/FolderBasedOptionPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/FolderBasedOptionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsSelector.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveCommonPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveCommonPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabSelector.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/package-info.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/spi/CustomizerFactories.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/spi/CustomizerFactories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/spi/OptionsFilter.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/spi/OptionsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/spi/PreferencesCustomizer.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/spi/PreferencesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/editor/spi/PreviewProvider.java
+++ b/options.editor/src/org/netbeans/modules/options/editor/spi/PreviewProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/generaleditor/GeneralEditorPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/generaleditor/GeneralEditorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/generaleditor/GeneralEditorPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/generaleditor/GeneralEditorPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/generaleditor/Model.java
+++ b/options.editor/src/org/netbeans/modules/options/generaleditor/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/indentation/CustomizerSelector.java
+++ b/options.editor/src/org/netbeans/modules/options/indentation/CustomizerSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/indentation/FormattingSettingsFromNbPreferences.java
+++ b/options.editor/src/org/netbeans/modules/options/indentation/FormattingSettingsFromNbPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/indentation/IndentationPanel.java
+++ b/options.editor/src/org/netbeans/modules/options/indentation/IndentationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/indentation/IndentationPanelController.java
+++ b/options.editor/src/org/netbeans/modules/options/indentation/IndentationPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/src/org/netbeans/modules/options/indentation/ProxyPreferences.java
+++ b/options.editor/src/org/netbeans/modules/options/indentation/ProxyPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/test/unit/src/org/netbeans/modules/options/editor/EditorOptionsTest.java
+++ b/options.editor/test/unit/src/org/netbeans/modules/options/editor/EditorOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.editor/test/unit/src/org/netbeans/modules/options/indentation/ProxyPreferencesTest.java
+++ b/options.editor/test/unit/src/org/netbeans/modules/options/indentation/ProxyPreferencesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.java/src/org/netbeans/modules/options/java/api/JavaOptions.java
+++ b/options.java/src/org/netbeans/modules/options/java/api/JavaOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.java/src/org/netbeans/modules/options/java/resources/package-info.java
+++ b/options.java/src/org/netbeans/modules/options/java/resources/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/core/options/keymap/api/KeyStrokeUtils.java
+++ b/options.keymap/src/org/netbeans/core/options/keymap/api/KeyStrokeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/core/options/keymap/api/ShortcutAction.java
+++ b/options.keymap/src/org/netbeans/core/options/keymap/api/ShortcutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/core/options/keymap/api/ShortcutsFinder.java
+++ b/options.keymap/src/org/netbeans/core/options/keymap/api/ShortcutsFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/core/options/keymap/spi/KeymapManager.java
+++ b/options.keymap/src/org/netbeans/core/options/keymap/spi/KeymapManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ActionHolder.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ActionHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ActionsSearchProvider.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ActionsSearchProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ButtonCellEditor.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ButtonCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ButtonCellRenderer.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ButtonCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/CompoundAction.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/CompoundAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ExportShortcutsAction.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ExportShortcutsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/KeymapListRenderer.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/KeymapListRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/KeymapPanel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/KeymapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/KeymapPanelController.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/KeymapPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/KeymapViewModel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/KeymapViewModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/LayersBridge.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/LayersBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/MutableShortcutsModel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/MutableShortcutsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/Popupable.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/Popupable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ProfilesPanel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ProfilesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutCellPanel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutCellPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutListener.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutPopupPanel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutPopupPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutProvider.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutTextField.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutTextField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutsDialog.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutsDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutsFinderImpl.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutsFinderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/TableSorter.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/TableSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/src/org/netbeans/modules/options/keymap/XMLStorage.java
+++ b/options.keymap/src/org/netbeans/modules/options/keymap/XMLStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/test/unit/src/org/netbeans/core/options/keymap/api/KeyStrokeUtilsTest.java
+++ b/options.keymap/test/unit/src/org/netbeans/core/options/keymap/api/KeyStrokeUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/test/unit/src/org/netbeans/modules/options/keymap/KeymapModelTest.java
+++ b/options.keymap/test/unit/src/org/netbeans/modules/options/keymap/KeymapModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/options.keymap/test/unit/src/org/netbeans/modules/options/keymap/KeymapViewModelTest.java
+++ b/options.keymap/test/unit/src/org/netbeans/modules/options/keymap/KeymapViewModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/api/Embedding.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/api/Embedding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/api/ParserManager.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/api/ParserManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/api/ResultIterator.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/api/ResultIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/api/Snapshot.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/api/Snapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/api/Source.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/api/Source.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/api/Task.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/api/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/api/UserTask.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/api/UserTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/DialogBindingEmbeddingProvider.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/DialogBindingEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderFactory.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderRegistrationProcessor.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/IndexerBridge.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/IndexerBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/ParserAccessor.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/ParserAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/ParserEventForward.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/ParserEventForward.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/ResultIteratorAccessor.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/ResultIteratorAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/RunWhenScanFinishedSupport.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/RunWhenScanFinishedSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/SchedulerAccessor.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/SchedulerAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/Schedulers.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/Schedulers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/SelfProfile.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/SelfProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/SourceAccessor.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/SourceAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/SourceCache.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/SourceCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/SourceFlags.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/SourceFlags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/TaskProcessor.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/TaskProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/Utilities.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/event/FileChangeSupport.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/event/FileChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/impl/event/ParserChangeSupport.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/impl/event/ParserChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/implspi/EnvironmentFactory.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/implspi/EnvironmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/implspi/ProfilerSupport.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/implspi/ProfilerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/implspi/SchedulerControl.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/implspi/SchedulerControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/implspi/SourceControl.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/implspi/SourceControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/implspi/SourceEnvironment.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/implspi/SourceEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/implspi/SourceFactory.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/implspi/SourceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/implspi/TaskProcessorControl.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/implspi/TaskProcessorControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/CursorMovedSchedulerEvent.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/CursorMovedSchedulerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/EmbeddingProvider.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/EmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/IndexingAwareParserResultTask.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/IndexingAwareParserResultTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/LowMemoryWatcher.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/LowMemoryWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/ParseException.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/Parser.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/ParserBasedEmbeddingProvider.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/ParserBasedEmbeddingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/ParserFactory.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/ParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/ParserResultTask.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/ParserResultTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/Scheduler.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/Scheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/SchedulerEvent.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/SchedulerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/SchedulerTask.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/SchedulerTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/SourceModificationEvent.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/SourceModificationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/TaskFactory.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/TaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/TaskIndexingMode.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/TaskIndexingMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/src/org/netbeans/modules/parsing/spi/support/CancelSupport.java
+++ b/parsing.api/src/org/netbeans/modules/parsing/spi/support/CancelSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/ASchedulerEvent.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/ASchedulerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/Counter.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/Counter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/EmbeddingTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/EmbeddingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/IndexingAwareTestCase.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/IndexingAwareTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/MyScheduler.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/MyScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/ParserManagerTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/ParserManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/ParsingTestBase.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/ParsingTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/RunUserActionTaskTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/RunUserActionTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotMemLeakTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotMemLeakTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotSizeTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/Sorter.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/Sorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SourceTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/TestEditorMimeTypeImplementation.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/TestEditorMimeTypeImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/TestEnvironmentFactory.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/TestEnvironmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/TestUtil.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/VyletelaZezulickaTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/VyletelaZezulickaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/ASchedulerEvent.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/ASchedulerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/CachingTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/CachingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/CancelSupportTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/CancelSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/CaretSchelulerTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/CaretSchelulerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/EmbeddingTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/EmbeddingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/IndexerEmulator.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/IndexerEmulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/RunWhenScanFinishedSupportTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/RunWhenScanFinishedSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/SchedulerEventTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/SchedulerEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/TaskProcessorTest.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/TaskProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/TestComparator.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/TestComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/TwoFiles156606Test.java
+++ b/parsing.api/test/unit/src/org/netbeans/modules/parsing/impl/TwoFiles156606Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/api/indexing/IndexingManager.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/api/indexing/IndexingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ArchiveTimeStamps.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ArchiveTimeStamps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/CacheFolder.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/CacheFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/CancelRequest.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/CancelRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexables.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Crawler.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Crawler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Debug.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Debug.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DefaultCacheFolderProvider.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DefaultCacheFolderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DefaultPathRecognizer.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DefaultPathRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DeletedIndexable.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DeletedIndexable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/EventKind.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/EventKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileEventLog.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileEventLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawler.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectIndexable.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectIndexable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectProvider.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexBinaryWorkPool.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexBinaryWorkPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexFactoryImpl.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexableImpl.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerControl.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerRegistrationProcessor.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexingModule.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexingModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexingUtils.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/InjectedTasksSupport.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/InjectedTasksSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LongHashMap.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LongHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Notify.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Notify.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathKind.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRecognizerRegistrationProcessor.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRecognizerRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRecognizerRegistry.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRecognizerRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistry.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistryEvent.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistryListener.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ProxyBinaryIndexerFactory.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ProxyBinaryIndexerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ProxyIterable.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ProxyIterable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RootsListener.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RootsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/SPIAccessor.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ScanCancelledException.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ScanCancelledException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/SuspendSupport.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/SuspendSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/TimeStamps.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/TimeStamps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/TransientUpdateSupport.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/TransientUpdateSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/URLCache.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/URLCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Util.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/VisibilitySupport.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/VisibilitySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskProvider.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/Utilities.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/DownloadedIndexPatcher.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/DownloadedIndexPatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/IndexDownloader.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/IndexDownloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/IndexingActivityInterceptor.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/IndexingActivityInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/IndexingController.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/friendapi/IndexingController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/ActiveDocumentProvider.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/ActiveDocumentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/CacheFolderProvider.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/CacheFolderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/ContextProvider.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/ContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/FileAnnotationsRefresh.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/FileAnnotationsRefresh.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/NotifyImplementation.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/implspi/NotifyImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/DocumentBasedIndexManager.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/DocumentBasedIndexManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/LayeredDocumentIndex.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/LayeredDocumentIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/LuceneIndexFactory.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/LuceneIndexFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/BinaryIndexer.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/BinaryIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/BinaryIndexerFactory.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/BinaryIndexerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/ConstrainedBinaryIndexer.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/ConstrainedBinaryIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/Context.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/CustomIndexer.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/CustomIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/CustomIndexerFactory.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/CustomIndexerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/EmbeddingIndexer.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/EmbeddingIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/EmbeddingIndexerFactory.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/EmbeddingIndexerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/Indexable.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/Indexable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/PathRecognizer.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/PathRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/PathRecognizerRegistration.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/PathRecognizerRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/SourceIndexerFactory.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/SourceIndexerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/SuspendStatus.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/SuspendStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexDocument.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexResult.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupport.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupport.java
+++ b/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/api/indexing/IndexingManagerTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/api/indexing/IndexingManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ArchiveTimeStampsTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ArchiveTimeStampsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/AttachableDocumentIndexCacheTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/AttachableDocumentIndexCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/BrokenIndexRecoveryTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/BrokenIndexRecoveryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexablesCacheTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexablesCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexablesTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ConstrainedBinaryIndexerTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ConstrainedBinaryIndexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/DocumentStoreTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/DocumentStoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/EmbeddedIndexerTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/EmbeddedIndexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/FileListWorkOrderingTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/FileListWorkOrderingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawlerTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/FooPathRecognizer.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/FooPathRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IdentityDigestTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IdentityDigestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexerOrderingTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexerOrderingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexerVersionsTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexerVersionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexingSupportACIDTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexingSupportACIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexingTestBase.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexingTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/InjectedTasksSupportTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/InjectedTasksSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/MimeTypes.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/MimeTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ParsinApiInteractionTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ParsinApiInteractionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/PathRegistryTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/PathRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ProxyIterableTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ProxyIterableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RefreshWorkTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RefreshWorkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater2Test.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdaterTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdaterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdaterTestSupport.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdaterTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ScanStartedTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ScanStartedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/TestEditorMimeTypesImpl.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/TestEditorMimeTypesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/TestEnvironmentFactory.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/TestEnvironmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/VisibilityChangeTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/VisibilityChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskProviderTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/lucene/LuceneIndexTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/lucene/LuceneIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/EmbeddedPathRecognizer.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/EmbeddedPathRecognizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/FileQueryTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/FileQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupportTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupportLifeLock230220Test.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupportLifeLock230220Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupportTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/AllFieldsSelector.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/AllFieldsSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/BitSetCollector.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/BitSetCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/CacheCleaner.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/CacheCleaner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/Convertors.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/Convertors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/DocumentIndexImpl.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/DocumentIndexImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/Evictable.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/Evictable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/EvictionPolicy.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/EvictionPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/IndexCacheFactory.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/IndexCacheFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/IndexDocumentImpl.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/IndexDocumentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/IndexFactory.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/IndexFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/LRUCache.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/LRUCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/LuceneIndex.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/LuceneIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/LuceneIndexFactory.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/LuceneIndexFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/MemoryIndex.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/MemoryIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/RecordOwnerLockFactory.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/RecordOwnerLockFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/SimpleDocumentIndexCache.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/SimpleDocumentIndexCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/SupportAccessor.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/SupportAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/TermCollector.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/TermCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/spi/ScanSuspendImplementation.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/spi/ScanSuspendImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Convertor.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Convertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Convertors.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Convertors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndex.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndex2.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndex2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndexCache.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndexCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Index.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/IndexDocument.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/IndexDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/IndexManager.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/IndexManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/IndexReaderInjection.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/IndexReaderInjection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/LowMemoryWatcher.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/LowMemoryWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Queries.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Queries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/StoppableConvertor.java
+++ b/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/StoppableConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/AsyncCloseTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/AsyncCloseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/DocumentIndexPerfTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/DocumentIndexPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/IndexTransactionTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/IndexTransactionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LRUCacheTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LRUCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LuceneIndexTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LuceneIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/NativeFSLockFactoryTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/NativeFSLockFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/RawIndexPerfTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/RawIndexPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/RecordOwnerLockFactoryTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/RecordOwnerLockFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/IndexManagerTestUtilities.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/IndexManagerTestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/LMListenerTest.java
+++ b/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/LMListenerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/CurrentDocumentScheduler.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/CurrentDocumentScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/CurrentEditorTaskScheduler.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/CurrentEditorTaskScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/CursorSensitiveScheduler.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/CursorSensitiveScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/DataObjectEnvFactory.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/DataObjectEnvFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/EditorMimeTypesImpl.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/EditorMimeTypesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/EventSupport.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/EventSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/Installer.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/NbSamplerProfiler.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/NbSamplerProfiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/SelectedNodesScheduler.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/SelectedNodesScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/src/org/netbeans/modules/parsing/nb/indexing/NbActiveDocumentProvider.java
+++ b/parsing.nb/src/org/netbeans/modules/parsing/nb/indexing/NbActiveDocumentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/impl/SchedulerTestAccess.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/impl/SchedulerTestAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/impl/indexing/EmbeddedIndexerTest.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/impl/indexing/EmbeddedIndexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/ALanguageHierarchy.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/ALanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/DocumentModification1Test.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/DocumentModification1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/DocumentModification2Test.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/DocumentModification2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/DocumentModificationNoLexerTest.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/DocumentModificationNoLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/FileModificationTest.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/FileModificationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/RepositoryUpdaterEventTest.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/RepositoryUpdaterEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/TaskProcessorSuspendTest.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/TaskProcessorSuspendTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.ui/src/org/netbeans/modules/parsing/ui/WaitScanFinishedCompletionProvider.java
+++ b/parsing.ui/src/org/netbeans/modules/parsing/ui/WaitScanFinishedCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/NotifyImpl.java
+++ b/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/NotifyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/RefreshAllIndexes.java
+++ b/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/RefreshAllIndexes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/ScanForExternalChanges.java
+++ b/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/ScanForExternalChanges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/errors/ErrorAnnotator.java
+++ b/parsing.ui/src/org/netbeans/modules/parsing/ui/indexing/errors/ErrorAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/BigJavaFile.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/BigJavaFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/Class.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/Class.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/JFrame20kB.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/JFrame20kB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/Main.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/Main20kB.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/Main20kB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/TestClassForCopyPaste.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestData/src/org/netbeans/test/performance/TestClassForCopyPaste.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/Test.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass000.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass000.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass001.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass001.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass002.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass002.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass003.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass003.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass004.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass004.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass005.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass005.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass006.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass006.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass007.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass007.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass008.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass008.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass009.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass009.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass010.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass010.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass011.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass011.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass012.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass012.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass013.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass013.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass014.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass014.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass015.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass015.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass016.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass016.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass017.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass017.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass018.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass018.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass019.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass019.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass020.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass020.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass021.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass021.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass022.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass022.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass023.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass023.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass024.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass024.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass025.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass025.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass026.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass026.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass027.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass027.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass028.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass028.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass029.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass029.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass030.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass030.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass031.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass031.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass032.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass032.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass033.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass033.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass034.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass034.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass035.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass035.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass036.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass036.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass037.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass037.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass038.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass038.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass039.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass039.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass040.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass040.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass041.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass041.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass042.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass042.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass043.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass043.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass044.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass044.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass045.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass045.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass046.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass046.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass047.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass047.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass048.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass048.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass049.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass049.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass050.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass050.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass051.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass051.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass052.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass052.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass053.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass053.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass054.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass054.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass055.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass055.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass056.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass056.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass057.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass057.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass058.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass058.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass059.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass059.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass060.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass060.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass061.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass061.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass062.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass062.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass063.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass063.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass064.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass064.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass065.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass065.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass066.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass066.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass067.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass067.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass068.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass068.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass069.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass069.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass070.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass070.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass071.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass071.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass072.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass072.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass073.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass073.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass074.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass074.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass075.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass075.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass076.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass076.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass077.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass077.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass078.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass078.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass079.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass079.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass080.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass080.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass081.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass081.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass082.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass082.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass083.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass083.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass084.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass084.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass085.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass085.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass086.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass086.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass087.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass087.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass088.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass088.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass089.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass089.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass090.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass090.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass091.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass091.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass092.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass092.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass093.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass093.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass094.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass094.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass095.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass095.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass096.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass096.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass097.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass097.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass098.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass098.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass099.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder100/SampleJavaClass099.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass000.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass000.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass001.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass001.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass002.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass002.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass003.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass003.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass004.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass004.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass005.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass005.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass006.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass006.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass007.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass007.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass008.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass008.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass009.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass009.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass010.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass010.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass011.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass011.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass012.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass012.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass013.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass013.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass014.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass014.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass015.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass015.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass016.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass016.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass017.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass017.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass018.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass018.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass019.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass019.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass020.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass020.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass021.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass021.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass022.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass022.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass023.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass023.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass024.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass024.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass025.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass025.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass026.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass026.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass027.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass027.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass028.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass028.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass029.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass029.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass030.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass030.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass031.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass031.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass032.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass032.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass033.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass033.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass034.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass034.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass035.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass035.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass036.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass036.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass037.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass037.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass038.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass038.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass039.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass039.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass040.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass040.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass041.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass041.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass042.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass042.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass043.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass043.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass044.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass044.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass045.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass045.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass046.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass046.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass047.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass047.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass048.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass048.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass049.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass049.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass050.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass050.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass051.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass051.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass052.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass052.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass053.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass053.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass054.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass054.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass055.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass055.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass056.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass056.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass057.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass057.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass058.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass058.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass059.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass059.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass060.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass060.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass061.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass061.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass062.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass062.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass063.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass063.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass064.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass064.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass065.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass065.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass066.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass066.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass067.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass067.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass068.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass068.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass069.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass069.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass070.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass070.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass071.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass071.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass072.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass072.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass073.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass073.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass074.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass074.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass075.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass075.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass076.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass076.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass077.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass077.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass078.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass078.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass079.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass079.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass080.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass080.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass081.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass081.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass082.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass082.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass083.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass083.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass084.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass084.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass085.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass085.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass086.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass086.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass087.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass087.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass088.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass088.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass089.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass089.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass090.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass090.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass091.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass091.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass092.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass092.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass093.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass093.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass094.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass094.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass095.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass095.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass096.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass096.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass097.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass097.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass098.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass098.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass099.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass099.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass100.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass100.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass101.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass101.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass102.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass102.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass103.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass103.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass104.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass104.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass105.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass105.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass106.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass106.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass107.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass107.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass108.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass108.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass109.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass109.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass110.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass110.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass111.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass111.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass112.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass112.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass113.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass113.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass114.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass114.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass115.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass115.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass116.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass116.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass117.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass117.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass118.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass118.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass119.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass119.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass120.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass120.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass121.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass121.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass122.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass122.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass123.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass123.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass124.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass124.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass125.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass125.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass126.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass126.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass127.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass127.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass128.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass128.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass129.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass129.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass130.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass130.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass131.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass131.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass132.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass132.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass133.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass133.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass134.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass134.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass135.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass135.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass136.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass136.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass137.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass137.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass138.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass138.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass139.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass139.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass140.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass140.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass141.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass141.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass142.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass142.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass143.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass143.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass144.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass144.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass145.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass145.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass146.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass146.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass147.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass147.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass148.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass148.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass149.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass149.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass150.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass150.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass151.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass151.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass152.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass152.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass153.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass153.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass154.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass154.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass155.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass155.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass156.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass156.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass157.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass157.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass158.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass158.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass159.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass159.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass160.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass160.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass161.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass161.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass162.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass162.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass163.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass163.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass164.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass164.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass165.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass165.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass166.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass166.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass167.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass167.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass168.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass168.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass169.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass169.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass170.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass170.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass171.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass171.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass172.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass172.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass173.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass173.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass174.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass174.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass175.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass175.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass176.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass176.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass177.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass177.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass178.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass178.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass179.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass179.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass180.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass180.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass181.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass181.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass182.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass182.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass183.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass183.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass184.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass184.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass185.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass185.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass186.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass186.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass187.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass187.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass188.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass188.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass189.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass189.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass190.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass190.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass191.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass191.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass192.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass192.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass193.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass193.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass194.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass194.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass195.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass195.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass196.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass196.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass197.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass197.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass198.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass198.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass199.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass199.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass200.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass200.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass201.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass201.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass202.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass202.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass203.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass203.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass204.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass204.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass205.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass205.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass206.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass206.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass207.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass207.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass208.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass208.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass209.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass209.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass210.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass210.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass211.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass211.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass212.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass212.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass213.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass213.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass214.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass214.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass215.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass215.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass216.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass216.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass217.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass217.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass218.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass218.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass219.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass219.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass220.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass220.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass221.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass221.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass222.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass222.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass223.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass223.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass224.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass224.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass225.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass225.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass226.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass226.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass227.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass227.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass228.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass228.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass229.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass229.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass230.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass230.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass231.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass231.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass232.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass232.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass233.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass233.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass234.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass234.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass235.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass235.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass236.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass236.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass237.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass237.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass238.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass238.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass239.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass239.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass240.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass240.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass241.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass241.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass242.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass242.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass243.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass243.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass244.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass244.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass245.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass245.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass246.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass246.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass247.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass247.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass248.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass248.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass249.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass249.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass250.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass250.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass251.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass251.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass252.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass252.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass253.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass253.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass254.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass254.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass255.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass255.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass256.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass256.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass257.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass257.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass258.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass258.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass259.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass259.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass260.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass260.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass261.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass261.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass262.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass262.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass263.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass263.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass264.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass264.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass265.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass265.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass266.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass266.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass267.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass267.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass268.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass268.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass269.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass269.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass270.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass270.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass271.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass271.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass272.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass272.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass273.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass273.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass274.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass274.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass275.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass275.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass276.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass276.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass277.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass277.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass278.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass278.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass279.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass279.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass280.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass280.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass281.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass281.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass282.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass282.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass283.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass283.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass284.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass284.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass285.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass285.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass286.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass286.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass287.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass287.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass288.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass288.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass289.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass289.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass290.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass290.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass291.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass291.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass292.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass292.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass293.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass293.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass294.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass294.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass295.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass295.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass296.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass296.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass297.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass297.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass298.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass298.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass299.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass299.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass300.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass300.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass301.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass301.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass302.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass302.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass303.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass303.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass304.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass304.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass305.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass305.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass306.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass306.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass307.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass307.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass308.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass308.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass309.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass309.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass310.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass310.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass311.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass311.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass312.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass312.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass313.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass313.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass314.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass314.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass315.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass315.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass316.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass316.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass317.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass317.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass318.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass318.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass319.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass319.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass320.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass320.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass321.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass321.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass322.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass322.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass323.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass323.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass324.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass324.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass325.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass325.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass326.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass326.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass327.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass327.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass328.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass328.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass329.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass329.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass330.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass330.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass331.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass331.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass332.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass332.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass333.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass333.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass334.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass334.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass335.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass335.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass336.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass336.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass337.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass337.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass338.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass338.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass339.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass339.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass340.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass340.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass341.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass341.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass342.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass342.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass343.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass343.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass344.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass344.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass345.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass345.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass346.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass346.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass347.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass347.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass348.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass348.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass349.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass349.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass350.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass350.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass351.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass351.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass352.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass352.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass353.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass353.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass354.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass354.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass355.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass355.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass356.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass356.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass357.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass357.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass358.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass358.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass359.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass359.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass360.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass360.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass361.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass361.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass362.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass362.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass363.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass363.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass364.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass364.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass365.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass365.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass366.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass366.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass367.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass367.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass368.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass368.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass369.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass369.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass370.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass370.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass371.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass371.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass372.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass372.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass373.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass373.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass374.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass374.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass375.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass375.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass376.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass376.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass377.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass377.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass378.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass378.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass379.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass379.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass380.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass380.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass381.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass381.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass382.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass382.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass383.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass383.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass384.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass384.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass385.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass385.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass386.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass386.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass387.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass387.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass388.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass388.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass389.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass389.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass390.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass390.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass391.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass391.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass392.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass392.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass393.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass393.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass394.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass394.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass395.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass395.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass396.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass396.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass397.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass397.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass398.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass398.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass399.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass399.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass400.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass400.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass401.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass401.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass402.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass402.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass403.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass403.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass404.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass404.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass405.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass405.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass406.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass406.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass407.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass407.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass408.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass408.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass409.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass409.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass410.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass410.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass411.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass411.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass412.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass412.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass413.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass413.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass414.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass414.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass415.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass415.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass416.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass416.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass417.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass417.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass418.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass418.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass419.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass419.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass420.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass420.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass421.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass421.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass422.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass422.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass423.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass423.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass424.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass424.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass425.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass425.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass426.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass426.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass427.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass427.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass428.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass428.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass429.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass429.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass430.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass430.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass431.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass431.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass432.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass432.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass433.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass433.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass434.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass434.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass435.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass435.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass436.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass436.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass437.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass437.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass438.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass438.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass439.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass439.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass440.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass440.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass441.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass441.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass442.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass442.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass443.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass443.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass444.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass444.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass445.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass445.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass446.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass446.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass447.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass447.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass448.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass448.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass449.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass449.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass450.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass450.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass451.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass451.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass452.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass452.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass453.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass453.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass454.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass454.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass455.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass455.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass456.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass456.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass457.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass457.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass458.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass458.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass459.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass459.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass460.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass460.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass461.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass461.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass462.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass462.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass463.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass463.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass464.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass464.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass465.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass465.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass466.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass466.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass467.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass467.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass468.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass468.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass469.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass469.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass470.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass470.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass471.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass471.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass472.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass472.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass473.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass473.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass474.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass474.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass475.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass475.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass476.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass476.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass477.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass477.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass478.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass478.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass479.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass479.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass480.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass480.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass481.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass481.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass482.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass482.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass483.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass483.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass484.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass484.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass485.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass485.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass486.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass486.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass487.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass487.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass488.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass488.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass489.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass489.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass490.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass490.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass491.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass491.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass492.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass492.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass493.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass493.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass494.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass494.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass495.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass495.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass496.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass496.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass497.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass497.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass498.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass498.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass499.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass499.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass500.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass500.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass501.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass501.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass502.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass502.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass503.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass503.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass504.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass504.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass505.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass505.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass506.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass506.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass507.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass507.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass508.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass508.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass509.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass509.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass510.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass510.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass511.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass511.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass512.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass512.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass513.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass513.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass514.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass514.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass515.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass515.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass516.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass516.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass517.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass517.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass518.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass518.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass519.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass519.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass520.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass520.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass521.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass521.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass522.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass522.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass523.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass523.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass524.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass524.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass525.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass525.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass526.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass526.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass527.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass527.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass528.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass528.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass529.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass529.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass530.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass530.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass531.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass531.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass532.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass532.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass533.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass533.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass534.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass534.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass535.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass535.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass536.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass536.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass537.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass537.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass538.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass538.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass539.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass539.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass540.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass540.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass541.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass541.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass542.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass542.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass543.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass543.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass544.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass544.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass545.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass545.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass546.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass546.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass547.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass547.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass548.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass548.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass549.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass549.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass550.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass550.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass551.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass551.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass552.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass552.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass553.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass553.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass554.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass554.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass555.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass555.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass556.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass556.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass557.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass557.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass558.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass558.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass559.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass559.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass560.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass560.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass561.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass561.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass562.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass562.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass563.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass563.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass564.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass564.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass565.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass565.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass566.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass566.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass567.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass567.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass568.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass568.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass569.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass569.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass570.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass570.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass571.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass571.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass572.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass572.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass573.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass573.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass574.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass574.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass575.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass575.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass576.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass576.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass577.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass577.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass578.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass578.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass579.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass579.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass580.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass580.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass581.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass581.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass582.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass582.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass583.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass583.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass584.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass584.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass585.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass585.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass586.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass586.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass587.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass587.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass588.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass588.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass589.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass589.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass590.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass590.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass591.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass591.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass592.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass592.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass593.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass593.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass594.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass594.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass595.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass595.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass596.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass596.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass597.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass597.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass598.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass598.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass599.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass599.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass600.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass600.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass601.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass601.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass602.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass602.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass603.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass603.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass604.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass604.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass605.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass605.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass606.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass606.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass607.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass607.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass608.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass608.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass609.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass609.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass610.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass610.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass611.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass611.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass612.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass612.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass613.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass613.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass614.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass614.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass615.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass615.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass616.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass616.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass617.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass617.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass618.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass618.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass619.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass619.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass620.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass620.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass621.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass621.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass622.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass622.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass623.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass623.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass624.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass624.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass625.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass625.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass626.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass626.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass627.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass627.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass628.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass628.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass629.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass629.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass630.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass630.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass631.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass631.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass632.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass632.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass633.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass633.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass634.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass634.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass635.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass635.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass636.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass636.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass637.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass637.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass638.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass638.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass639.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass639.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass640.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass640.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass641.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass641.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass642.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass642.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass643.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass643.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass644.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass644.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass645.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass645.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass646.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass646.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass647.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass647.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass648.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass648.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass649.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass649.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass650.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass650.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass651.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass651.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass652.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass652.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass653.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass653.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass654.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass654.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass655.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass655.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass656.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass656.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass657.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass657.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass658.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass658.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass659.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass659.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass660.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass660.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass661.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass661.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass662.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass662.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass663.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass663.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass664.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass664.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass665.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass665.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass666.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass666.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass667.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass667.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass668.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass668.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass669.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass669.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass670.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass670.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass671.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass671.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass672.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass672.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass673.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass673.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass674.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass674.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass675.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass675.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass676.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass676.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass677.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass677.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass678.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass678.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass679.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass679.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass680.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass680.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass681.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass681.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass682.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass682.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass683.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass683.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass684.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass684.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass685.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass685.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass686.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass686.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass687.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass687.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass688.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass688.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass689.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass689.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass690.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass690.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass691.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass691.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass692.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass692.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass693.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass693.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass694.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass694.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass695.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass695.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass696.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass696.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass697.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass697.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass698.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass698.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass699.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass699.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass700.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass700.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass701.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass701.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass702.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass702.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass703.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass703.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass704.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass704.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass705.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass705.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass706.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass706.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass707.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass707.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass708.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass708.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass709.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass709.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass710.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass710.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass711.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass711.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass712.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass712.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass713.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass713.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass714.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass714.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass715.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass715.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass716.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass716.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass717.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass717.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass718.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass718.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass719.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass719.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass720.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass720.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass721.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass721.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass722.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass722.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass723.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass723.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass724.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass724.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass725.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass725.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass726.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass726.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass727.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass727.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass728.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass728.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass729.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass729.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass730.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass730.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass731.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass731.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass732.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass732.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass733.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass733.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass734.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass734.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass735.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass735.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass736.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass736.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass737.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass737.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass738.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass738.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass739.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass739.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass740.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass740.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass741.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass741.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass742.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass742.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass743.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass743.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass744.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass744.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass745.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass745.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass746.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass746.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass747.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass747.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass748.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass748.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass749.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass749.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass750.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass750.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass751.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass751.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass752.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass752.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass753.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass753.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass754.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass754.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass755.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass755.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass756.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass756.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass757.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass757.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass758.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass758.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass759.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass759.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass760.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass760.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass761.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass761.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass762.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass762.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass763.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass763.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass764.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass764.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass765.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass765.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass766.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass766.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass767.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass767.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass768.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass768.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass769.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass769.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass770.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass770.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass771.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass771.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass772.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass772.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass773.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass773.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass774.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass774.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass775.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass775.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass776.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass776.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass777.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass777.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass778.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass778.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass779.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass779.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass780.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass780.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass781.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass781.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass782.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass782.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass783.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass783.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass784.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass784.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass785.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass785.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass786.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass786.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass787.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass787.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass788.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass788.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass789.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass789.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass790.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass790.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass791.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass791.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass792.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass792.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass793.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass793.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass794.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass794.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass795.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass795.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass796.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass796.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass797.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass797.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass798.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass798.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass799.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass799.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass800.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass800.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass801.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass801.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass802.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass802.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass803.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass803.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass804.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass804.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass805.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass805.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass806.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass806.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass807.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass807.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass808.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass808.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass809.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass809.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass810.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass810.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass811.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass811.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass812.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass812.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass813.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass813.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass814.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass814.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass815.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass815.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass816.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass816.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass817.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass817.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass818.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass818.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass819.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass819.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass820.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass820.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass821.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass821.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass822.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass822.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass823.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass823.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass824.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass824.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass825.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass825.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass826.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass826.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass827.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass827.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass828.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass828.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass829.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass829.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass830.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass830.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass831.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass831.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass832.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass832.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass833.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass833.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass834.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass834.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass835.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass835.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass836.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass836.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass837.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass837.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass838.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass838.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass839.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass839.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass840.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass840.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass841.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass841.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass842.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass842.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass843.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass843.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass844.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass844.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass845.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass845.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass846.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass846.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass847.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass847.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass848.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass848.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass849.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass849.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass850.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass850.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass851.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass851.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass852.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass852.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass853.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass853.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass854.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass854.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass855.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass855.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass856.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass856.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass857.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass857.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass858.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass858.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass859.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass859.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass860.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass860.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass861.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass861.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass862.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass862.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass863.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass863.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass864.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass864.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass865.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass865.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass866.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass866.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass867.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass867.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass868.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass868.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass869.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass869.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass870.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass870.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass871.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass871.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass872.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass872.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass873.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass873.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass874.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass874.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass875.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass875.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass876.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass876.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass877.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass877.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass878.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass878.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass879.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass879.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass880.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass880.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass881.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass881.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass882.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass882.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass883.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass883.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass884.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass884.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass885.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass885.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass886.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass886.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass887.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass887.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass888.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass888.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass889.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass889.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass890.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass890.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass891.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass891.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass892.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass892.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass893.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass893.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass894.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass894.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass895.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass895.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass896.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass896.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass897.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass897.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass898.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass898.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass899.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass899.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass900.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass900.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass901.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass901.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass902.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass902.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass903.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass903.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass904.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass904.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass905.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass905.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass906.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass906.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass907.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass907.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass908.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass908.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass909.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass909.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass910.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass910.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass911.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass911.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass912.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass912.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass913.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass913.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass914.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass914.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass915.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass915.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass916.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass916.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass917.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass917.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass918.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass918.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass919.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass919.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass920.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass920.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass921.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass921.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass922.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass922.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass923.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass923.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass924.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass924.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass925.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass925.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass926.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass926.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass927.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass927.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass928.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass928.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass929.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass929.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass930.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass930.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass931.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass931.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass932.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass932.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass933.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass933.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass934.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass934.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass935.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass935.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass936.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass936.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass937.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass937.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass938.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass938.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass939.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass939.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass940.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass940.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass941.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass941.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass942.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass942.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass943.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass943.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass944.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass944.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass945.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass945.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass946.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass946.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass947.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass947.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass948.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass948.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass949.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass949.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass950.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass950.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass951.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass951.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass952.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass952.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass953.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass953.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass954.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass954.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass955.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass955.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass956.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass956.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass957.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass957.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass958.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass958.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass959.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass959.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass960.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass960.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass961.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass961.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass962.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass962.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass963.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass963.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass964.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass964.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass965.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass965.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass966.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass966.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass967.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass967.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass968.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass968.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass969.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass969.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass970.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass970.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass971.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass971.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass972.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass972.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass973.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass973.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass974.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass974.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass975.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass975.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass976.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass976.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass977.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass977.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass978.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass978.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass979.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass979.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass980.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass980.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass981.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass981.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass982.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass982.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass983.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass983.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass984.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass984.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass985.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass985.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass986.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass986.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass987.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass987.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass988.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass988.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass989.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass989.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass990.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass990.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass991.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass991.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass992.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass992.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass993.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass993.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass994.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass994.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass995.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass995.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass996.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass996.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass997.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass997.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass998.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass998.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass999.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder1000/SampleJavaClass999.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass000.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass000.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass001.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass001.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass002.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass002.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass003.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass003.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass004.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass004.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass005.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass005.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass006.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass006.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass007.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass007.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass008.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass008.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass009.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass009.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass010.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass010.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass011.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass011.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass012.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass012.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass013.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass013.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass014.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass014.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass015.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass015.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass016.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass016.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass017.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass017.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass018.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass018.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass019.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass019.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass020.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass020.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass021.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass021.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass022.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass022.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass023.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass023.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass024.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass024.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass025.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass025.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass026.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass026.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass027.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass027.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass028.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass028.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass029.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass029.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass030.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass030.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass031.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass031.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass032.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass032.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass033.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass033.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass034.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass034.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass035.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass035.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass036.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass036.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass037.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass037.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass038.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass038.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass039.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass039.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass040.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass040.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass041.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass041.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass042.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass042.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass043.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass043.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass044.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass044.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass045.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass045.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass046.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass046.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass047.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass047.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass048.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass048.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass049.java
+++ b/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/javaFolder50/SampleJavaClass049.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/AllPropsChildren.java
+++ b/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/AllPropsChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/AllPropsNode.java
+++ b/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/AllPropsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/OnePropNode.java
+++ b/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/OnePropNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/PropertiesNotifier.java
+++ b/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/PropertiesNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/RefreshPropsAction.java
+++ b/performance.java/test/qa-functional/data/SystemProperties/src/org/myorg/systemproperties/RefreshPropsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/MeasureJ2SEActionsTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/MeasureJ2SEActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/MeasureJ2SEDialogsTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/MeasureJ2SEDialogsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/MeasureJ2SEMenusTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/MeasureJ2SEMenusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/AddToFavoritesTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/AddToFavoritesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseAllEditorsTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseAllEditorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseEditorModifiedTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseEditorModifiedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseEditorTabTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseEditorTabTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CloseEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CommentingCodeInEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CommentingCodeInEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CountingSecurityManager.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CreateNBProjectTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CreateNBProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CreateProjectTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CreateProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ExpandNodesInComponentInspectorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ExpandNodesInComponentInspectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ExpandNodesProjectsViewTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ExpandNodesProjectsViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/JavaCompletionInEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/JavaCompletionInEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesNoCloneableEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesNoCloneableEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesNoCloneableEditorWithOpenedEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesNoCloneableEditorWithOpenedEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesWithOpenedEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/OpenFilesWithOpenedEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/PageUpPageDownInEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/PageUpPageDownInEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/PasteInEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/PasteInEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ProfileProjectTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ProfileProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/RefactorFindUsagesTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/RefactorFindUsagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SaveModifiedFileTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SaveModifiedFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SearchTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SelectCategoriesInNewFileTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SelectCategoriesInNewFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ShiftCodeInEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ShiftCodeInEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ShowClassMembersInNavigatorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/ShowClassMembersInNavigatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SwitchToFileTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SwitchToFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SwitchViewTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/SwitchViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/TypingInEditorTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/TypingInEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AboutDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AboutDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AddJDBCDriverDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AddJDBCDriverDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AddProfilingPointWizardTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AddProfilingPointWizardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AttachDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/AttachDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/DeleteFileDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/DeleteFileDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/DocumentsDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/DocumentsDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/FavoritesWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/FavoritesWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/FilesWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/FilesWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/FindInProjectsTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/FindInProjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/GotoLineDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/GotoLineDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/HelpContentsWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/HelpContentsWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/InternationalizeDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/InternationalizeDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/JavaPlatformManagerTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/JavaPlatformManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/JavadocIndexSearchTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/JavadocIndexSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/LibrariesManagerTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/LibrariesManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NetBeansPlatformManagerTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NetBeansPlatformManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewBreakpointDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewBreakpointDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewDatabaseConnectionDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewDatabaseConnectionDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewFileDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewFileDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewProjectDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewProjectDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewWatchDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/NewWatchDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OpenFileDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OpenFileDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OpenProjectDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OpenProjectDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OptionsTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OutputWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/OutputWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/PluginManagerTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/PluginManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProfilerWindowsTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProfilerWindowsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProjectPropertiesWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProjectPropertiesWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProjectsWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProjectsWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProxyConfigurationTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ProxyConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RefactorFindUsagesDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RefactorFindUsagesDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RefactorMoveClassDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RefactorMoveClassDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RefactorRenameDialogTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RefactorRenameDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RuntimeWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/RuntimeWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ServerManagerTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ServerManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/TemplateManagerTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/TemplateManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ToDoWindowTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/dialogs/ToDoWindowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/EditorDownButtonPopupMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/EditorDownButtonPopupMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/FilesViewPopupMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/FilesViewPopupMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/FormInspectorNodePopupMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/FormInspectorNodePopupMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/MainMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/MainMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/MainSubMenusTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/MainSubMenusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/ProjectsViewPopupMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/ProjectsViewPopupMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/ProjectsViewSubMenusTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/ProjectsViewSubMenusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/RuntimeViewPopupMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/RuntimeViewPopupMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/SourceEditorPopupMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/SourceEditorPopupMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/ToolsMenuTest.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/menus/ToolsMenuTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/setup/J2SEBaseSetup.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/setup/J2SEBaseSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/setup/J2SESetup.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/setup/J2SESetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/ComplexJavaProjectStartup.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/ComplexJavaProjectStartup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/ComplexNBProjectStartup.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/ComplexNBProjectStartup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/MeasureWarmUp.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/MeasureWarmUp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/OutOfTheBoxStartup.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/OutOfTheBoxStartup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/PrepareIDEForComplexMeasurements.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/PrepareIDEForComplexMeasurements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/PrepareIDEForPluginComplexMeasurements.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/PrepareIDEForPluginComplexMeasurements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/Utilities.java
+++ b/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/startup/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/unit/src/org/netbeans/performance/j2se/MeasureJ2SEFootprintsTest.java
+++ b/performance.java/test/unit/src/org/netbeans/performance/j2se/MeasureJ2SEFootprintsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/FindUsages.java
+++ b/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/FindUsages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/J2SEProjectWorkflow.java
+++ b/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/J2SEProjectWorkflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/OutOfTheBox.java
+++ b/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/OutOfTheBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/RefactoringRename.java
+++ b/performance.java/test/unit/src/org/netbeans/performance/j2se/footprints/RefactoringRename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/api/ContextProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/api/ContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/api/Engine.java
+++ b/performance/actionsframework/src/org/netbeans/actions/api/Engine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractContextMenuFactory.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractContextMenuFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractEngine.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractMenuFactory.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractMenuFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractToolbarFactory.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/AbstractToolbarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/ActionFactory.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/ActionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/ContextMenuFactory.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/ContextMenuFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/MenuFactory.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/MenuFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/engine/spi/ToolbarFactory.java
+++ b/performance/actionsframework/src/org/netbeans/actions/engine/spi/ToolbarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/examples/MiniEdit.java
+++ b/performance/actionsframework/src/org/netbeans/actions/examples/MiniEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/Interpreter.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/Interpreter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/SimpleActionProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/SimpleActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/SimpleConstraint.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/SimpleConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/SimpleContainerProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/SimpleContainerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/SimpleEngine.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/SimpleEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/SimpleInvoker.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/SimpleInvoker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/SimpleKey.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/SimpleKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/simple/SimpleKeymap.java
+++ b/performance/actionsframework/src/org/netbeans/actions/simple/SimpleKeymap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/spi/ActionProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/spi/ActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/spi/ContainerProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/spi/ContainerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/spi/ContextProviderSupport.java
+++ b/performance/actionsframework/src/org/netbeans/actions/spi/ContextProviderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/spi/ProxyActionProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/spi/ProxyActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/spi/ProxyContainerProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/spi/ProxyContainerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/actionsframework/src/org/netbeans/actions/spi/ProxyContextProvider.java
+++ b/performance/actionsframework/src/org/netbeans/actions/spi/ProxyContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/aspectj/ListenerCount.aj
+++ b/performance/aspectj/ListenerCount.aj
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/aspectj/SwingThreadRuleCheck.aj
+++ b/performance/aspectj/SwingThreadRuleCheck.aj
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/Benchmark.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/Benchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/BenchmarkSuite.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/BenchmarkSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/DataDescriptor.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/DataDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/DataManager.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/DataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/MapArgBenchmark.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/MapArgBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/MultiInstanceBenchmark.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/MultiInstanceBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/MultiInstanceIntArgBenchmark.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/MultiInstanceIntArgBenchmark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/PlainReporter.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/PlainReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/Reporter.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/Reporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/SuiteAssembler.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/SuiteAssembler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/XMLReporter.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/XMLReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/ArgumentSeries.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/ArgumentSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/BDEGrammar.jjt
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/BDEGrammar.jjt
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/Interval.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/Interval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/LoadDefinition.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/LoadDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/StoreDefinition.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/StoreDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/TestDefinition.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/TestDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/TestSpecBuilder.java
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/TestSpecBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/override/SimpleNode.xjava
+++ b/performance/benchmarks/src/org/netbeans/performance/benchmarks/bde/override/SimpleNode.xjava
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/djava/security/MessageDigestTest.java
+++ b/performance/benchmarks/test/perf/src/djava/security/MessageDigestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/djava/util/jar/ManifestTest.java
+++ b/performance/benchmarks/test/perf/src/djava/util/jar/ManifestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/bundle/PropertiesTest.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/bundle/PropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTest.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestArrayList.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestArrayList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestArrayListForN.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestArrayListForN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestLinkedList.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestLinkedList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestVector.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestVectorForN.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/collections/ListTestVectorForN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/CopyArray.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/CopyArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/EventQueueTest.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/EventQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/ExceptionConstruct.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/ExceptionConstruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/InnerClassConstruct.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/InnerClassConstruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/RunnableMethod.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/RunnableMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/SetThreadName.java
+++ b/performance/benchmarks/test/perf/src/org/netbeans/performance/platform/SetThreadName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/reports/src/org/netbeans/performance/results/AnalyzeResultsTask.java
+++ b/performance/benchmarks/test/reports/src/org/netbeans/performance/results/AnalyzeResultsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/reports/src/org/netbeans/performance/results/ComparePanel.java
+++ b/performance/benchmarks/test/reports/src/org/netbeans/performance/results/ComparePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/reports/src/org/netbeans/performance/results/GUI.java
+++ b/performance/benchmarks/test/reports/src/org/netbeans/performance/results/GUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/reports/src/org/netbeans/performance/results/ReportUtils.java
+++ b/performance/benchmarks/test/reports/src/org/netbeans/performance/results/ReportUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/reports/src/org/netbeans/performance/results/TestCaseResults.java
+++ b/performance/benchmarks/test/reports/src/org/netbeans/performance/results/TestCaseResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/reports/src/org/netbeans/performance/results/TestResult.java
+++ b/performance/benchmarks/test/reports/src/org/netbeans/performance/results/TestResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/benchmarks/test/reports/test/src/org/netbeans/performance/results/TestResultTest.java
+++ b/performance/benchmarks/test/reports/test/src/org/netbeans/performance/results/TestResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/cnd/test/qa-functional/src/org/netbeans/performance/cnd/MeasureCNDSetupTest.java
+++ b/performance/cnd/test/qa-functional/src/org/netbeans/performance/cnd/MeasureCNDSetupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/cnd/test/qa-functional/src/org/netbeans/performance/cnd/setup/CNDSetup.java
+++ b/performance/cnd/test/qa-functional/src/org/netbeans/performance/cnd/setup/CNDSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/cnd/test/unit/src/org/netbeans/performance/cnd/Utilities.java
+++ b/performance/cnd/test/unit/src/org/netbeans/performance/cnd/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/AirlineReservationPortType.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/AirlineReservationPortType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/AirlineReservationPortType_Impl.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/AirlineReservationPortType_Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/AirlineReservationService.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/AirlineReservationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/HotelReservationPortType.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/HotelReservationPortType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/HotelReservationPortType_Impl.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/HotelReservationPortType_Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/HotelReservationService.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/HotelReservationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/PartnerUtils.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/PartnerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/VehicleReservationPortType.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/VehicleReservationPortType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/VehicleReservationPortType_Impl.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/VehicleReservationPortType_Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/VehicleReservationService.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/VehicleReservationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/callback/ReservationCallbackProviderBean.java
+++ b/performance/enterprise/test/qa-functional/data/TravelReservationService/ReservationPartnerServices/src/java/partnerservices/callback/ReservationCallbackProviderBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/EPUtilities.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/EPUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseActions1Test.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseActions1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseActions2Test.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseActions2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseActions3Test.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseActions3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseGCTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseGCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseSetupTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/MeasureEnterpriseSetupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/XMLSchemaComponentOperator.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/XMLSchemaComponentOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewBpelProcessTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewBpelProcessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewWSDLDocumentTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewWSDLDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewXMLDocumentTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewXMLDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewXMLSchemaTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/AddNewXMLSchemaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/ApplyDesignPatternTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/ApplyDesignPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/BuildComplexProjectTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/BuildComplexProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/CreateBPELmoduleTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/CreateBPELmoduleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/CreateCompositeApplicationTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/CreateCompositeApplicationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/NavigatorSchemaViewModeTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/NavigatorSchemaViewModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/OpenBPELprojectTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/OpenBPELprojectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/OpenComplexDiagramTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/OpenComplexDiagramTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/OpenSchemaViewTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/OpenSchemaViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SchemaNavigatorDesignViewTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SchemaNavigatorDesignViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SchemaNavigatorSchemaViewTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SchemaNavigatorSchemaViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SchemaViewSwitchTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SchemaViewSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SwitchToDesignViewTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SwitchToDesignViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SwitchToSchemaViewTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/SwitchToSchemaViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/ValidateSchemaTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/ValidateSchemaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/WatchProjectsTest.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/actions/WatchProjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/setup/EnterpriseSetup.java
+++ b/performance/enterprise/test/qa-functional/src/org/netbeans/performance/enterprise/setup/EnterpriseSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/footprint/EPFootprintUtilities.java
+++ b/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/footprint/EPFootprintUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/footprint/J2EEProjectWorkflow.java
+++ b/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/footprint/J2EEProjectWorkflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/prepare/PrepareIDEForEnterpriseComplexMeasurements.java
+++ b/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/prepare/PrepareIDEForEnterpriseComplexMeasurements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/scanclasspath/EPScanClasspath.java
+++ b/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/scanclasspath/EPScanClasspath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/startup/ComplexEnterpriseProjectStartup.java
+++ b/performance/enterprise/test/unit/src/org/netbeans/performance/enterprise/startup/ComplexEnterpriseProjectStartup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/CDataBuffer.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/CDataBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/CImage.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/CImage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/CRaster.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/CRaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/CSampleModel.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/CSampleModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/CacheReader.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/CacheReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/CacheWriter.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/CacheWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/CacheWriterTask.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/CacheWriterTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/imagecache/src/org/netbeans/imagecache/ImageCacheTest.java
+++ b/performance/imagecache/src/org/netbeans/imagecache/ImageCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/jtrace/src/jtrace.cpp
+++ b/performance/jtrace/src/jtrace.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/data/MobileApplicationSwitchConfiguration/src/switchit/Midlet.java
+++ b/performance/mobility/test/qa-functional/data/MobileApplicationSwitchConfiguration/src/switchit/Midlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/data/MobileApplicationVisualMIDlet/src/allComponents/VisualMIDletMIDP20.java
+++ b/performance/mobility/test/qa-functional/data/MobileApplicationVisualMIDlet/src/allComponents/VisualMIDletMIDP20.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/data/MobileApplicationVisualMIDlet/src/simple/VisualMIDlet.java
+++ b/performance/mobility/test/qa-functional/data/MobileApplicationVisualMIDlet/src/simple/VisualMIDlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MIDletEditorOperator.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MIDletEditorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MPUtilities.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MPUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MeasureMobilityActionsTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MeasureMobilityActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MeasureMobilityDialogsTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MeasureMobilityDialogsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MeasureMobilitySetupTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/MeasureMobilitySetupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/CreateMIDletTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/CreateMIDletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/CreateMobilityProjectTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/CreateMobilityProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/CreateVisualMIDletTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/CreateVisualMIDletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/MIDletViewsSwitchTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/MIDletViewsSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/OpenMIDletEditorTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/OpenMIDletEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/OpenMobileProjectTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/OpenMobileProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/SwitchConfigurationTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/actions/SwitchConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/CloseProjectPropertyTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/CloseProjectPropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/MobilityDeploymentManagerDialogTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/MobilityDeploymentManagerDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/NewConfigurationDialogTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/NewConfigurationDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/ProjectPropertiesDialogTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/ProjectPropertiesDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/QuickRunDialogTest.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/dialogs/QuickRunDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/setup/MobilitySetup.java
+++ b/performance/mobility/test/qa-functional/src/org/netbeans/performance/mobility/setup/MobilitySetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/unit/src/org/netbeans/performance/mobility/footprint/MPOutOfTheBox.java
+++ b/performance/mobility/test/unit/src/org/netbeans/performance/mobility/footprint/MPOutOfTheBox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/unit/src/org/netbeans/performance/mobility/footprint/MobilityProjectWorkflow.java
+++ b/performance/mobility/test/unit/src/org/netbeans/performance/mobility/footprint/MobilityProjectWorkflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/unit/src/org/netbeans/performance/mobility/prepare/PrepareIDEForMobilityComplexMeasurementsTest.java
+++ b/performance/mobility/test/unit/src/org/netbeans/performance/mobility/prepare/PrepareIDEForMobilityComplexMeasurementsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/unit/src/org/netbeans/performance/mobility/scanclasspath/MPScanClasspath.java
+++ b/performance/mobility/test/unit/src/org/netbeans/performance/mobility/scanclasspath/MPScanClasspath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/unit/src/org/netbeans/performance/mobility/startup/ComplexMobilityProjectStartup.java
+++ b/performance/mobility/test/unit/src/org/netbeans/performance/mobility/startup/ComplexMobilityProjectStartup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/mobility/test/unit/src/org/netbeans/performance/mobility/startup/OutOfTheBoxStartupWTK.java
+++ b/performance/mobility/test/unit/src/org/netbeans/performance/mobility/startup/OutOfTheBoxStartupWTK.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/antext/CheckForJFreeChart.java
+++ b/performance/sparrow/src/org/netbeans/performance/antext/CheckForJFreeChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/antext/ForEachFileTask.java
+++ b/performance/sparrow/src/org/netbeans/performance/antext/ForEachFileTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/antext/GenerateHTMLreport.java
+++ b/performance/sparrow/src/org/netbeans/performance/antext/GenerateHTMLreport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/antext/IteratingTask.java
+++ b/performance/sparrow/src/org/netbeans/performance/antext/IteratingTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/analysis/ChartMaker.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/analysis/ChartMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/analysis/GcCharts.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/analysis/GcCharts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/analysis/GenRunsData.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/analysis/GenRunsData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/chart/NbChart.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/chart/NbChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/chart/NbStatisticalDataset.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/chart/NbStatisticalDataset.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/FolderAggregation.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/FolderAggregation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/Gc.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/Gc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/GcLog.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/GcLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/GcTestSet.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/GcTestSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/IdeCfg.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/IdeCfg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/JavaLineswitch.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/JavaLineswitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/ModuleEntry.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/ModuleEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/ModulesLog.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/ModulesLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/NbLog.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/NbLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/NbRunLog.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/NbRunLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/TestSet.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/TestSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/TimeLog.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/TimeLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/impl/logparsing/Utils.java
+++ b/performance/sparrow/src/org/netbeans/performance/impl/logparsing/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/AbstractDataAggregation.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/AbstractDataAggregation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/AbstractLogElement.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/AbstractLogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/AbstractLogFile.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/AbstractLogFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/Analyzer.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/Analyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/Average.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/Average.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/AveragedNameValueLogElement.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/AveragedNameValueLogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/DataAggregation.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/DataAggregation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/DataNotFoundException.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/DataNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/ElementFilter.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/ElementFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/LogElement.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/LogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/LogFile.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/LogFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/NameValueLogElement.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/NameValueLogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/NameValuePairLogElement.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/NameValuePairLogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/Named.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/Named.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/ParseException.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/Timestamped.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/Timestamped.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/TimestampedLogElement.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/TimestampedLogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/ValueLogElement.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/ValueLogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/Valued.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/Valued.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/AbstractHTML.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/AbstractHTML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/AbstractHTMLContainer.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/AbstractHTMLContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTML.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLContainer.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLDocument.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLImage.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLImage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLIterator.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLListItem.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLListItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLSubdocument.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLSubdocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLTable.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLTableRow.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLTableRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLTextItem.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLTextItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLUnorderedList.java
+++ b/performance/sparrow/src/org/netbeans/performance/spi/html/HTMLUnorderedList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/Inst.java
+++ b/performance/src/org/netbeans/modules/performance/Inst.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/guitracker/ActionTracker.java
+++ b/performance/src/org/netbeans/modules/performance/guitracker/ActionTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/guitracker/LoggingEventQueue.java
+++ b/performance/src/org/netbeans/modules/performance/guitracker/LoggingEventQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/guitracker/LoggingRepaintManager.java
+++ b/performance/src/org/netbeans/modules/performance/guitracker/LoggingRepaintManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/guitracker/Main.java
+++ b/performance/src/org/netbeans/modules/performance/guitracker/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/utilities/CommonUtilities.java
+++ b/performance/src/org/netbeans/modules/performance/utilities/CommonUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/utilities/LoggingScanClasspath.java
+++ b/performance/src/org/netbeans/modules/performance/utilities/LoggingScanClasspath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/utilities/MeasureStartupTimeTestCase.java
+++ b/performance/src/org/netbeans/modules/performance/utilities/MeasureStartupTimeTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/utilities/MemoryFootprintTestCase.java
+++ b/performance/src/org/netbeans/modules/performance/utilities/MemoryFootprintTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/utilities/PerformanceTestCase.java
+++ b/performance/src/org/netbeans/modules/performance/utilities/PerformanceTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/utilities/PerformanceTestCase2.java
+++ b/performance/src/org/netbeans/modules/performance/utilities/PerformanceTestCase2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/src/org/netbeans/modules/performance/utilities/ValidatePopupMenuOnNodes.java
+++ b/performance/src/org/netbeans/modules/performance/utilities/ValidatePopupMenuOnNodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/qa-functional/src/org/netbeans/test/ide/PerfCountingSecurityManager.java
+++ b/performance/test/qa-functional/src/org/netbeans/test/ide/PerfCountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/qa-functional/src/org/netbeans/test/ide/PerfIDECommitValidationTest.java
+++ b/performance/test/qa-functional/src/org/netbeans/test/ide/PerfIDECommitValidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/qa-functional/src/org/netbeans/test/ide/PerfIDEValidation.java
+++ b/performance/test/qa-functional/src/org/netbeans/test/ide/PerfIDEValidation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/qa-functional/src/org/netbeans/test/ide/PerfMemoryValidationTest.java
+++ b/performance/test/qa-functional/src/org/netbeans/test/ide/PerfMemoryValidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/qa-functional/src/org/netbeans/test/ide/PerfUtil.java
+++ b/performance/test/qa-functional/src/org/netbeans/test/ide/PerfUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/qa-functional/src/org/netbeans/test/ide/PerfWatchProjects.java
+++ b/performance/test/qa-functional/src/org/netbeans/test/ide/PerfWatchProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scalability/AWTThreadFreeTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scalability/AWTThreadFreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scalability/Calls.java
+++ b/performance/test/unit/src/org/netbeans/performance/scalability/Calls.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scalability/CountingSecurityManager.java
+++ b/performance/test/unit/src/org/netbeans/performance/scalability/CountingSecurityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scalability/ExpandFolderTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scalability/ExpandFolderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scalability/MeasureScalabilityTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scalability/MeasureScalabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scalability/TabSwitchSpeedTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scalability/TabSwitchSpeedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scanning/JavaNavigatorPerfTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scanning/JavaNavigatorPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scanning/MeasureScanningTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scanning/MeasureScanningTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scanning/ScanProjectPerfTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scanning/ScanProjectPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scanning/ScanSeveralProjectsPerfTest.java
+++ b/performance/test/unit/src/org/netbeans/performance/scanning/ScanSeveralProjectsPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scanning/ScanningHandler.java
+++ b/performance/test/unit/src/org/netbeans/performance/scanning/ScanningHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/test/unit/src/org/netbeans/performance/scanning/Utilities.java
+++ b/performance/test/unit/src/org/netbeans/performance/scanning/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/Main.java
+++ b/performance/threaddemo/src/threaddemo/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/Monitor.java
+++ b/performance/threaddemo/src/threaddemo/Monitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/apps/index/Index.java
+++ b/performance/threaddemo/src/threaddemo/apps/index/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/apps/index/IndexApp.java
+++ b/performance/threaddemo/src/threaddemo/apps/index/IndexApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/apps/index/IndexImpl.java
+++ b/performance/threaddemo/src/threaddemo/apps/index/IndexImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/apps/populate/Populate.java
+++ b/performance/threaddemo/src/threaddemo/apps/populate/Populate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/apps/refactor/Refactor.java
+++ b/performance/threaddemo/src/threaddemo/apps/refactor/Refactor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/data/DomProvider.java
+++ b/performance/threaddemo/src/threaddemo/data/DomProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/data/DomSupport.java
+++ b/performance/threaddemo/src/threaddemo/data/DomSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/data/PhadhailEditorSupport.java
+++ b/performance/threaddemo/src/threaddemo/data/PhadhailEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/data/PhadhailLookups.java
+++ b/performance/threaddemo/src/threaddemo/data/PhadhailLookups.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/data/PhadhailNewType.java
+++ b/performance/threaddemo/src/threaddemo/data/PhadhailNewType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/DuplexLock.java
+++ b/performance/threaddemo/src/threaddemo/locking/DuplexLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/EventHybridLock.java
+++ b/performance/threaddemo/src/threaddemo/locking/EventHybridLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/EventLock.java
+++ b/performance/threaddemo/src/threaddemo/locking/EventLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/LockAction.java
+++ b/performance/threaddemo/src/threaddemo/locking/LockAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/LockExceptionAction.java
+++ b/performance/threaddemo/src/threaddemo/locking/LockExceptionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/Locks.java
+++ b/performance/threaddemo/src/threaddemo/locking/Locks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/MonitorLock.java
+++ b/performance/threaddemo/src/threaddemo/locking/MonitorLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/PrivilegedLock.java
+++ b/performance/threaddemo/src/threaddemo/locking/PrivilegedLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/RWLock.java
+++ b/performance/threaddemo/src/threaddemo/locking/RWLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/ReadWriteLockWrapper.java
+++ b/performance/threaddemo/src/threaddemo/locking/ReadWriteLockWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/locking/Worker.java
+++ b/performance/threaddemo/src/threaddemo/locking/Worker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/AbstractPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/AbstractPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/BufferedPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/BufferedPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/EventHybridLockedPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/EventHybridLockedPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/LockedPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/LockedPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/MonitoredPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/MonitoredPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/Phadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/Phadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/PhadhailEvent.java
+++ b/performance/threaddemo/src/threaddemo/model/PhadhailEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/PhadhailListener.java
+++ b/performance/threaddemo/src/threaddemo/model/PhadhailListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/PhadhailNameEvent.java
+++ b/performance/threaddemo/src/threaddemo/model/PhadhailNameEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/Phadhails.java
+++ b/performance/threaddemo/src/threaddemo/model/Phadhails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/SpunPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/SpunPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/SwungPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/SwungPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/model/SynchPhadhail.java
+++ b/performance/threaddemo/src/threaddemo/model/SynchPhadhail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/util/ClobberException.java
+++ b/performance/threaddemo/src/threaddemo/util/ClobberException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/util/DocumentParseSupport.java
+++ b/performance/threaddemo/src/threaddemo/util/DocumentParseSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/util/DocumentParseSupportDelta.java
+++ b/performance/threaddemo/src/threaddemo/util/DocumentParseSupportDelta.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/util/TwoWayEvent.java
+++ b/performance/threaddemo/src/threaddemo/util/TwoWayEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/util/TwoWayListener.java
+++ b/performance/threaddemo/src/threaddemo/util/TwoWayListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/util/TwoWaySupport.java
+++ b/performance/threaddemo/src/threaddemo/util/TwoWaySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/ElementLook.java
+++ b/performance/threaddemo/src/threaddemo/views/ElementLook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/PhadhailLook.java
+++ b/performance/threaddemo/src/threaddemo/views/PhadhailLook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/PhadhailLookProvider.java
+++ b/performance/threaddemo/src/threaddemo/views/PhadhailLookProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/PhadhailNode.java
+++ b/performance/threaddemo/src/threaddemo/views/PhadhailNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/PhadhailTreeModel.java
+++ b/performance/threaddemo/src/threaddemo/views/PhadhailTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/PhadhailViews.java
+++ b/performance/threaddemo/src/threaddemo/views/PhadhailViews.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/looktree/LookTreeCellEditor.java
+++ b/performance/threaddemo/src/threaddemo/views/looktree/LookTreeCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/looktree/LookTreeCellRenderer.java
+++ b/performance/threaddemo/src/threaddemo/views/looktree/LookTreeCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/looktree/LookTreeModel.java
+++ b/performance/threaddemo/src/threaddemo/views/looktree/LookTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/looktree/LookTreeNode.java
+++ b/performance/threaddemo/src/threaddemo/views/looktree/LookTreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/looktree/LookTreePath.java
+++ b/performance/threaddemo/src/threaddemo/views/looktree/LookTreePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/looktree/LookTreeView.java
+++ b/performance/threaddemo/src/threaddemo/views/looktree/LookTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/src/threaddemo/views/looktree/PopupHandler.java
+++ b/performance/threaddemo/src/threaddemo/views/looktree/PopupHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/test/threaddemo/locking/EventHybridLockTest.java
+++ b/performance/threaddemo/test/threaddemo/locking/EventHybridLockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/test/threaddemo/locking/EventLockTest.java
+++ b/performance/threaddemo/test/threaddemo/locking/EventLockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/test/threaddemo/locking/ReadWriteLockTest.java
+++ b/performance/threaddemo/test/threaddemo/locking/ReadWriteLockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/performance/threaddemo/test/threaddemo/util/TwoWaySupportTest.java
+++ b/performance/threaddemo/test/threaddemo/util/TwoWaySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print.editor/src/org/netbeans/modules/print/editor/Editor.java
+++ b/print.editor/src/org/netbeans/modules/print/editor/Editor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/api/print/PrintManager.java
+++ b/print/src/org/netbeans/api/print/PrintManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/action/PageSetupAction.java
+++ b/print/src/org/netbeans/modules/print/action/PageSetupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/action/PrintAction.java
+++ b/print/src/org/netbeans/modules/print/action/PrintAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/provider/ComponentDocument.java
+++ b/print/src/org/netbeans/modules/print/provider/ComponentDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/provider/ComponentLine.java
+++ b/print/src/org/netbeans/modules/print/provider/ComponentLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/provider/ComponentPage.java
+++ b/print/src/org/netbeans/modules/print/provider/ComponentPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/provider/ComponentPanel.java
+++ b/print/src/org/netbeans/modules/print/provider/ComponentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/provider/ComponentProvider.java
+++ b/print/src/org/netbeans/modules/print/provider/ComponentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/provider/EditorProvider.java
+++ b/print/src/org/netbeans/modules/print/provider/EditorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/provider/TextProvider.java
+++ b/print/src/org/netbeans/modules/print/provider/TextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/ui/Attribute.java
+++ b/print/src/org/netbeans/modules/print/ui/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/ui/Editor.java
+++ b/print/src/org/netbeans/modules/print/ui/Editor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/ui/Paper.java
+++ b/print/src/org/netbeans/modules/print/ui/Paper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/ui/Preview.java
+++ b/print/src/org/netbeans/modules/print/ui/Preview.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/ui/Printer.java
+++ b/print/src/org/netbeans/modules/print/ui/Printer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/util/Config.java
+++ b/print/src/org/netbeans/modules/print/util/Config.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/util/Macro.java
+++ b/print/src/org/netbeans/modules/print/util/Macro.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/util/Percent.java
+++ b/print/src/org/netbeans/modules/print/util/Percent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/modules/print/util/UI.java
+++ b/print/src/org/netbeans/modules/print/util/UI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/spi/print/PrintPage.java
+++ b/print/src/org/netbeans/spi/print/PrintPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/src/org/netbeans/spi/print/PrintProvider.java
+++ b/print/src/org/netbeans/spi/print/PrintProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/print/test/unit/src/org/netbeans/modules/print/test/PrintManagerTest.java
+++ b/print/test/unit/src/org/netbeans/modules/print/test/PrintManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ActionsSupport.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ActionsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/EditorContext.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/EditorContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/EditorSupport.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/EditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/GestureSubmitter.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/GestureSubmitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/GoToSource.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/GoToSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/JavaPlatform.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/JavaPlatform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerDialogs.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerDialogs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerIDESettings.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerIDESettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerProject.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerSource.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerStorage.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ProfilerStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ProgressDisplayer.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ProgressDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/ProjectUtilities.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/ProjectUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/icons/GeneralIcons.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/icons/GeneralIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/icons/Icons.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/icons/Icons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/icons/LanguageIcons.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/icons/LanguageIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/icons/ProfilerIcons.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/icons/ProfilerIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/java/ExternalPackages.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/java/ExternalPackages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/java/JavaProfilerSource.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/java/JavaProfilerSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/java/ProfilerTypeUtils.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/java/ProfilerTypeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/java/SourceClassInfo.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/java/SourceClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/java/SourceMethodInfo.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/java/SourceMethodInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/java/SourcePackageInfo.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/java/SourcePackageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/project/ProjectContentsSupport.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/project/ProjectContentsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/api/project/ProjectProfilingSupport.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/api/project/ProjectProfilingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/ActionsSupportProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/ActionsSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/EditorSupportProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/EditorSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/IconsProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/IconsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/JavaPlatformManagerProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/JavaPlatformManagerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/JavaPlatformProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/JavaPlatformProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/LoadGenPlugin.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/LoadGenPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/ProfilerDialogsProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/ProfilerDialogsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/ProfilerStorageProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/ProfilerStorageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/ProjectUtilitiesProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/ProjectUtilitiesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/SessionListener.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/SessionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/java/AbstractJavaProfilerSource.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/java/AbstractJavaProfilerSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/java/GoToSourceProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/java/GoToSourceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/java/ProfilerTypeUtilsProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/java/ProfilerTypeUtilsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/project/ProjectContentsSupportProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/project/ProjectContentsSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.api/src/org/netbeans/modules/profiler/spi/project/ProjectProfilingSupportProvider.java
+++ b/profiler.api/src/org/netbeans/modules/profiler/spi/project/ProjectProfilingSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.attach/src/org/netbeans/modules/profiler/attach/AttachWizard.java
+++ b/profiler.attach/src/org/netbeans/modules/profiler/attach/AttachWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.attach/src/org/netbeans/modules/profiler/attach/dialog/AttachDialog.java
+++ b/profiler.attach/src/org/netbeans/modules/profiler/attach/dialog/AttachDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.attach/src/org/netbeans/modules/profiler/attach/providers/RemotePackExporter.java
+++ b/profiler.attach/src/org/netbeans/modules/profiler/attach/providers/RemotePackExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.attach/src/org/netbeans/modules/profiler/attach/providers/TargetPlatformEnum.java
+++ b/profiler.attach/src/org/netbeans/modules/profiler/attach/providers/TargetPlatformEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.attach/src/org/netbeans/modules/profiler/attach/spi/AbstractRemotePackExporter.java
+++ b/profiler.attach/src/org/netbeans/modules/profiler/attach/spi/AbstractRemotePackExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.attach/src/org/netbeans/modules/profiler/attach/spi/AttachStepsProvider.java
+++ b/profiler.attach/src/org/netbeans/modules/profiler/attach/spi/AttachStepsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.attach/src/org/netbeans/modules/profiler/attach/steps/BasicAttachStepsProvider.java
+++ b/profiler.attach/src/org/netbeans/modules/profiler/attach/steps/BasicAttachStepsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.freeform/src/org/netbeans/modules/profiler/freeform/FreeFormAntProjectSupportProvider.java
+++ b/profiler.freeform/src/org/netbeans/modules/profiler/freeform/FreeFormAntProjectSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.freeform/src/org/netbeans/modules/profiler/freeform/FreeFormProjectProfilingSupportProvider.java
+++ b/profiler.freeform/src/org/netbeans/modules/profiler/freeform/FreeFormProjectProfilingSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.freeform/src/org/netbeans/modules/profiler/freeform/FreeFormProjectsSupport.java
+++ b/profiler.freeform/src/org/netbeans/modules/profiler/freeform/FreeFormProjectsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.freeform/src/org/netbeans/modules/profiler/freeform/Util.java
+++ b/profiler.freeform/src/org/netbeans/modules/profiler/freeform/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/AbstractController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/AbstractController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/AbstractTopLevelController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/AbstractTopLevelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/AnalysisController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/AnalysisController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassPresenterPanel.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassPresenterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesListController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesListController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/CompareSnapshotsHelper.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/CompareSnapshotsHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/FieldsBrowserController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/FieldsBrowserController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapFragmentWalker.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapFragmentWalker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalker.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalkerManager.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalkerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HintsController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HintsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesListController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesListController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/LegendPanel.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/LegendPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/NavigationHistoryManager.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/NavigationHistoryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OQLController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OQLController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OQLSupport.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OQLSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ReferencesBrowserController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ReferencesBrowserController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/SummaryController.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/SummaryController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/api/DetailsSupport.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/api/DetailsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/ArrayDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/ArrayDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/ArrayValueView.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/ArrayValueView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/BasicExportAction.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/BasicExportAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/PrimitiveDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/PrimitiveDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/StringDecoder.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/StringDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/StringDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/StringDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/AtomicDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/AtomicDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/IoDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/IoDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/JmxDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/JmxDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/LangDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/LangDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/MathDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/MathDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/NetDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/NetDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ReferenceDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ReferenceDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ReflectionDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ReflectionDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ThreadDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ThreadDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/UtilDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/UtilDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/FieldAccessor.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/FieldAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageBuilder.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageDetailProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageDetailProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageExportAction.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageExportAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/InstanceBuilder.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/InstanceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/InstanceBuilderRegistry.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/InstanceBuilderRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/AwtDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/AwtDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/BaseBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/BaseBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/BorderBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/BorderBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/ButtonBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/ButtonBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/ComponentBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/ComponentBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/ComponentDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/ComponentDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/DataViewBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/DataViewBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/JComponentBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/JComponentBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/PaneBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/PaneBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/TextComponentBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/TextComponentBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/Utils.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/WindowBuilders.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/WindowBuilders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/EditorDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/EditorDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/JavaDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/JavaDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/JavacDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/JavacDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/PlatformDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/PlatformDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/VCSDetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/VCSDetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/spi/DetailsProvider.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/spi/DetailsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/spi/DetailsUtils.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/spi/DetailsUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Distribution.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Distribution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/FieldAccess.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/FieldAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Histogram.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Histogram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/IteratingRule.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/IteratingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/MemoryLint.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/MemoryLint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Rule.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/RuleRegistry.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/RuleRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/StringHelper.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/StringHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Utils.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Walker.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/Walker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/CollapsedHashMap.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/CollapsedHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/DeepSize.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/DeepSize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/DuplicatedString.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/DuplicatedString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/HashMapHistogram.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/HashMapHistogram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/OverallocatedString.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/OverallocatedString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/RetainedSetByClass.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/RetainedSetByClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/RetainedSetByInstance.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/RetainedSetByInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/TooManyBooleans.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/TooManyBooleans.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/WrongWeakHashMap.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/memorylint/rules/WrongWeakHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/AbstractHeapWalkerNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/AbstractHeapWalkerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ArrayItem.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ArrayItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ArrayNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ArrayNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/BrowserUtils.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/BrowserUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ChildrenComputer.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ChildrenComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ClassNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ClassNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapPatterns.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapPatterns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerFieldNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerFieldNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerInstanceNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerInstanceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNodeFactory.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/InstanceNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/InstanceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/InstancesContainerNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/InstancesContainerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectArrayFieldNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectArrayFieldNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectArrayNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectArrayNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectFieldNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectFieldNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveArrayFieldNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveArrayFieldNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveArrayNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveArrayNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveFieldNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveFieldNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/RootNode.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/oql/ui/OQLEditor.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/oql/ui/OQLEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/AnalysisControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/AnalysisControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/ClassesControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/ClassesControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/ClassesListControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/ClassesListControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/CollapsibleSplitPane.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/CollapsibleSplitPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldTableCellRenderer.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldTreeCellRenderer.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldTreeCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldsBrowserControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldsBrowserControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/HeapFragmentWalkerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/HeapFragmentWalkerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/HeapWalkerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/HeapWalkerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/InstancesControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/InstancesControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/InstancesListControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/InstancesListControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OQLControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OQLControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OQLQueryCustomizer.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OQLQueryCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OpenHeapWalkerAction.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OpenHeapWalkerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OverviewControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OverviewControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/ReferencesBrowserControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/ReferencesBrowserControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/SummaryControllerUI.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/SummaryControllerUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/icons/HeapWalkerIcons.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/icons/HeapWalkerIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/icons/impl/HeapWalkerIconsProviderImpl.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/icons/impl/HeapWalkerIconsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalker/HprofDataObject.java
+++ b/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalker/HprofDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/src/org/netbeans/modules/profiler/j2se/J2SEAntProjectSupportProvider.java
+++ b/profiler.j2se/src/org/netbeans/modules/profiler/j2se/J2SEAntProjectSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/src/org/netbeans/modules/profiler/j2se/J2SEProjectProfilingSupportProvider.java
+++ b/profiler.j2se/src/org/netbeans/modules/profiler/j2se/J2SEProjectProfilingSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/src/org/netbeans/modules/profiler/j2se/JFXProjectProfilingSupportProvider.java
+++ b/profiler.j2se/src/org/netbeans/modules/profiler/j2se/JFXProjectProfilingSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/files/ChildTestOutputStream.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/files/ChildTestOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/files/TestFileOutputStream.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/files/TestFileOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/files/TestFileReader.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/files/TestFileReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/listeners/SubTestAWTEventListener.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/listeners/SubTestAWTEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/listeners/TestAWTEventListener.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/listeners/TestAWTEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/listeners/TestMouseListener.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/listeners/TestMouseListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/painters/TestComponent.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/painters/TestComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/painters/TestPanel.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/painters/TestPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/socket/TestSocketChanel.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/socket/TestSocketChanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/streams/TestInputStream.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/streams/TestInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/data/JavaApp/src/ui/TestUIManager.java
+++ b/profiler.j2se/test/unit/data/JavaApp/src/ui/TestUIManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/RepositoryImpl.java
+++ b/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestGraphBuilder.java
+++ b/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestGraphBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestUtilities.java
+++ b/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/antsrc/org/netbeans/modules/profiler/nbimpl/BuildEndListener.java
+++ b/profiler.nbimpl/antsrc/org/netbeans/modules/profiler/nbimpl/BuildEndListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/antsrc/org/netbeans/modules/profiler/nbimpl/NBProfileDirectTask.java
+++ b/profiler.nbimpl/antsrc/org/netbeans/modules/profiler/nbimpl/NBProfileDirectTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/antsrc/org/netbeans/modules/profiler/nbimpl/StartProfilerTask.java
+++ b/profiler.nbimpl/antsrc/org/netbeans/modules/profiler/nbimpl/StartProfilerTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/NetBeansProfiler.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/NetBeansProfiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/AntActions.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/AntActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/FileSensitivePerformer.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/FileSensitivePerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfileClassEditorAction.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfileClassEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfileElementNavigatorAction.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfileElementNavigatorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfileMethodEditorAction.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfileMethodEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfilerLauncher.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfilerLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfilerToolbarDropdownAction.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfilerToolbarDropdownAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProjectSensitivePerformer.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProjectSensitivePerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ClasspathInfoFactory.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ClasspathInfoFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ElementUtilitiesEx.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ElementUtilitiesEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacClassInfo.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacClassInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacMethodInfo.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacMethodInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacPackageInfo.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacPackageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ParsingUtils.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ParsingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ScanSensitiveTask.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/ScanSensitiveTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/AntProjectSupport.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/AntProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/AntProjectSupportProvider.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/AntProjectSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/JavaProjectContentsSupportProvider.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/JavaProjectContentsSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/JavaProjectProfilingSupportProvider.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/JavaProjectProfilingSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/ProjectUtilities.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/ProjectUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/AntRemotePackExporter.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/AntRemotePackExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/BaseProfilerTypeUtilsImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/BaseProfilerTypeUtilsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/DefaultProfilerArgsProvider.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/DefaultProfilerArgsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/FindActionProvider.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/FindActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/GlobalProfilerTypeUtilsImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/GlobalProfilerTypeUtilsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/GoToJavaSourceProvider.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/GoToJavaSourceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/JavaPlatformImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/JavaPlatformImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/JavaPlatformManagerImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/JavaPlatformManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/JavaProfilerSourceImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/JavaProfilerSourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProfilerStorageProviderImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProfilerStorageProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProfilingPointAnnotatorImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProfilingPointAnnotatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProfilingPointsUIHelperImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProfilingPointsUIHelperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProjectEditorSupportImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProjectEditorSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProjectProfilerTypeUtilsImpl.java
+++ b/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/ProjectProfilerTypeUtilsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/classinfo/ClassInfoTest.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/classinfo/ClassInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/files/ChildTestOutputStream.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/files/ChildTestOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/files/TestFileInputStream.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/files/TestFileInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/files/TestFileOutputStream.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/files/TestFileOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/listeners/TestAWTEventListener.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/listeners/TestAWTEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/listeners/TestMouseListener.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/listeners/TestMouseListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/listeners/sub/SubTestAWTEventListener.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/listeners/sub/SubTestAWTEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/painters/TestComponent.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/painters/TestComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/painters/TestPanel.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/painters/TestPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/socket/TestSocketChanel.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/socket/TestSocketChanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/streams/TestInputStream.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/streams/TestInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/data/JavaApp/src/ui/TestUIManager.java
+++ b/profiler.nbimpl/test/unit/data/JavaApp/src/ui/TestUIManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/BaseProjectTest.java
+++ b/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/BaseProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/TestUtilities.java
+++ b/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/javac/JavacClassInfoTest.java
+++ b/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/javac/JavacClassInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbmodule/src/org/netbeans/modules/profiler/nbmodule/NbModuleAntProjectSupportProvider.java
+++ b/profiler.nbmodule/src/org/netbeans/modules/profiler/nbmodule/NbModuleAntProjectSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.nbmodule/src/org/netbeans/modules/profiler/nbmodule/NbModuleProjectProfilingSupportProvider.java
+++ b/profiler.nbmodule/src/org/netbeans/modules/profiler/nbmodule/NbModuleProjectProfilingSupportProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ProfilerOptionsCategory.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ProfilerOptionsCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ui/ProfilerOptionsPanel.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ui/ProfilerOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/ProfilerOptionsContainer.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/ProfilerOptionsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/ProfilerOptionsPanel.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/ProfilerOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/EngineOptionsPanel.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/EngineOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/FiltersOptionsPanel.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/FiltersOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/GeneralOptionsPanel.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/GeneralOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/SnapshotsOptionsPanel.java
+++ b/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/impl/SnapshotsOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/ClassnameCompletionItem.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/ClassnameCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/FunctionCompletionItem.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/FunctionCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/KeywordCompletionItem.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/KeywordCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLEditorKit.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLEditorKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLLanguageHierarchy.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLLanguageHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLLanguageProvider.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLLanguageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLLexer.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLTokenId.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/PackageCompletionItem.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/PackageCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/ui/OQLEditor.java
+++ b/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/ui/OQLEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/OQLEngine.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/OQLEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/OQLException.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/OQLException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/ReferenceChain.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/ReferenceChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineImpl.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLQueryImpl.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/ReachableExcludes.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/ReachableExcludes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/ReachableObjects.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/ReachableObjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/TreeIterator.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/TreeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/hat.js
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/hat.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/icons/OQLIcons.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/icons/OQLIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/icons/impl/OQLIconsProviderImpl.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/icons/impl/OQLIconsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryCategory.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryDefinition.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryRepository.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/src/org/netbeans/modules/profiler/oql/spi/OQLEditorImpl.java
+++ b/profiler.oql/src/org/netbeans/modules/profiler/oql/spi/OQLEditorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/test/unit/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineTest.java
+++ b/profiler.oql/test/unit/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.oql/test/unit/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryRepositoryTest.java
+++ b/profiler.oql/test/unit/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryRepositoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/CodeProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/CodeProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/CodeProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/CodeProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/GlobalProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/GlobalProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/GlobalProfilingPointsProcessor.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/GlobalProfilingPointsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Installer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/LoadGenProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/LoadGenProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/LoadGenProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/LoadGenProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointAnnotator.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointScopeProvider.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointWizard.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointsAnnotationProvider.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointsAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointsManager.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ResetResultsProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ResetResultsProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ResetResultsProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ResetResultsProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/StopwatchProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/StopwatchProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/StopwatchProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/StopwatchProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TakeSnapshotProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TakeSnapshotProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TakeSnapshotProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TakeSnapshotProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedGlobalProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedGlobalProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedTakeSnapshotProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedTakeSnapshotProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedTakeSnapshotProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedTakeSnapshotProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredGlobalProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredGlobalProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredTakeSnapshotProfilingPoint.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredTakeSnapshotProfilingPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredTakeSnapshotProfilingPointFactory.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredTakeSnapshotProfilingPointFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Utils.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/CustomizeProfilingPointAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/CustomizeProfilingPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/DeleteProfilingPointAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/DeleteProfilingPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/EnableDisableProfilingPointAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/EnableDisableProfilingPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/InsertProfilingPointAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/InsertProfilingPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/InsertProfilingPointMenuAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/InsertProfilingPointMenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/LoadGeneratorCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/LoadGeneratorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/LocationCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/LocationCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/OpenProfilingPointsWindowAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/OpenProfilingPointsWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointReport.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsDisplayer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsIcons.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsUIHelper.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsUIHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsWindow.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsWindowUI.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProfilingPointsWindowUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProjectSelector.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ProjectSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ResetResultsCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ResetResultsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ShowOppositeProfilingPointAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ShowOppositeProfilingPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/SnapshotCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/SnapshotCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/StopwatchCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/StopwatchCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TakeSnapshotCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TakeSnapshotCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TimeCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TimeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TimedTakeSnapshotCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TimedTakeSnapshotCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ToggleProfilingPointAction.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ToggleProfilingPointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TriggerCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TriggerCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TriggeredTakeSnapshotCustomizer.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/TriggeredTakeSnapshotCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ValidityAwarePanel.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ValidityAwarePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ValidityListener.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ValidityListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/WizardPanel1UI.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/WizardPanel1UI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/icons/ProfilingPointsIcons.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/icons/ProfilingPointsIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/icons/ProfilingPointsIconsProviderImpl.java
+++ b/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/icons/ProfilingPointsIconsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/AbstractProjectLookupProvider.java
+++ b/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/AbstractProjectLookupProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/AppletSupport.java
+++ b/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/AppletSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilities.java
+++ b/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilitiesProviderImpl.java
+++ b/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilitiesProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ClassNameComparator.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ClassNameComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ItemValueFormatter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ItemValueFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/PackageStateHandler.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/PackageStateHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/Positionable.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/Positionable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ProbeItemDescriptor.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ProbeItemDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ProbeStateHandler.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/ProbeStateHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/SessionInitializationException.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/SessionInitializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerPackage.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerPackageProvider.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerPackageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerProbe.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerProbe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerProbeDescriptor.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerProbeDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerProgressObject.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerProgressObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerSupport.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/TracerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/AttachToBugAction.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/AttachToBugAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/DetailsView.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/DetailsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/ExportSnapshotAction.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/ExportSnapshotAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/IdeSnapshot.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/IdeSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/IdeSnapshotAction.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/IdeSnapshotAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/NpssDataObject.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/NpssDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TimelineView.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TimelineView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerController.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerModel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerSupportImpl.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerView.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/TracerView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsPanel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsTable.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsTableCellRenderer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsTableCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsTableModel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/DetailsTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/ItemValueRenderer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/ItemValueRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/MarkRenderer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/MarkRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/TimestampRenderer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/details/TimestampRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/CSVExporter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/CSVExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/DataExport.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/DataExport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/ExportBatch.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/ExportBatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/Exporter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/Exporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/HTMLExporter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/HTMLExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/XMLExporter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/XMLExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/icons/TracerIcons.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/icons/TracerIcons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/icons/TracerIconsProviderImpl.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/icons/TracerIconsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptions.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptionsCategory.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptionsCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptionsPanel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptionsPanelController.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/options/TracerOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/TestPackage.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/TestPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/TestPackageProvider.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/TestPackageProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/TestProbe.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/TestProbe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/UiGesturesProbe.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/packages/UiGesturesProbe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/probes/ProbeDescriptorComponent.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/probes/ProbeDescriptorComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/probes/ProbePresenter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/probes/ProbePresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ColorIcon.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ColorIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/CustomComboRenderer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/CustomComboRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/DropdownButton.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/DropdownButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/EnhancedLabelRenderer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/EnhancedLabelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HeaderButton.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HeaderButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HeaderLabel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HeaderLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HeaderPanel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HeaderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HorizontalLayout.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/HorizontalLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/LabelRenderer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/LabelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/LegendFont.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/LegendFont.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ScrollBar.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ScrollBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ScrollableContainer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ScrollableContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/SectionSeparator.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/SectionSeparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/Separator.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/Separator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/SimpleSeparator.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/SimpleSeparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/Spacer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/Spacer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/TimelineMarksPainter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/TimelineMarksPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/TransparentToolBar.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/TransparentToolBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/VerticalLayout.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/VerticalLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/VisibilityHandler.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/VisibilityHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/ChartPanel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/ChartPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/ContinuousXYPainter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/ContinuousXYPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/DiscreteXYPainter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/DiscreteXYPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/PointsComputer.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/PointsComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/ProbesPanel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/ProbesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/RowBackgroundDecorator.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/RowBackgroundDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/RowBoundsDecorator.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/RowBoundsDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/RowForegroundDecorator.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/RowForegroundDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineAxis.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineAxis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineChart.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineColorFactory.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineColorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineIconPainter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineIconPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineLegendOverlay.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineLegendOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineModel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelinePaintersFactory.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelinePaintersFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelinePanel.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelinePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSelectionManager.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSelectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSelectionOverlay.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSelectionOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSupport.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineTooltipOverlay.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineTooltipOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineTooltipPainter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineTooltipPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineUnitsOverlay.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineUnitsOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineXYItem.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineXYItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineXYPainter.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineXYPainter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/VerticalTimelineLayout.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/VerticalTimelineLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/XChartSelectionOverlay.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/XChartSelectionOverlay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/ContinuousXYItemDescriptor.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/ContinuousXYItemDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/DiscreteXYItemDescriptor.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/DiscreteXYItemDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/IconItemDescriptor.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/IconItemDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/ValueItemDescriptor.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/ValueItemDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/XYItemDescriptor.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/items/XYItemDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/logs/LogReader.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/logs/LogReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/logs/LogRecords.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/logs/LogRecords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/package-info.java
+++ b/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.utilities/src/org/netbeans/modules/profiler/utilities/Delegate.java
+++ b/profiler.utilities/src/org/netbeans/modules/profiler/utilities/Delegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.utilities/src/org/netbeans/modules/profiler/utilities/OutputParameter.java
+++ b/profiler.utilities/src/org/netbeans/modules/profiler/utilities/OutputParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.utilities/src/org/netbeans/modules/profiler/utilities/ProfilerUtils.java
+++ b/profiler.utilities/src/org/netbeans/modules/profiler/utilities/ProfilerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.utilities/src/org/netbeans/modules/profiler/utilities/Visitable.java
+++ b/profiler.utilities/src/org/netbeans/modules/profiler/utilities/Visitable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler.utilities/src/org/netbeans/modules/profiler/utilities/Visitor.java
+++ b/profiler.utilities/src/org/netbeans/modules/profiler/utilities/Visitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/HeapDumpWatch.java
+++ b/profiler/src/org/netbeans/modules/profiler/HeapDumpWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/LoadedSnapshot.java
+++ b/profiler/src/org/netbeans/modules/profiler/LoadedSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/NetBeansProfiler.java
+++ b/profiler/src/org/netbeans/modules/profiler/NetBeansProfiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ProfilerModule.java
+++ b/profiler/src/org/netbeans/modules/profiler/ProfilerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ProfilerTopComponent.java
+++ b/profiler/src/org/netbeans/modules/profiler/ProfilerTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ProfilingMonitor.java
+++ b/profiler/src/org/netbeans/modules/profiler/ProfilingMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ResultsListener.java
+++ b/profiler/src/org/netbeans/modules/profiler/ResultsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ResultsManager.java
+++ b/profiler/src/org/netbeans/modules/profiler/ResultsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/SampledCPUSnapshot.java
+++ b/profiler/src/org/netbeans/modules/profiler/SampledCPUSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/SaveSnapshotAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/SaveSnapshotAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ServerStateMonitor.java
+++ b/profiler/src/org/netbeans/modules/profiler/ServerStateMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/SnapshotInfoAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/SnapshotInfoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/SnapshotInfoPanel.java
+++ b/profiler/src/org/netbeans/modules/profiler/SnapshotInfoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/SnapshotResultsWindow.java
+++ b/profiler/src/org/netbeans/modules/profiler/SnapshotResultsWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/SnapshotsListener.java
+++ b/profiler/src/org/netbeans/modules/profiler/SnapshotsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ThreadDumpWindow.java
+++ b/profiler/src/org/netbeans/modules/profiler/ThreadDumpWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/AttachAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/AttachAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/CompareSnapshotsAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/CompareSnapshotsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/GetCmdLineArgumentsAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/GetCmdLineArgumentsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/HeapDumpAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/HeapDumpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/InternalStatsAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/InternalStatsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/JavaPlatformSelector.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/JavaPlatformSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/LoadSnapshotAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/LoadSnapshotAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/ProfilingAwareAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/ProfilingAwareAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/ProfilingSupport.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/ProfilingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/ResetResultsAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/ResetResultsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/RunCalibrationAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/RunCalibrationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/RunGCAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/RunGCAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/SnapshotsWindowAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/SnapshotsWindowAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/StopAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/StopAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/TakeSnapshotAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/TakeSnapshotAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/actions/TakeThreadDumpAction.java
+++ b/profiler/src/org/netbeans/modules/profiler/actions/TakeThreadDumpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/impl/CloseButtonProvider.java
+++ b/profiler/src/org/netbeans/modules/profiler/impl/CloseButtonProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/impl/ProfilerDialogs.java
+++ b/profiler/src/org/netbeans/modules/profiler/impl/ProfilerDialogs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/impl/ProfilerDialogsProviderImpl.java
+++ b/profiler/src/org/netbeans/modules/profiler/impl/ProfilerDialogsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/impl/icons/IconsProviderImpl.java
+++ b/profiler/src/org/netbeans/modules/profiler/impl/icons/IconsProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ui/HprofDataObject.java
+++ b/profiler/src/org/netbeans/modules/profiler/ui/HprofDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ui/NBHTMLLabel.java
+++ b/profiler/src/org/netbeans/modules/profiler/ui/NBHTMLLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ui/NBSwingWorker.java
+++ b/profiler/src/org/netbeans/modules/profiler/ui/NBSwingWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ui/NpsDataObject.java
+++ b/profiler/src/org/netbeans/modules/profiler/ui/NpsDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/ui/ProfilerProgressDisplayer.java
+++ b/profiler/src/org/netbeans/modules/profiler/ui/ProfilerProgressDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/utils/IDEUtils.java
+++ b/profiler/src/org/netbeans/modules/profiler/utils/IDEUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/utils/MainClassChooser.java
+++ b/profiler/src/org/netbeans/modules/profiler/utils/MainClassChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/utils/MainClassWarning.java
+++ b/profiler/src/org/netbeans/modules/profiler/utils/MainClassWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ProfilerFeature.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ProfilerFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ProfilerFeatures.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ProfilerFeatures.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ProfilerPlugin.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ProfilerPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ProfilerPlugins.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ProfilerPlugins.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ProfilerSession.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ProfilerSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ProfilerSessions.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ProfilerSessions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ProfilerWindow.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ProfilerWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/SessionStorage.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/SessionStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/SnapshotsWindow.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/SnapshotsWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/FeatureMode.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/FeatureMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/FeatureUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/FeatureUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/LocksFeature.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/LocksFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/LocksFeatureUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/LocksFeatureUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/MethodsFeature.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/MethodsFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/MethodsFeatureModes.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/MethodsFeatureModes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/MethodsFeatureUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/MethodsFeatureUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/MonitorFeature.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/MonitorFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/MonitorFeatureUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/MonitorFeatureUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/ObjectsFeature.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/ObjectsFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/ObjectsFeatureModes.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/ObjectsFeatureModes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/ObjectsFeatureUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/ObjectsFeatureUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/SQLFeature.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/SQLFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/SQLFeatureModes.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/SQLFeatureModes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/SQLFeatureUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/SQLFeatureUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/ThreadsFeature.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/ThreadsFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/features/ThreadsFeatureUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/features/ThreadsFeatureUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/ClassMethodList.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/ClassMethodList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/ClassMethodSelector.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/ClassMethodSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/FeaturesView.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/FeaturesView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/FilterSelector.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/FilterSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/ProfilerStatus.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/ProfilerStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/ProjectsSelector.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/ProjectsSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/SnapshotsWindowHelper.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/SnapshotsWindowHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/SnapshotsWindowUI.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/SnapshotsWindowUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/WeakProcessor.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/WeakProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/impl/WelcomePanel.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/impl/WelcomePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ui/DropdownButton.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ui/DropdownButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ui/ProjectSelector.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ui/ProjectSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ui/SettingsPanel.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ui/SettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ui/StayOpenPopupMenu.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ui/StayOpenPopupMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ui/TitledMenuSeparator.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ui/TitledMenuSeparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/src/org/netbeans/modules/profiler/v2/ui/ToggleButtonMenuItem.java
+++ b/profiler/src/org/netbeans/modules/profiler/v2/ui/ToggleButtonMenuItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/test/qa-functional/src/org/netbeans/test/profiler/ProfilerValidationTest.java
+++ b/profiler/test/qa-functional/src/org/netbeans/test/profiler/ProfilerValidationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/profiler/test/unit/src/org/netbeans/modules/profiler/actions/SelfSamplerActionTest.java
+++ b/profiler/test/unit/src/org/netbeans/modules/profiler/actions/SelfSamplerActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/AbstractWindowRunner.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/AbstractWindowRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/CancelAction.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/CancelAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/ListComponent.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/ListComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/NbProgressBar.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/NbProgressBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/PopupPane.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/PopupPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/ProgressListAction.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/ProgressListAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/ProgressUI.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/ProgressUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/ProgressVisualizerProvider.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/ProgressVisualizerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/ProviderImpl.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/ProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/RunOffEDTImpl.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/RunOffEDTImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/src/org/netbeans/modules/progress/ui/StatusLineComponent.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/StatusLineComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/test/unit/src/org/netbeans/modules/progress/ui/RunOffEDTImplTest.java
+++ b/progress.ui/test/unit/src/org/netbeans/modules/progress/ui/RunOffEDTImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/progress.ui/test/unit/src/org/netbeans/modules/progress/ui/StatusLineComponentTest.java
+++ b/progress.ui/test/unit/src/org/netbeans/modules/progress/ui/StatusLineComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.compat8/src/org/netbeans/spi/project/support/ant/ReferenceHelperCompat.java
+++ b/project.ant.compat8/src/org/netbeans/spi/project/support/ant/ReferenceHelperCompat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.compat8/test/unit/src/org/netbeans/spi/project/support/ant/ReferenceHelperCompatTest.java
+++ b/project.ant.compat8/test/unit/src/org/netbeans/spi/project/support/ant/ReferenceHelperCompatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/api/project/ant/FileChooser.java
+++ b/project.ant.ui/src/org/netbeans/api/project/ant/FileChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/modules/project/ant/ui/AntProjectModule.java
+++ b/project.ant.ui/src/org/netbeans/modules/project/ant/ui/AntProjectModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/modules/project/ant/ui/FileChooserAccessory.java
+++ b/project.ant.ui/src/org/netbeans/modules/project/ant/ui/FileChooserAccessory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablePanel.java
+++ b/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablesCustomizerAction.java
+++ b/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablesCustomizerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablesModel.java
+++ b/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablesPanel.java
+++ b/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/CustomizerUtilities.java
+++ b/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/CustomizerUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/LicenseHeadersPanel.java
+++ b/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/LicenseHeadersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/StoreGroup.java
+++ b/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/StoreGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/VariablesSupport.java
+++ b/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/VariablesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/test/unit/src/org/netbeans/modules/project/ant/ui/AntArtifactQueryTest.java
+++ b/project.ant.ui/test/unit/src/org/netbeans/modules/project/ant/ui/AntArtifactQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/test/unit/src/org/netbeans/modules/project/ant/ui/VariablesModelTest.java
+++ b/project.ant.ui/test/unit/src/org/netbeans/modules/project/ant/ui/VariablesModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant.ui/test/unit/src/org/netbeans/spi/project/support/ant/ui/StoreGroupTest.java
+++ b/project.ant.ui/test/unit/src/org/netbeans/spi/project/support/ant/ui/StoreGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/antsrc/org/netbeans/modules/project/ant/task/RegenerateFilesTask.java
+++ b/project.ant/antsrc/org/netbeans/modules/project/ant/task/RegenerateFilesTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/antsrc/org/netbeans/modules/project/ant/task/ShowCRCTask.java
+++ b/project.ant/antsrc/org/netbeans/modules/project/ant/task/ShowCRCTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/antsrc/org/netbeans/spi/project/support/ant/CRC32Calculator.java
+++ b/project.ant/antsrc/org/netbeans/spi/project/support/ant/CRC32Calculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/api/project/ant/AntArtifact.java
+++ b/project.ant/src/org/netbeans/api/project/ant/AntArtifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/api/project/ant/AntArtifactQuery.java
+++ b/project.ant/src/org/netbeans/api/project/ant/AntArtifactQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/api/project/ant/AntBuildExtender.java
+++ b/project.ant/src/org/netbeans/api/project/ant/AntBuildExtender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/api/project/ant/AntBuildExtenderAccessorImpl.java
+++ b/project.ant/src/org/netbeans/api/project/ant/AntBuildExtenderAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/AntBasedGenericType.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/AntBasedGenericType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/AntBasedProcessor.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/AntBasedProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingleton.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/AntBuildExtenderAccessor.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/AntBuildExtenderAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/ProjectLibraryProvider.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/ProjectLibraryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/ProjectXMLCatalogReader.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/ProjectXMLCatalogReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/ProjectXMLCatalogReaderBeanInfo.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/ProjectXMLCatalogReaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/ProjectXMLKnownChecksums.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/ProjectXMLKnownChecksums.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/modules/project/ant/StandardAntArtifactQueryImpl.java
+++ b/project.ant/src/org/netbeans/modules/project/ant/StandardAntArtifactQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/ant/AntArtifactProvider.java
+++ b/project.ant/src/org/netbeans/spi/project/ant/AntArtifactProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/ant/AntArtifactQueryImplementation.java
+++ b/project.ant/src/org/netbeans/spi/project/ant/AntArtifactQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/ant/AntBuildExtenderFactory.java
+++ b/project.ant/src/org/netbeans/spi/project/ant/AntBuildExtenderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/ant/AntBuildExtenderImplementation.java
+++ b/project.ant/src/org/netbeans/spi/project/ant/AntBuildExtenderImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/ant/GeneratedFilesInterceptor.java
+++ b/project.ant/src/org/netbeans/spi/project/ant/GeneratedFilesInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/AntBasedProjectRegistration.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/AntBasedProjectRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/AntBasedProjectType.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/AntBasedProjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectEvent.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectHelper.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectListener.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/AuxiliaryPropertiesImpl.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/AuxiliaryPropertiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/EditableProperties.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/EditableProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/ExtensibleMetadataProviderImpl.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/ExtensibleMetadataProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/FilterPropertyProvider.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/FilterPropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/GeneratedFilesHelper.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/GeneratedFilesHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/GlobFileBuiltQuery.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/GlobFileBuiltQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/PathMatcher.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/PathMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/ProjectGenerator.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/ProjectGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/ProjectProperties.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/ProjectProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/ProjectXmlSavedHook.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/ProjectXmlSavedHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/PropertyEvaluator.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/PropertyEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/PropertyProvider.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/PropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/PropertyUtils.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/PropertyUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/SequentialPropertyEvaluator.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/SequentialPropertyEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/SharabilityQueryImpl.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/SharabilityQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/SimpleAntArtifact.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/SimpleAntArtifact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/src/org/netbeans/spi/project/support/ant/SubprojectProviderImpl.java
+++ b/project.ant/src/org/netbeans/spi/project/support/ant/SubprojectProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/api/project/ant/AntArtifactTest.java
+++ b/project.ant/test/unit/src/org/netbeans/api/project/ant/AntArtifactTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/api/project/ant/AntBuildExtenderTest.java
+++ b/project.ant/test/unit/src/org/netbeans/api/project/ant/AntBuildExtenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingletonTest.java
+++ b/project.ant/test/unit/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingletonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/modules/project/ant/ProjectLibraryProviderTest.java
+++ b/project.ant/test/unit/src/org/netbeans/modules/project/ant/ProjectLibraryProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedProjectRegistrationTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedProjectRegistrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedTestUtil.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedTestUtilTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedTestUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntProjectHelperTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntProjectHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/EditablePropertiesTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/EditablePropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/FilterPropertyProviderTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/FilterPropertyProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/GeneratedFilesHelperTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/GeneratedFilesHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/GlobFileBuiltQueryTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/GlobFileBuiltQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/PathMatcherTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/PathMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/ProjectGeneratorTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/ProjectGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/PropertyUtilsTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/PropertyUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/ReferenceHelperTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/ReferenceHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SequentialPropertyEvaluatorTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SequentialPropertyEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SharabilityQueryImplTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SharabilityQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SimpleAntArtifactTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SimpleAntArtifactTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SourcesHelperIssue258004Test.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SourcesHelperIssue258004Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SourcesHelperTest.java
+++ b/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SourcesHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.indexingbridge/src/org/netbeans/modules/project/indexingbridge/IndexingBridge.java
+++ b/project.indexingbridge/src/org/netbeans/modules/project/indexingbridge/IndexingBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/api/project/libraries/LibrariesCustomizer.java
+++ b/project.libraries.ui/src/org/netbeans/api/project/libraries/LibrariesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/api/project/libraries/LibraryChooser.java
+++ b/project.libraries.ui/src/org/netbeans/api/project/libraries/LibraryChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/api/project/libraries/LibraryChooserGUI.java
+++ b/project.libraries.ui/src/org/netbeans/api/project/libraries/LibraryChooserGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/ALPUtils.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/ALPUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/AllLibrariesCustomizer.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/AllLibrariesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibrariesCustomizer.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibrariesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibrariesCustomizerAction.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibrariesCustomizerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibrariesModel.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibrariesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibraryRenderer.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/LibraryRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/NewLibraryPanel.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/NewLibraryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/ProxyLibraryImplementation.java
+++ b/project.libraries.ui/src/org/netbeans/modules/project/libraries/ui/ProxyLibraryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/src/org/netbeans/spi/project/libraries/LibraryCustomizerContext.java
+++ b/project.libraries.ui/src/org/netbeans/spi/project/libraries/LibraryCustomizerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/test/unit/src/org/netbeans/api/project/libraries/LibraryManageTest.java
+++ b/project.libraries.ui/test/unit/src/org/netbeans/api/project/libraries/LibraryManageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageAccessor.java
+++ b/project.libraries.ui/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries.ui/test/unit/src/org/netbeans/modules/project/libraries/ui/ProxyLibraryImplementationTest.java
+++ b/project.libraries.ui/test/unit/src/org/netbeans/modules/project/libraries/ui/ProxyLibraryImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/api/project/libraries/Library.java
+++ b/project.libraries/src/org/netbeans/api/project/libraries/Library.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/api/project/libraries/LibraryManager.java
+++ b/project.libraries/src/org/netbeans/api/project/libraries/LibraryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/DefaultLibraryImplementation.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/DefaultLibraryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/FileLockManager.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/FileLockManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibrariesModule.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibrariesModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibrariesStorage.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibrariesStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryAccessor.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationConvertor.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationConvertorImpl.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationConvertorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationHandler.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationHandlerImpl.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationParser.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryDeclarationParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryTypeRegistry.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/modules/project/libraries/LibraryTypeRegistryImpl.java
+++ b/project.libraries/src/org/netbeans/modules/project/libraries/LibraryTypeRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/ArealLibraryProvider.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/ArealLibraryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryFactory.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryImplementation.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryImplementation2.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryImplementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryImplementation3.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryImplementation3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryProvider.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryStorageArea.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryStorageArea.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryStorageAreaCache.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryStorageAreaCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/LibraryTypeProvider.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/LibraryTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/NamedLibraryImplementation.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/NamedLibraryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/WritableLibraryProvider.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/WritableLibraryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/support/ForwardingLibraryImplementation.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/support/ForwardingLibraryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/src/org/netbeans/spi/project/libraries/support/LibrariesSupport.java
+++ b/project.libraries/src/org/netbeans/spi/project/libraries/support/LibrariesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/api/project/libraries/LibraryManagerTest.java
+++ b/project.libraries/test/unit/src/org/netbeans/api/project/libraries/LibraryManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/api/project/libraries/LibraryTest.java
+++ b/project.libraries/test/unit/src/org/netbeans/api/project/libraries/LibraryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageDeadlock166109Test.java
+++ b/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageDeadlock166109Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageDeadlock167218Test.java
+++ b/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageDeadlock167218Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageDeadlock172779Test.java
+++ b/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageDeadlock172779Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageRefreshTest.java
+++ b/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageRefreshTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageTest.java
+++ b/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesTestUtil.java
+++ b/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/TestEntityCatalog.java
+++ b/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/TestEntityCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.libraries/test/unit/src/org/netbeans/spi/project/libraries/support/LibrariesSupportTest.java
+++ b/project.libraries/test/unit/src/org/netbeans/spi/project/libraries/support/LibrariesSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.spi.intern.impl/src/org/netbeans/modules/project/spi/intern/impl/IDEServicesImpl.java
+++ b/project.spi.intern.impl/src/org/netbeans/modules/project/spi/intern/impl/IDEServicesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.spi.intern/src/org/netbeans/modules/project/spi/intern/ProjectIDEServices.java
+++ b/project.spi.intern/src/org/netbeans/modules/project/spi/intern/ProjectIDEServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/project.spi.intern/src/org/netbeans/modules/project/spi/intern/ProjectIDEServicesImplementation.java
+++ b/project.spi.intern/src/org/netbeans/modules/project/spi/intern/ProjectIDEServicesImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectInformationProvider.java
+++ b/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectInformationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectManager.java
+++ b/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi.nb/src/org/netbeans/modules/projectapi/nb/TimedWeakReference.java
+++ b/projectapi.nb/src/org/netbeans/modules/projectapi/nb/TimedWeakReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi.nb/test/unit/src/org/netbeans/api/project/ProjectUtilsTest.java
+++ b/projectapi.nb/test/unit/src/org/netbeans/api/project/ProjectUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/META-INF/upgrade/ProjectUtils.hint
+++ b/projectapi/src/META-INF/upgrade/ProjectUtils.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/FileOwnerQuery.java
+++ b/projectapi/src/org/netbeans/api/project/FileOwnerQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/Project.java
+++ b/projectapi/src/org/netbeans/api/project/Project.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/ProjectInformation.java
+++ b/projectapi/src/org/netbeans/api/project/ProjectInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/ProjectManager.java
+++ b/projectapi/src/org/netbeans/api/project/ProjectManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/ProjectUtils.java
+++ b/projectapi/src/org/netbeans/api/project/ProjectUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/SourceGroup.java
+++ b/projectapi/src/org/netbeans/api/project/SourceGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/SourceGroupModifier.java
+++ b/projectapi/src/org/netbeans/api/project/SourceGroupModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/api/project/Sources.java
+++ b/projectapi/src/org/netbeans/api/project/Sources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/AuxiliaryConfigBasedPreferencesProvider.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/AuxiliaryConfigBasedPreferencesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/AuxiliaryConfigImpl.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/AuxiliaryConfigImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/FileOwnerCollocationQueryImpl.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/FileOwnerCollocationQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/Installer.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/LazyLookupProviders.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/LazyLookupProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/LookupProviderAnnotationProcessor.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/LookupProviderAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/MetaLookupMerger.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/MetaLookupMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/ProjectFileBuiltQuery.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/ProjectFileBuiltQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/ProjectFileEncodingQueryImplementation.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/ProjectFileEncodingQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/ProjectSharabilityQuery.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/ProjectSharabilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/ProjectSharabilityQuery2.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/ProjectSharabilityQuery2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/SPIAccessor.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
+++ b/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ActionProgress.java
+++ b/projectapi/src/org/netbeans/spi/project/ActionProgress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ActionProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/ActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/AuxiliaryConfiguration.java
+++ b/projectapi/src/org/netbeans/spi/project/AuxiliaryConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/AuxiliaryProperties.java
+++ b/projectapi/src/org/netbeans/spi/project/AuxiliaryProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/CacheDirectoryProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/CacheDirectoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/CopyOperationImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/CopyOperationImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/DataFilesProviderImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/DataFilesProviderImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/DeleteOperationImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/DeleteOperationImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/DependencyProjectProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/DependencyProjectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/FileOwnerQueryImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/FileOwnerQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/LookupMerger.java
+++ b/projectapi/src/org/netbeans/spi/project/LookupMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/LookupProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/LookupProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/MoveOperationImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/MoveOperationImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/MoveOrRenameOperationImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/MoveOrRenameOperationImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectConfiguration.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectConfigurationProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectContainerProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectContainerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectFactory.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectFactory2.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectFactory2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectIconAnnotator.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectIconAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectInformationProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectInformationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectManagerImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectManagerImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectServiceProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectServiceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/ProjectState.java
+++ b/projectapi/src/org/netbeans/spi/project/ProjectState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/SingleMethod.java
+++ b/projectapi/src/org/netbeans/spi/project/SingleMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/SourceGroupModifierImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/SourceGroupModifierImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/SourceGroupRelativeModifierImplementation.java
+++ b/projectapi/src/org/netbeans/spi/project/SourceGroupRelativeModifierImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/SubprojectProvider.java
+++ b/projectapi/src/org/netbeans/spi/project/SubprojectProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/support/DelegatingLookupImpl.java
+++ b/projectapi/src/org/netbeans/spi/project/support/DelegatingLookupImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/support/GenericSources.java
+++ b/projectapi/src/org/netbeans/spi/project/support/GenericSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/support/LookupProviderSupport.java
+++ b/projectapi/src/org/netbeans/spi/project/support/LookupProviderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/src/org/netbeans/spi/project/support/ProjectOperations.java
+++ b/projectapi/src/org/netbeans/spi/project/support/ProjectOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/api/project/FileOwnerQueryTest.java
+++ b/projectapi/test/unit/src/org/netbeans/api/project/FileOwnerQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/api/project/ProjectManagerTest.java
+++ b/projectapi/test/unit/src/org/netbeans/api/project/ProjectManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/api/project/ProjectUtilsTest.java
+++ b/projectapi/test/unit/src/org/netbeans/api/project/ProjectUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/api/project/TestUtil.java
+++ b/projectapi/test/unit/src/org/netbeans/api/project/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/api/project/TestUtilTest.java
+++ b/projectapi/test/unit/src/org/netbeans/api/project/TestUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/modules/projectapi/AuxiliaryConfigBasedPreferencesProviderTest.java
+++ b/projectapi/test/unit/src/org/netbeans/modules/projectapi/AuxiliaryConfigBasedPreferencesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/modules/projectapi/AuxiliaryConfigImplTest.java
+++ b/projectapi/test/unit/src/org/netbeans/modules/projectapi/AuxiliaryConfigImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/modules/projectapi/FileOwnerCollocationQueryImplTest.java
+++ b/projectapi/test/unit/src/org/netbeans/modules/projectapi/FileOwnerCollocationQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/modules/projectapi/LazyLookupProvidersTest.java
+++ b/projectapi/test/unit/src/org/netbeans/modules/projectapi/LazyLookupProvidersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/modules/projectapi/ParallelInitializationTest.java
+++ b/projectapi/test/unit/src/org/netbeans/modules/projectapi/ParallelInitializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementationTest.java
+++ b/projectapi/test/unit/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/modules/projectapi/nb/NbProjectManagerAccessor.java
+++ b/projectapi/test/unit/src/org/netbeans/modules/projectapi/nb/NbProjectManagerAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/spi/project/support/DelegatingLookupImplTest.java
+++ b/projectapi/test/unit/src/org/netbeans/spi/project/support/DelegatingLookupImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectapi/test/unit/src/org/netbeans/spi/project/support/LookupProviderSupportTest.java
+++ b/projectapi/test/unit/src/org/netbeans/spi/project/support/LookupProviderSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ClassPathContainerResolver.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ClassPathContainerResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/DotClassPath.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/DotClassPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/DotClassPathParser.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/DotClassPathParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/EclipseProject.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/EclipseProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/EclipseProjectReference.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/EclipseProjectReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/EclipseUtils.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/EclipseUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ImportProblemsPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ImportProblemsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ImportProjectAction.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ImportProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Importer.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Importer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/JavaPlatformSupport.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/JavaPlatformSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Link.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Link.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/PreferredVMParser.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/PreferredVMParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectFactory.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectImporterException.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectImporterException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectOpenHookImpl.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectOpenHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectParser.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ProjectParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/RequiredProjectsPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/RequiredProjectsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ResynchronizeEclipseAction.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/ResynchronizeEclipseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateAllProjects.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateAllProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateEclipseReferencePanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateEclipseReferencePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateProjectAction.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpgradableProject.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpgradableProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UserLibraryParser.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UserLibraryParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Util.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Workspace.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/Workspace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceFactory.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceParser.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/DotClassPathEntry.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/DotClassPathEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/Facets.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/Facets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/LaunchConfiguration.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/LaunchConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectFactorySupport.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectFactorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectImportModel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectImportModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectTypeFactory.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectTypeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectTypeUpdater.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectTypeUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/UpgradableProjectLookupProvider.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/spi/UpgradableProjectLookupProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/EclipseWizardIterator.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/EclipseWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ImporterWizardPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ImporterWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProgressPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProgressPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProjectImporterWizard.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProjectImporterWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProjectSelectionPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProjectSelectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProjectWizardPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/ProjectWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/SelectionPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/SelectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/SelectionWizardPanel.java
+++ b/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/wizard/SelectionWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/ImporterTest.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/ImporterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportAppRunParams.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportAppRunParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportJavaCParams.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportJavaCParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportJavaVersion.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportJavaVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportMultipleRootsJavaProjectFromWS.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportMultipleRootsJavaProjectFromWS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportProjectWithJarRef.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportProjectWithJarRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportProjectWithTransitiveDeps.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportProjectWithTransitiveDeps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportSimpleJavaProjectFromWS.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportSimpleJavaProjectFromWS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportSimpleWebProjectFromWS.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportSimpleWebProjectFromWS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportSourceFilters.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportSourceFilters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportStandaloneProject.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportStandaloneProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportTestProjects.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImportTestProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImporterMenu.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImporterMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImporterWizard.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ImporterWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ProjectImporterTestCase.java
+++ b/projectimport.eclipse.core/test/qa-functional/src/org/netbeans/modules/projectimport/eclipse/gui/ProjectImporterTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ClassPathContainerResolverTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ClassPathContainerResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ClassPathParserTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ClassPathParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ComplexProjectAnalysisTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ComplexProjectAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/EclipseProjectTestUtils.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/EclipseProjectTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/EqualityAndHashCodeTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/EqualityAndHashCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/PreferredVMParserTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/PreferredVMParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ProjectImporterTestCase.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ProjectImporterTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ProjectParserTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/ProjectParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/SingleProjectAnalysisTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/SingleProjectAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/UserLibraryParserTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/UserLibraryParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceAnalysisTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceParserTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectFactorySupportTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectFactorySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectImportModelTest.java
+++ b/projectimport.eclipse.core/test/unit/src/org/netbeans/modules/projectimport/eclipse/core/spi/ProjectImportModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectimport.eclipse.j2se/src/org/netbeans/modules/projectimport/eclipse/j2se/J2SEProjectFactory.java
+++ b/projectimport.eclipse.j2se/src/org/netbeans/modules/projectimport/eclipse/j2se/J2SEProjectFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/BrowseFolders.java
+++ b/projectui/src/org/netbeans/modules/project/ui/BrowseFolders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ExitDialog.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ExitDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ExtIcon.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ExtIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/Hacks.java
+++ b/projectui/src/org/netbeans/modules/project/ui/Hacks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/LazyProject.java
+++ b/projectui/src/org/netbeans/modules/project/ui/LazyProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/LazyProjectInitializing.java
+++ b/projectui/src/org/netbeans/modules/project/ui/LazyProjectInitializing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/NewFileIterator.java
+++ b/projectui/src/org/netbeans/modules/project/ui/NewFileIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/NewFileWizard.java
+++ b/projectui/src/org/netbeans/modules/project/ui/NewFileWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/NewProjectWizard.java
+++ b/projectui/src/org/netbeans/modules/project/ui/NewProjectWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/NoProjectNew.java
+++ b/projectui/src/org/netbeans/modules/project/ui/NoProjectNew.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/NodeSelectionProjectPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/NodeSelectionProjectPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
+++ b/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
+++ b/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/OpenProjectsTrampolineImpl.java
+++ b/projectui/src/org/netbeans/modules/project/ui/OpenProjectsTrampolineImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/PhysicalView.java
+++ b/projectui/src/org/netbeans/modules/project/ui/PhysicalView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectCellRenderer.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectChooserFactoryImpl.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectChooserFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectInfoAccessor.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectInfoAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectTab.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectTabAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectTemplatePanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectTemplatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectUiModule.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectUiModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectUtilities.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
+++ b/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanelGUI.java
+++ b/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanelGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/SyncEditorWithViewsAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/SyncEditorWithViewsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/TemplateChooserPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/TemplateChooserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/TemplateChooserPanelGUI.java
+++ b/projectui/src/org/netbeans/modules/project/ui/TemplateChooserPanelGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/TemplatesPanelGUI.java
+++ b/projectui/src/org/netbeans/modules/project/ui/TemplatesPanelGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/Actions.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/Actions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/ActionsUtil.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/ActionsUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/ActiveConfigAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/ActiveConfigAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/BasicAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/BasicAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/BuildExecutionSupportImpl.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/BuildExecutionSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/CloseAllProjectsAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/CloseAllProjectsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/CloseOtherProjectsAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/CloseOtherProjectsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/CloseProject.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/CloseProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/CustomizeProject.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/CustomizeProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/FileAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/FileAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/LookupSensitiveAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/LookupSensitiveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectActionWithHistory.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectActionWithHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/NewFile.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/NewFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/NewProject.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/NewProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/OpenProject.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/OpenProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/OpenProjectFolderAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/OpenProjectFolderAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/OpenSubprojects.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/OpenSubprojects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/ProjectAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/ProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/RecentProjects.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/RecentProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/RunLastBuildAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/RunLastBuildAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/SelectNodeAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/SelectNodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/SetMainProject.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/SetMainProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/ShortcutManager.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/ShortcutManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/StopBuildingAction.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/StopBuildingAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/StopBuildingAlert.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/StopBuildingAlert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/actions/VerticalGridLayout.java
+++ b/projectui/src/org/netbeans/modules/project/ui/actions/VerticalGridLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/api/ProjectActionUtils.java
+++ b/projectui/src/org/netbeans/modules/project/ui/api/ProjectActionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/api/ProjectInfoAccessorImpl.java
+++ b/projectui/src/org/netbeans/modules/project/ui/api/ProjectInfoAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/api/ProjectTemplates.java
+++ b/projectui/src/org/netbeans/modules/project/ui/api/ProjectTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/api/RecentProjects.java
+++ b/projectui/src/org/netbeans/modules/project/ui/api/RecentProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/api/UnloadedProjectInformation.java
+++ b/projectui/src/org/netbeans/modules/project/ui/api/UnloadedProjectInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/convertor/ExtProjectConvertorServices.java
+++ b/projectui/src/org/netbeans/modules/project/ui/convertor/ExtProjectConvertorServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/AdHocGroup.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/AdHocGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/AdHocGroupEditPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/AdHocGroupEditPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/CheckBoxRenderrer.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/CheckBoxRenderrer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/DirectoryGroup.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/DirectoryGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/DirectoryGroupEditPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/DirectoryGroupEditPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/GroupEditPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/GroupEditPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/GroupMainCategory.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/GroupMainCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/GroupOptionProcessor.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/GroupOptionProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/GroupsMenu.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/GroupsMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/ManageGroupsPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/ManageGroupsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/NewGroupPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/NewGroupPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/SubprojectsGroup.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/SubprojectsGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/groups/SubprojectsGroupEditPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/groups/SubprojectsGroupEditPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenProjectActionFactory.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenProjectActionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenProjectAnnotator.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenProjectAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenProjectNotifier.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenProjectNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesAlertPanel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesAlertPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesImpl.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesModel.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesSettings.java
+++ b/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/quicksearch/SearchForProjectsQuickSearch.java
+++ b/projectui/src/org/netbeans/modules/project/ui/quicksearch/SearchForProjectsQuickSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/spi/TemplateCategorySorter.java
+++ b/projectui/src/org/netbeans/modules/project/ui/spi/TemplateCategorySorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/zip/ChangeImportFolder.java
+++ b/projectui/src/org/netbeans/modules/project/ui/zip/ChangeImportFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/zip/ExportZIP.java
+++ b/projectui/src/org/netbeans/modules/project/ui/zip/ExportZIP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/src/org/netbeans/modules/project/ui/zip/ImportZIP.java
+++ b/projectui/src/org/netbeans/modules/project/ui/zip/ImportZIP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/CloseProjectsTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/CloseProjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ExtIconTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ExtIconTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/LazyProjectTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/LazyProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectHookThrowsExceptionTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectHookThrowsExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListDuplicatesTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListDuplicatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListNPUTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListNPUTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMain2Test.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMain2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMainTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectsTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectsTrampolineImplTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectsTrampolineImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/PhysicalViewTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/PhysicalViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectChooserAccessoryTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectChooserAccessoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectUtilitiesTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeFindTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeFindTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeInitializedSoonerTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeInitializedSoonerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeNotRecognizedTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeNotRecognizedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewModeSourcesTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewModeSourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromContextOpenTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromContextOpenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromPopupTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromPopupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen2Test.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen3Test.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen4Test.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen4Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpenTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/TemplateChooserPanelGUITest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/TemplateChooserPanelGUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/TemplatesPanelGUITest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/TemplatesPanelGUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/ActionsUtilTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/ActionsUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/ActiveConfigActionTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/ActiveConfigActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/CloseProjectTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/CloseProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/CustomizeProjectTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/CustomizeProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/FileActionTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/FileActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionBase.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionNonEQTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionNonEQTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionUILogTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/LookupSensitiveActionUILogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/MainProjectActionTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/MainProjectActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/ProjectActionTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/ProjectActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/SelectNodeActionTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/SelectNodeActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/SetMainProjectTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/SetMainProjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/TestSupport.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/actions/TestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/api/RecentProjectsTest.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/api/RecentProjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectui/test/unit/src/org/netbeans/modules/project/ui/test/ProjectSupport.java
+++ b/projectui/test/unit/src/org/netbeans/modules/project/ui/test/ProjectSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/api/project/ui/OpenProjects.java
+++ b/projectuiapi.base/src/org/netbeans/api/project/ui/OpenProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/api/project/ui/ProjectGroup.java
+++ b/projectuiapi.base/src/org/netbeans/api/project/ui/ProjectGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/api/project/ui/ProjectGroupChangeEvent.java
+++ b/projectuiapi.base/src/org/netbeans/api/project/ui/ProjectGroupChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/api/project/ui/ProjectGroupChangeListener.java
+++ b/projectuiapi.base/src/org/netbeans/api/project/ui/ProjectGroupChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/DefaultProjectConvertorServices.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/DefaultProjectConvertorServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorAcceptor.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorAcceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorFactory.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorProcessor.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/uiapi/BaseUtilities.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/uiapi/BaseUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/uiapi/OpenProjectsTrampoline.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/uiapi/OpenProjectsTrampoline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/uiapi/ProjectConvertorServiceFactory.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/uiapi/ProjectConvertorServiceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/modules/project/uiapi/ProjectOpenedTrampoline.java
+++ b/projectuiapi.base/src/org/netbeans/modules/project/uiapi/ProjectOpenedTrampoline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/PrivilegedTemplates.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/PrivilegedTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectConvertor.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectOpenedHook.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectOpenedHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectProblemResolver.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectProblemResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectProblemsProvider.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectProblemsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/RecommendedTemplates.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/RecommendedTemplates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/support/ProjectConvertors.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/support/ProjectConvertors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/support/ProjectProblemsProviderSupport.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/support/ProjectProblemsProviderSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/src/org/netbeans/spi/project/ui/support/UILookupMergerSupport.java
+++ b/projectuiapi.base/src/org/netbeans/spi/project/ui/support/UILookupMergerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/DelegateToOwnerLookupTest.java
+++ b/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/DelegateToOwnerLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/ProjectConvertorFactoryTest.java
+++ b/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/ProjectConvertorFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/TestProject.java
+++ b/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/TestProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/TestTrampoline.java
+++ b/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/TestTrampoline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi.base/test/unit/src/org/netbeans/spi/project/ui/support/UILookupMergerSupportTest.java
+++ b/projectuiapi.base/test/unit/src/org/netbeans/spi/project/ui/support/UILookupMergerSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/META-INF/upgrade/Templates.hint
+++ b/projectuiapi/src/META-INF/upgrade/Templates.hint
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/api/project/ui/ProjectProblems.java
+++ b/projectuiapi/src/org/netbeans/api/project/ui/ProjectProblems.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/ActionsFactory.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/ActionsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/BrokenReferencesImplementation.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/BrokenReferencesImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/BuildExecutionSupportImplementation.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/BuildExecutionSupportImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/CategoryChangeSupport.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/CategoryChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/CategoryModel.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/CategoryModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/CategoryView.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/CategoryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/CompositeCategoryProviderAnnotationProcessor.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/CompositeCategoryProviderAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/CustomizerDialog.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/CustomizerDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/CustomizerPane.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/CustomizerPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/DefaultProjectDeletePanel.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/DefaultProjectDeletePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/DefaultProjectOperationsImplementation.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/DefaultProjectOperationsImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/DefaultProjectRenamePanel.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/DefaultProjectRenamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/NodeFactoryAnnotationProcessor.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/NodeFactoryAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/OpenProjectsListener.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/OpenProjectsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectChooserFactory.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectChooserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectCopyPanel.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectCopyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesLegacy.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesLegacy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProvider.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectUiapiModule.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectUiapiModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/SavingProjectDataPanel.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/SavingProjectDataPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/modules/project/uiapi/Utilities.java
+++ b/projectuiapi/src/org/netbeans/modules/project/uiapi/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/CustomizerProvider.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/CustomizerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/CustomizerProvider2.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/CustomizerProvider2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/LogicalViewProvider.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/LogicalViewProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/PathFinder.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/PathFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/BuildExecutionSupport.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/BuildExecutionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/CommonProjectActions.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/CommonProjectActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/DefaultProjectOperations.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/DefaultProjectOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/FileActionPerformer.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/FileActionPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/FileSensitiveActions.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/FileSensitiveActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/MainProjectSensitiveActions.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/MainProjectSensitiveActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeFactory.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeFactorySupport.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeFactorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeList.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectActionPerformer.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectActionPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectChooser.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectCustomizer.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectSensitiveActions.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectSensitiveActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/Templates.java
+++ b/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/Templates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/test/unit/src/org/netbeans/modules/project/uiapi/DefaultProjectOperationsImplementationTest.java
+++ b/projectuiapi/test/unit/src/org/netbeans/modules/project/uiapi/DefaultProjectOperationsImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/test/unit/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProviderTest.java
+++ b/projectuiapi/test/unit/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/CommonProjectActionsTest.java
+++ b/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/CommonProjectActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/NodeFactorySupportTest.java
+++ b/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/NodeFactorySupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/ProjectCustomizerListenersTest.java
+++ b/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/ProjectCustomizerListenersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/ProjectCustomizerTest.java
+++ b/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/ProjectCustomizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/package-info.java
+++ b/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties.syntax/src/org/netbeans/modules/properties/syntax/EditorSettingsCopy.java
+++ b/properties.syntax/src/org/netbeans/modules/properties/syntax/EditorSettingsCopy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesKit.java
+++ b/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesSettingsInitializer.java
+++ b/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesSettingsInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesSyntax.java
+++ b/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesSyntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesTokenContext.java
+++ b/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesTokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties.syntax/src/org/netbeans/modules/properties/syntax/RestoreColoring.java
+++ b/properties.syntax/src/org/netbeans/modules/properties/syntax/RestoreColoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/BundleEditPanel.java
+++ b/properties/src/org/netbeans/modules/properties/BundleEditPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/BundleNodeCustomizer.java
+++ b/properties/src/org/netbeans/modules/properties/BundleNodeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/BundleStructure.java
+++ b/properties/src/org/netbeans/modules/properties/BundleStructure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/Element.java
+++ b/properties/src/org/netbeans/modules/properties/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/FileEntryNode.java
+++ b/properties/src/org/netbeans/modules/properties/FileEntryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/FindPanel.java
+++ b/properties/src/org/netbeans/modules/properties/FindPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/FindPerformer.java
+++ b/properties/src/org/netbeans/modules/properties/FindPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/KeyComparator.java
+++ b/properties/src/org/netbeans/modules/properties/KeyComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/KeyNode.java
+++ b/properties/src/org/netbeans/modules/properties/KeyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/LangRenameAction.java
+++ b/properties/src/org/netbeans/modules/properties/LangRenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/LocaleNodeCustomizer.java
+++ b/properties/src/org/netbeans/modules/properties/LocaleNodeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/LocalePanel.java
+++ b/properties/src/org/netbeans/modules/properties/LocalePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/MultiBundleStructure.java
+++ b/properties/src/org/netbeans/modules/properties/MultiBundleStructure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PresentableFileEntry.java
+++ b/properties/src/org/netbeans/modules/properties/PresentableFileEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesDataLoader.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesDataLoaderBeanInfo.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesDataNode.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesDataObject.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesEditorSupport.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesEncoding.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesEncoding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesFileEntry.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesFileEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesLocaleNode.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesLocaleNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesOpen.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesOpen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesParser.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesRequestProcessor.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesStructure.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesStructure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesTableCellEditor.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesTableCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertiesTableModel.java
+++ b/properties/src/org/netbeans/modules/properties/PropertiesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertyBundleEvent.java
+++ b/properties/src/org/netbeans/modules/properties/PropertyBundleEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertyBundleListener.java
+++ b/properties/src/org/netbeans/modules/properties/PropertyBundleListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertyBundleSupport.java
+++ b/properties/src/org/netbeans/modules/properties/PropertyBundleSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/PropertyPanel.java
+++ b/properties/src/org/netbeans/modules/properties/PropertyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/StructHandler.java
+++ b/properties/src/org/netbeans/modules/properties/StructHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/TableViewSettings.java
+++ b/properties/src/org/netbeans/modules/properties/TableViewSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/Util.java
+++ b/properties/src/org/netbeans/modules/properties/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/src/org/netbeans/modules/properties/UtilConvert.java
+++ b/properties/src/org/netbeans/modules/properties/UtilConvert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/qa-functional/src/lib/PropertiesEditorTestCase.java
+++ b/properties/test/qa-functional/src/lib/PropertiesEditorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromExplorer1Test.java
+++ b/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromExplorer1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromExplorer2Test.java
+++ b/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromExplorer2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromMainWindow1Test.java
+++ b/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromMainWindow1Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromMainWindow2Test.java
+++ b/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/creating_properties_file/CreatingPropertiesFileFromMainWindow2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/properties_editing/AddingNewKeyAndValuesTest.java
+++ b/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/properties_editing/AddingNewKeyAndValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/properties_editing/SimpleAndAdvanceEditorTest.java
+++ b/properties/test/qa-functional/src/org/netbeans/properties/jelly2tests/suites/properties_editing/SimpleAndAdvanceEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/unit/src/org/netbeans/modules/properties/ElementTest.java
+++ b/properties/test/unit/src/org/netbeans/modules/properties/ElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/unit/src/org/netbeans/modules/properties/MultiBundleStructureTest.java
+++ b/properties/test/unit/src/org/netbeans/modules/properties/MultiBundleStructureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/unit/src/org/netbeans/modules/properties/PropertiesDataObjectTest.java
+++ b/properties/test/unit/src/org/netbeans/modules/properties/PropertiesDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/unit/src/org/netbeans/modules/properties/PropertiesEncodingInMimeLookupTest.java
+++ b/properties/test/unit/src/org/netbeans/modules/properties/PropertiesEncodingInMimeLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/properties/test/unit/src/org/netbeans/modules/properties/PropertiesEncodingTest.java
+++ b/properties/test/unit/src/org/netbeans/modules/properties/PropertiesEncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/api/fileinfo/NonRecursiveFolder.java
+++ b/queries/src/org/netbeans/api/fileinfo/NonRecursiveFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/api/queries/CollocationQuery.java
+++ b/queries/src/org/netbeans/api/queries/CollocationQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/api/queries/FileBuiltQuery.java
+++ b/queries/src/org/netbeans/api/queries/FileBuiltQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/api/queries/FileEncodingQuery.java
+++ b/queries/src/org/netbeans/api/queries/FileEncodingQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/api/queries/SharabilityQuery.java
+++ b/queries/src/org/netbeans/api/queries/SharabilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/api/queries/VersioningQuery.java
+++ b/queries/src/org/netbeans/api/queries/VersioningQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/api/queries/VisibilityQuery.java
+++ b/queries/src/org/netbeans/api/queries/VisibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/modules/queries/ParentChildCollocationQuery.java
+++ b/queries/src/org/netbeans/modules/queries/ParentChildCollocationQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/modules/queries/UnknownEncoding.java
+++ b/queries/src/org/netbeans/modules/queries/UnknownEncoding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/CollocationQueryImplementation.java
+++ b/queries/src/org/netbeans/spi/queries/CollocationQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/CollocationQueryImplementation2.java
+++ b/queries/src/org/netbeans/spi/queries/CollocationQueryImplementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/FileBuiltQueryImplementation.java
+++ b/queries/src/org/netbeans/spi/queries/FileBuiltQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/FileEncodingQueryImplementation.java
+++ b/queries/src/org/netbeans/spi/queries/FileEncodingQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation.java
+++ b/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation2.java
+++ b/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/VersioningQueryImplementation.java
+++ b/queries/src/org/netbeans/spi/queries/VersioningQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/VisibilityQueryChangeEvent.java
+++ b/queries/src/org/netbeans/spi/queries/VisibilityQueryChangeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/VisibilityQueryImplementation.java
+++ b/queries/src/org/netbeans/spi/queries/VisibilityQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/src/org/netbeans/spi/queries/VisibilityQueryImplementation2.java
+++ b/queries/src/org/netbeans/spi/queries/VisibilityQueryImplementation2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/test/unit/src/org/netbeans/api/queries/CollocationQuery2Test.java
+++ b/queries/test/unit/src/org/netbeans/api/queries/CollocationQuery2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/test/unit/src/org/netbeans/api/queries/CollocationQueryTest.java
+++ b/queries/test/unit/src/org/netbeans/api/queries/CollocationQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/test/unit/src/org/netbeans/api/queries/FileEncodingQueryTest.java
+++ b/queries/test/unit/src/org/netbeans/api/queries/FileEncodingQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/test/unit/src/org/netbeans/api/queries/SharabilityQueryTest.java
+++ b/queries/test/unit/src/org/netbeans/api/queries/SharabilityQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/test/unit/src/org/netbeans/api/queries/VersioningQueryTest.java
+++ b/queries/test/unit/src/org/netbeans/api/queries/VersioningQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/queries/test/unit/src/org/netbeans/modules/queries/ParentChildCollocationQueryTest.java
+++ b/queries/test/unit/src/org/netbeans/modules/queries/ParentChildCollocationQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/AbstractRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/AbstractRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/AccessorImpl.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/Context.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/CopyRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/CopyRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/MoveRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/MoveRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/MultipleCopyRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/MultipleCopyRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/Problem.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/Problem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/ProblemDetails.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/ProblemDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/ProgressEvent.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/ProgressEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/ProgressListener.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/ProgressListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/RefactoringElement.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/RefactoringElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/RefactoringSession.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/RefactoringSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/RenameRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/RenameRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/SafeDeleteRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/SafeDeleteRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/Scope.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/Scope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/SingleCopyRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/SingleCopyRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/WhereUsedQuery.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/WhereUsedQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/APIAccessor.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/APIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/ActionsImplementationFactory.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/ActionsImplementationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/CannotRedoRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/CannotRedoRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/CannotUndoRefactoring.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/CannotUndoRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/ProgressSupport.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/ProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/SPIAccessor.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/SPIUIAccessor.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/impl/SPIUIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/ui/ExplorerContext.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/ui/ExplorerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/api/ui/RefactoringActionsFactory.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/api/ui/RefactoringActionsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/impl/ClipboardConvertor.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/impl/ClipboardConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/impl/FolderRenameHandlerImpl.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/impl/FolderRenameHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/impl/RefactoringWarmUpTask.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/impl/RefactoringWarmUpTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/CopyFile.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/CopyFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/DefaultActionsProvider.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/DefaultActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/DeleteFile.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/DeleteFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileDeletePlugin.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileDeletePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileHandlingFactory.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileHandlingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileMovePlugin.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileMovePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileRenamePlugin.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FileRenamePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FilesCopyPlugin.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/FilesCopyPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/PackageDeleteRefactoringPlugin.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/PackageDeleteRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/RefactoringTreeElement.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/RefactoringTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/plugins/TreeElementFactoryImpl.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/plugins/TreeElementFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/AccessorImpl.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility2.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/FiltersManager.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/FiltersManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/GuardedBlockHandler.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/GuardedBlockHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/GuardedBlockHandlerFactory.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/GuardedBlockHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ModificationResult.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ModificationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProblemDetailsFactory.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProblemDetailsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProblemDetailsImplementation.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProblemDetailsImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProgressProvider.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProgressProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProgressProviderAdapter.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ProgressProviderAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ReadOnlyFilesHandler.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ReadOnlyFilesHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringCommit.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringCommit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementImplementation.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementsBag.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementsBag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringPlugin.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringPluginFactory.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/SimpleRefactoringElementImplementation.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/SimpleRefactoringElementImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/Transaction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/Transaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckNode.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckNodeListener.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckNodeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckRenderer.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CopyAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CopyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/DelegatingCustomScopeProvider.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/DelegatingCustomScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/DelegatingScopeInformation.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/DelegatingScopeInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/DelegatingScopeProvider.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/DelegatingScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ErrorPanel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ErrorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/FiltersManagerImpl.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/FiltersManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/FindUsagesOpenAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/FindUsagesOpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/MoveAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/MoveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ParametersPanel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ParametersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/PreviewManager.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/PreviewManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ProblemComponent.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ProblemComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RSMDataObjectAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RSMDataObjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RSMEditorAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RSMEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringContextAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringContextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringContextActionsProvider.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringContextActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringGlobalAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringGlobalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringMenu.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanelContainer.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanelContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPreviewOpenAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPreviewOpenAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringSubMenuAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringSubMenuAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringUndoRedo.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringUndoRedo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RenameAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/SafeDeleteAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/SafeDeleteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/SafeDeletePanel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/SafeDeletePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/SafeDeleteUI.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/SafeDeleteUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ScopeAnnotationProcessor.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ScopeAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ScrollableJPanel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ScrollableJPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/TooltipLabel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/TooltipLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/UndoManager.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/UndoManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/UndoableWrapper.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/UndoableWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/Util.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/WhereUsedAction.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/WhereUsedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/AccessorImpl.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ActionsImplementationProvider.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ActionsImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/CustomRefactoringPanel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/CustomRefactoringPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ExpandableTreeElement.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ExpandableTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/FiltersDescription.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/FiltersDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/RefactoringCustomUI.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/RefactoringCustomUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/RefactoringUI.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/RefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/RefactoringUIBypass.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/RefactoringUIBypass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopePanel.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeProvider.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReference.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReferences.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/TreeElement.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/TreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/TreeElementFactory.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/TreeElementFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/TreeElementFactoryImplementation.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/TreeElementFactoryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/UI.java
+++ b/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/UI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/api/impl/ProgressSupportTest.java
+++ b/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/api/impl/ProgressSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/api/ui/ActionInvocationTest.java
+++ b/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/api/ui/ActionInvocationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/plugins/FilesCopyPluginTest.java
+++ b/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/plugins/FilesCopyPluginTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/spi/BackupFacilityTest.java
+++ b/refactoring.api/test/unit/src/org/netbeans/modules/refactoring/spi/BackupFacilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/CreateElementUtilities.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/CreateElementUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/PackageRenameHandlerImpl.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/PackageRenameHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringModule.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/RenameHandlerImpl.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/RenameHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/SourceUtilsEx.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/SourceUtilsEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/WhereUsedBinaryElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/WhereUsedBinaryElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/WhereUsedElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/WhereUsedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ChangeParametersRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ChangeParametersRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/EncapsulateFieldRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/EncapsulateFieldRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ExtractInterfaceRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ExtractInterfaceRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ExtractSuperclassRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ExtractSuperclassRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InlineRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InlineRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InnerToOuterRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InnerToOuterRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/IntroduceLocalExtensionRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/IntroduceLocalExtensionRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/IntroduceParameterRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/IntroduceParameterRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InvertBooleanRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InvertBooleanRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/JavaMoveMembersProperties.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/JavaMoveMembersProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/JavaRefactoringUtils.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/JavaRefactoringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/MemberInfo.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/MemberInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/PullUpRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/PullUpRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/PushDownRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/PushDownRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ReplaceConstructorWithBuilderRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ReplaceConstructorWithBuilderRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ReplaceConstructorWithFactoryRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ReplaceConstructorWithFactoryRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/UseSuperTypeRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/UseSuperTypeRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/WhereUsedQueryConstants.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/WhereUsedQueryConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ui/JavaRefactoringActionsFactory.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ui/JavaRefactoringActionsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ui/JavaScopeBuilder.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ui/JavaScopeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/Call.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/Call.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallDescriptor.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyModel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTasks.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTasks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTopComponent.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallNode.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallOccurrence.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallOccurrence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ChangeParametersPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ChangeParametersPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ChangeParamsTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ChangeParamsTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/CopyClassRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/CopyClassRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/CopyClassesRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/CopyClassesRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/CopyTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/CopyTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/DeleteFile.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/DeleteFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/DeleteTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/DeleteTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/EncapsulateFieldRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/EncapsulateFieldRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/EncapsulateFieldsPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/EncapsulateFieldsPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ExtractInterfaceRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ExtractInterfaceRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ExtractSuperclassRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ExtractSuperclassRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindLocalUsagesQuery.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindLocalUsagesQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindOverridingVisitor.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindOverridingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindSubtypesVisitor.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindSubtypesVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindUsagesVisitor.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindUsagesVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindVisitor.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineMethodTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineMethodTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineVariableTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineVariableTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InnerToOuterRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InnerToOuterRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InnerToOuterTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InnerToOuterTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InstantRefactoringPerformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InstantRefactoringPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceLocalExtensionPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceLocalExtensionPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceLocalExtensionTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceLocalExtensionTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceParameterPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceParameterPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InvertBooleanRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InvertBooleanRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaPluginUtils.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaPluginUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaRefactoringsFactory.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaRefactoringsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaWhereUsedQueryPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaWhereUsedQueryPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/LocalVarScanner.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/LocalVarScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveClassTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveClassTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveFileRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveFileRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveMembersRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveMembersRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveMembersTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveMembersTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/OperatorPrecedence.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/OperatorPrecedence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/OverriddenAbsMethodFinder.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/OverriddenAbsMethodFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PackageRename.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PackageRename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PullUpRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PullUpRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PullUpTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PullUpTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PushDownRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PushDownRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PushDownTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PushDownTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RefactoringPluginFactoryImpl.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RefactoringPluginFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenamePropertyRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenamePropertyRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTestClassPluginFactory.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTestClassPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTestClassRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTestClassRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTransformer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ReplaceConstructorWithBuilderPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ReplaceConstructorWithBuilderPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ReplaceConstructorWithFactoryPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ReplaceConstructorWithFactoryPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/SafeDeleteRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/SafeDeleteRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/TreeDuplicator.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/TreeDuplicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/UseSuperTypeRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/UseSuperTypeRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/VarUsageVisitor.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/VarUsageVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/DiffElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/DiffElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaModificationResult.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaModificationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaRefactoringPlugin.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaRefactoringPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaWhereUsedFilters.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaWhereUsedFilters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/RefactoringVisitor.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/RefactoringVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ToPhaseException.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ToPhaseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaActionsImplementationProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaActionsImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaRefactoringActionDelegate.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaRefactoringActionDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaRefactoringGlobalAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaRefactoringGlobalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ClassItem.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ClassItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ComputeOffAWT.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ComputeOffAWT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ContextAnalyzer.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ContextAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/CopyClassRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/CopyClassRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/CopyClassesUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/CopyClassesUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldsRefactoring.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/EncapsulateFieldsRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractInterfaceAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractInterfaceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractInterfacePanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractInterfacePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractInterfaceRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractInterfaceRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractSuperclassAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractSuperclassAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractSuperclassPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractSuperclassPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractSuperclassRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ExtractSuperclassRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/HighlightsLayerFactory.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/HighlightsLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InlineAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InlineAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InlineRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InlineRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InnerToOuterAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InnerToOuterAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InnerToOuterPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InnerToOuterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InnerToOuterRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InnerToOuterRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InstantRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InstantRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InstantRefactoringUIImpl.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InstantRefactoringUIImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceLocalExtensionAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceLocalExtensionAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceLocalExtensionPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceLocalExtensionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceLocalExtensionUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceLocalExtensionUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InvertBooleanAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InvertBooleanAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InvertBooleanRefactoringPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InvertBooleanRefactoringPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InvertBooleanRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InvertBooleanRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaActionsImplementationFactory.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaActionsImplementationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringActionsProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringGlobalAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringGlobalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringUIFactory.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringUIFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRenameProperties.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRenameProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassesUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassesUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PackagetoTreePathHandleTask.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PackagetoTreePathHandleTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PushDownAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PushDownAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PushDownPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PushDownPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PushDownRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PushDownRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RefactoringActionsProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RefactoringActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RenamePanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RenamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RenameRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RenameRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithBuilderAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithBuilderAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithBuilderPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithBuilderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithBuilderUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithBuilderUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithFactoryAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithFactoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithFactoryPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithFactoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithFactoryUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ReplaceConstructorWithFactoryUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/SafeDeletePanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/SafeDeletePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/SafeDeleteUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/SafeDeleteUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/SyncDocumentRegion.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/SyncDocumentRegion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UseSuperTypeAction.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UseSuperTypeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UseSuperTypePanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UseSuperTypePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UseSuperTypeRefactoringUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UseSuperTypeRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelClass.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelMethod.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelPackage.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelVariable.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanelVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedQueryUI.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedQueryUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/DescriptionFilter.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/DescriptionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/ElementNode.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/ElementNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/FiltersDescription.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/FiltersDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/FiltersManager.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/FiltersManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/JCheckBoxIcon.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/JCheckBoxIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/NoBorderToolBar.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/NoBorderToolBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/SortActionSupport.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/SortActionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/TapPanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/TapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/TrivialLayout.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/TrivialLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/CompletionLayout.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/CompletionLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/CompletionLayoutPopup.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/CompletionLayoutPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/CompletionScrollPane.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/CompletionScrollPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/DocumentationScrollPane.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/DocumentationScrollPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/InstantOption.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/instant/InstantOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentFileScopeProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentFileScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectDependenciesScopeProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectDependenciesScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectScopeProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentPackageScopeProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentPackageScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CustomScopePanel.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CustomScopePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CustomScopeProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CustomScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/DependenciesScopeProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/DependenciesScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/OpenProjectsScopeProvider.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/OpenProjectsScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ElementGrip.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ElementGrip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ElementGripFactory.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ElementGripFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ElementGripTreeElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ElementGripTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/FileTreeElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/FileTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/FolderTreeElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/FolderTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/JavaPlatformTreeElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/JavaPlatformTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ProjectTreeElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/ProjectTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/RefactoringTreeElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/RefactoringTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/SourceGroupTreeElement.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/SourceGroupTreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/TreeElementFactoryImpl.java
+++ b/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/TreeElementFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/FUClass.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/FUClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/FindSubtype.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/FindSubtype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/Subtype1.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/Subtype1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/Subtype2.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/Subtype2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/SubtypeC.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fu/SubtypeC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/Iface.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/Iface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/SubClass.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/SubClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/SuperClass.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/SuperClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/Test.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/User.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/fumethod/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/Move.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/Move.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/MoveToNewPkg.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/MoveToNewPkg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/MoveToTest.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/MoveToTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/Reference.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/Reference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/StatRef.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/moveSource/StatRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/Rename.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/Rename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameCtor.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameCtor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameGenerics.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameGenerics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameLocalVariable.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameLocalVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameMethod.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameParameter.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameProperty.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameClass/RenameProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renamePkg/RenamePkg.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renamePkg/RenamePkg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renamePkg/subPkg/A.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renamePkg/subPkg/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameUndo/RenameUndo.java
+++ b/refactoring.java/test/qa-functional/data/projects/RefactoringTest/src/renameUndo/RenameUndo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/ConvertAnonymousToMemberTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/ConvertAnonymousToMemberTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/EncapsulateFieldTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/EncapsulateFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/FindUsagesClassTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/FindUsagesClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/FindUsagesMethodTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/FindUsagesMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/FindUsagesTestCase.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/FindUsagesTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/InspectAndTransformTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/InspectAndTransformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceConstantTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceConstantTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceFieldTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceMethodTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceParameterTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/IntroduceParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/ModifyingRefactoring.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/ModifyingRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/MoveTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/MoveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/PushPullTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/PushPullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/RefactoringTestCase.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/RefactoringTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/RenameTest.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/RenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/ConvertAnonymousToMemberAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/ConvertAnonymousToMemberAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/EncapsulateFieldAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/EncapsulateFieldAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/FindUsagesAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/FindUsagesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/InspectAndTransformAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/InspectAndTransformAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceConstantAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceConstantAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceFieldAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceFieldAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceMethodAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceMethodAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceParameterAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorIntroduceParameterAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorMoveAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorMoveAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorPullUpAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorPullUpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorPushDownAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorPushDownAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorRenameAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorRenameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorUndoAction.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/actions/RefactorUndoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/EncapsulateFieldOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/EncapsulateFieldOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/ErrorOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/ErrorOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/FindUsagesDialogOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/FindUsagesDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/InspectAndTransformOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/InspectAndTransformOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceConstantOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceConstantOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceFieldOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceFieldOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceMethodOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceMethodOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceParameterOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/IntroduceParameterOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/ManageInspectionsOperatot.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/ManageInspectionsOperatot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/MoveClassDialogOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/MoveClassDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/OverflowToolbarOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/OverflowToolbarOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/ParametersPanelOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/ParametersPanelOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/PullUpOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/PullUpOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/PushDownOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/PushDownOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/RefactoringOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/RefactoringOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/RefactoringResultOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/RefactoringResultOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/RenameOperator.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/operators/RenameOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/suites/FindUsagesSuite.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/suites/FindUsagesSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/suites/IntroduceSuite.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/suites/IntroduceSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/suites/JavaRefactoringSuite.java
+++ b/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/suites/JavaRefactoringSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEApp/src/package1/C.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEApp/src/package1/C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/B.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/B.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/D.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/I.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/I.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/Main.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEApp/src/simplej2seapp/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEApp/test/package1/D.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEApp/test/package1/D.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEAppChild/src/simplej2seappchild/SimpleJ2SEAppChild.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEAppChild/src/simplej2seappchild/SimpleJ2SEAppChild.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/data/SimpleJ2SEAppChild/src/simplej2seappchild/subpackage/NewClass.java
+++ b/refactoring.java/test/unit/data/SimpleJ2SEAppChild/src/simplej2seappchild/subpackage/NewClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/suites/JavaRefactoringTestSuite.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/suites/JavaRefactoringTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/suites/MoveRefactoringTestSuite.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/suites/MoveRefactoringTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ChangeParametersTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ChangeParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/CopyClassTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/CopyClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/EncapsulateFieldsTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/EncapsulateFieldsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractInterfaceTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractInterfaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractSuperclassTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractSuperclassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindSubclassesTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindSubclassesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindUsagesFilterTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindUsagesFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindUsagesPerfTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindUsagesPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindUsagesTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/FindUsagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InlineTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InlineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerToOutterTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerToOutterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/IntroduceLocalExtensionTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/IntroduceLocalExtensionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/IntroduceParameterTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/IntroduceParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InvertBooleanTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InvertBooleanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveBase.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassPerfTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveFieldTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveJavaFileTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveJavaFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveMethodTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/OpenDocumentsPerfTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/OpenDocumentsPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/PullUpTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/PullUpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/PushDownTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/PushDownTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefPerfTestCase.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefPerfTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefTestBase.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefactoringTestBase.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefactoringTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenamePackageTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenamePackageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenameTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ReplaceConstructorWithBuilderTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ReplaceConstructorWithBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ReplaceConstructorWithFactoryTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ReplaceConstructorWithFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/SafeDeleteVariableTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/SafeDeleteVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/UseSuperTypeTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/UseSuperTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/Utilities.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterActionTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/IntroduceParameterActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringActionsProviderTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringActionsProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/MoveRefactoringActionTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/MoveRefactoringActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/src/org/netbeans/modules/sampler/CLISampler.java
+++ b/sampler/src/org/netbeans/modules/sampler/CLISampler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/src/org/netbeans/modules/sampler/InternalSampler.java
+++ b/sampler/src/org/netbeans/modules/sampler/InternalSampler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/src/org/netbeans/modules/sampler/Sampler.java
+++ b/sampler/src/org/netbeans/modules/sampler/Sampler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
+++ b/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/src/org/netbeans/modules/sampler/SelfSampleVFS.java
+++ b/sampler/src/org/netbeans/modules/sampler/SelfSampleVFS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/test/unit/src/org/netbeans/modules/sampler/CustomSamplesStream.java
+++ b/sampler/test/unit/src/org/netbeans/modules/sampler/CustomSamplesStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/test/unit/src/org/netbeans/modules/sampler/SamplerTest.java
+++ b/sampler/test/unit/src/org/netbeans/modules/sampler/SamplerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sampler/test/unit/src/org/netbeans/modules/sampler/SelfSampleVFSTest.java
+++ b/sampler/test/unit/src/org/netbeans/modules/sampler/SelfSampleVFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/s2banttask/S2bConfigDelegator.java
+++ b/schema2beans/src/org/netbeans/modules/s2banttask/S2bConfigDelegator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/s2banttask/Schema2BeansAntTask.java
+++ b/schema2beans/src/org/netbeans/modules/s2banttask/Schema2BeansAntTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/AttrProp.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/AttrProp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/BaseAttribute.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/BaseAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/BaseProperty.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/BaseProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Bean.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Bean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/BeanComparator.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/BeanComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/BeanProp.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/BeanProp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/DDBeanInfo.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/DDBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/DDFactory.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/DDFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/DDLogFlags.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/DDLogFlags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/DDParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/DDParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/DDRegistry.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/DDRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/DDRegistryParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/DDRegistryParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/DOMBinding.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/DOMBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/JavaBeansUtil.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/JavaBeansUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/NodeFactory.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/NodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/NullEntityResolver.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/NullEntityResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/QName.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/QName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/ReflectiveBeanProp.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/ReflectiveBeanProp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Schema2Beans.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Schema2Beans.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansException.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansNestedException.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansNestedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansRuntimeException.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansUtil.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Schema2BeansUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/TraceLogger.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/TraceLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/ValidateException.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/ValidateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Version.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Version.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/Wrapper.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/Wrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beans/XMLUtil.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beans/XMLUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/AbstractCodeGeneratorClass.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/AbstractCodeGeneratorClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/BaseBeansFactory.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/BaseBeansFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/BeanBuilder.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/BeanBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/BeanClass.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/BeanClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/CodeGeneratorClass.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/CodeGeneratorClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/CodeGeneratorFactory.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/CodeGeneratorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/DataEnumRestriction.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/DataEnumRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/DataListRestriction.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/DataListRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/DataTypeRestriction.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/DataTypeRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/DocDefHandler.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/DocDefHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/DocDefParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/DocDefParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/EntityParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/EntityParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/GenBeans.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/GenBeans.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/GeneralParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/GeneralParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/GraphLink.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/GraphLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/GraphNode.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/GraphNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/HasAnnotation.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/HasAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/HasPrefixGuesser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/HasPrefixGuesser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/JavaBeanClass.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/JavaBeanClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/JavaBeansFactory.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/JavaBeansFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/PrefixGuesser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/PrefixGuesser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/S2bConfig.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/S2bConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/Schema2BeansProcessor.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/Schema2BeansProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaParseException.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaRep.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaRep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/TestListener.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/TestListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/TreeBuilder.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/TreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/TreeParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/TreeParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/XMLSchemaParser.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/XMLSchemaParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/beangraph/BeanGraph.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/beangraph/BeanGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/beangraph/CommonBean.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/beangraph/CommonBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/beangraph/SchemaTypeMappingType.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/beangraph/SchemaTypeMappingType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/GenBuffer.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/GenBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/IndentingWriter.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/IndentingWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/JavaUtil.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/JavaUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/JavaWriter.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/JavaWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/WriteIfDifferentOutputStream.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/WriteIfDifferentOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/XMLWriter.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/gen/XMLWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/CommonBean.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/CommonBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/MetaDD.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/MetaDD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/MetaElement.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/MetaElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/MetaProperty.java
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/metadd/MetaProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/BaseTest.java
+++ b/schema2beans/test/unit/data/BaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestApplication1_4.java
+++ b/schema2beans/test/unit/data/TestApplication1_4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestAttr.java
+++ b/schema2beans/test/unit/data/TestAttr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestBadNames.java
+++ b/schema2beans/test/unit/data/TestBadNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestBeanWrapper.java
+++ b/schema2beans/test/unit/data/TestBeanWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestBook.java
+++ b/schema2beans/test/unit/data/TestBook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestBookXMLSchema.java
+++ b/schema2beans/test/unit/data/TestBookXMLSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestContrivedApp.java
+++ b/schema2beans/test/unit/data/TestContrivedApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestDupInternalNames.java
+++ b/schema2beans/test/unit/data/TestDupInternalNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestEmpty.java
+++ b/schema2beans/test/unit/data/TestEmpty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestEncoding.java
+++ b/schema2beans/test/unit/data/TestEncoding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestEvents.java
+++ b/schema2beans/test/unit/data/TestEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestExceptions.java
+++ b/schema2beans/test/unit/data/TestExceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestExtension.java
+++ b/schema2beans/test/unit/data/TestExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestExtension2.java
+++ b/schema2beans/test/unit/data/TestExtension2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestExtensionSample.java
+++ b/schema2beans/test/unit/data/TestExtensionSample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestFinalWebApp.java
+++ b/schema2beans/test/unit/data/TestFinalWebApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestFind.java
+++ b/schema2beans/test/unit/data/TestFind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestGroupUnbounded.java
+++ b/schema2beans/test/unit/data/TestGroupUnbounded.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestInvoice.java
+++ b/schema2beans/test/unit/data/TestInvoice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestMdd.java
+++ b/schema2beans/test/unit/data/TestMdd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestMerge.java
+++ b/schema2beans/test/unit/data/TestMerge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestMergeExtendBaseBean.java
+++ b/schema2beans/test/unit/data/TestMergeExtendBaseBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestNamespace.java
+++ b/schema2beans/test/unit/data/TestNamespace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestOr.java
+++ b/schema2beans/test/unit/data/TestOr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestPositions.java
+++ b/schema2beans/test/unit/data/TestPositions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestPurchaseOrder.java
+++ b/schema2beans/test/unit/data/TestPurchaseOrder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestValid.java
+++ b/schema2beans/test/unit/data/TestValid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestVeto.java
+++ b/schema2beans/test/unit/data/TestVeto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestWebApp.java
+++ b/schema2beans/test/unit/data/TestWebApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestWebAppDelegator.java
+++ b/schema2beans/test/unit/data/TestWebAppDelegator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/TestWebAppDelegatorBaseBean.java
+++ b/schema2beans/test/unit/data/TestWebAppDelegatorBaseBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/data/book/MyDate.java
+++ b/schema2beans/test/unit/data/book/MyDate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/schema2beans/test/unit/src/tests/MainTest.java
+++ b/schema2beans/test/unit/src/tests/MainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2.java/src/org/netbeans/modules/selenium2/java/Selenium2JavaTestWizardIterator.java
+++ b/selenium2.java/src/org/netbeans/modules/selenium2/java/Selenium2JavaTestWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2.java/src/org/netbeans/modules/selenium2/java/api/Utils.java
+++ b/selenium2.java/src/org/netbeans/modules/selenium2/java/api/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2.maven/src/org/netbeans/modules/selenium2/maven/Selenium2MavenSupportImpl.java
+++ b/selenium2.maven/src/org/netbeans/modules/selenium2/maven/Selenium2MavenSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2.server/src/org/netbeans/modules/selenium2/server/Selenium2Customizer.java
+++ b/selenium2.server/src/org/netbeans/modules/selenium2/server/Selenium2Customizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2.server/src/org/netbeans/modules/selenium2/server/Selenium2ServerSupport.java
+++ b/selenium2.server/src/org/netbeans/modules/selenium2/server/Selenium2ServerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2.server/src/org/netbeans/modules/selenium2/server/Selenium2ServicesNode.java
+++ b/selenium2.server/src/org/netbeans/modules/selenium2/server/Selenium2ServicesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2.server/src/org/netbeans/modules/selenium2/server/api/Selenium2Server.java
+++ b/selenium2.server/src/org/netbeans/modules/selenium2/server/api/Selenium2Server.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2/src/org/netbeans/modules/selenium2/RunSeleniumTestsAction.java
+++ b/selenium2/src/org/netbeans/modules/selenium2/RunSeleniumTestsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2/src/org/netbeans/modules/selenium2/SeleniumTestCreatorConfiguration.java
+++ b/selenium2/src/org/netbeans/modules/selenium2/SeleniumTestCreatorConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2/src/org/netbeans/modules/selenium2/SeleniumTestCreatorConfigurationProvider.java
+++ b/selenium2/src/org/netbeans/modules/selenium2/SeleniumTestCreatorConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2/src/org/netbeans/modules/selenium2/SeleniumTestCreatorProvider.java
+++ b/selenium2/src/org/netbeans/modules/selenium2/SeleniumTestCreatorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2/src/org/netbeans/modules/selenium2/api/Selenium2Support.java
+++ b/selenium2/src/org/netbeans/modules/selenium2/api/Selenium2Support.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2/src/org/netbeans/modules/selenium2/api/Utils.java
+++ b/selenium2/src/org/netbeans/modules/selenium2/api/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/selenium2/src/org/netbeans/modules/selenium2/spi/Selenium2SupportImpl.java
+++ b/selenium2/src/org/netbeans/modules/selenium2/spi/Selenium2SupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/api/sendopts/CommandException.java
+++ b/sendopts/src/org/netbeans/api/sendopts/CommandException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/api/sendopts/CommandLine.java
+++ b/sendopts/src/org/netbeans/api/sendopts/CommandLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/modules/sendopts/DefaultProcessor.java
+++ b/sendopts/src/org/netbeans/modules/sendopts/DefaultProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/modules/sendopts/Handler.java
+++ b/sendopts/src/org/netbeans/modules/sendopts/Handler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/modules/sendopts/HandlerImpl.java
+++ b/sendopts/src/org/netbeans/modules/sendopts/HandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessor.java
+++ b/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessorImpl.java
+++ b/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/modules/sendopts/OptionImpl.java
+++ b/sendopts/src/org/netbeans/modules/sendopts/OptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/spi/sendopts/Arg.java
+++ b/sendopts/src/org/netbeans/spi/sendopts/Arg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/spi/sendopts/ArgsProcessor.java
+++ b/sendopts/src/org/netbeans/spi/sendopts/ArgsProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/spi/sendopts/Description.java
+++ b/sendopts/src/org/netbeans/spi/sendopts/Description.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/spi/sendopts/Env.java
+++ b/sendopts/src/org/netbeans/spi/sendopts/Env.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/spi/sendopts/Option.java
+++ b/sendopts/src/org/netbeans/spi/sendopts/Option.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/spi/sendopts/OptionGroups.java
+++ b/sendopts/src/org/netbeans/spi/sendopts/OptionGroups.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/src/org/netbeans/spi/sendopts/OptionProcessor.java
+++ b/sendopts/src/org/netbeans/spi/sendopts/OptionProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/AdditionalArgumentOptsTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/AdditionalArgumentOptsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/AlwaysOptionTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/AlwaysOptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/AnyOfTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/AnyOfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/DefaultArgumentOptsTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/DefaultArgumentOptsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/DefineRefineIgnoreTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/DefineRefineIgnoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/EnvTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/EnvTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/ErrorMessagesTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/ErrorMessagesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/ForClassWithProcessorTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/ForClassWithProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/MasterTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/MasterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/NoArgumentOptsTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/NoArgumentOptsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/OneArgumentOptsTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/OneArgumentOptsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/OneOfComplexTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/OneOfComplexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/OptionProviderTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/OptionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/OptionalArgumentOptsTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/OptionalArgumentOptsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/Processor.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/Processor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/Provider.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/Provider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/SharedOptionTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/SharedOptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/ShortDescriptionTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/ShortDescriptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/SingleSharedOptionTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/SingleSharedOptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/StandaloneTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/StandaloneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/api/sendopts/StreamingTest.java
+++ b/sendopts/test/unit/src/org/netbeans/api/sendopts/StreamingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/modules/sendopts/CaptureUsageTest.java
+++ b/sendopts/test/unit/src/org/netbeans/modules/sendopts/CaptureUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/modules/sendopts/HandlerImplTest.java
+++ b/sendopts/test/unit/src/org/netbeans/modules/sendopts/HandlerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/modules/sendopts/InstancesTest.java
+++ b/sendopts/test/unit/src/org/netbeans/modules/sendopts/InstancesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/spi/sendopts/annotations/ForClassTest.java
+++ b/sendopts/test/unit/src/org/netbeans/spi/sendopts/annotations/ForClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/sendopts/test/unit/src/org/netbeans/spi/sendopts/annotations/OptionTest.java
+++ b/sendopts/test/unit/src/org/netbeans/spi/sendopts/annotations/OptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/api/server/CommonServerUIs.java
+++ b/server/src/org/netbeans/api/server/CommonServerUIs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/api/server/ServerInstance.java
+++ b/server/src/org/netbeans/api/server/ServerInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/api/server/package-info.java
+++ b/server/src/org/netbeans/api/server/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/api/server/properties/InstanceProperties.java
+++ b/server/src/org/netbeans/api/server/properties/InstanceProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/api/server/properties/InstancePropertiesManager.java
+++ b/server/src/org/netbeans/api/server/properties/InstancePropertiesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/api/server/properties/package-info.java
+++ b/server/src/org/netbeans/api/server/properties/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ServerRegistry.java
+++ b/server/src/org/netbeans/modules/server/ServerRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/manager/CloudManagerAction.java
+++ b/server/src/org/netbeans/modules/server/ui/manager/CloudManagerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/manager/ServerManagerAction.java
+++ b/server/src/org/netbeans/modules/server/ui/manager/ServerManagerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/manager/ServerManagerPanel.java
+++ b/server/src/org/netbeans/modules/server/ui/manager/ServerManagerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/node/AddCloudInstanceAction.java
+++ b/server/src/org/netbeans/modules/server/ui/node/AddCloudInstanceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/node/AddServerInstanceAction.java
+++ b/server/src/org/netbeans/modules/server/ui/node/AddServerInstanceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/node/RootNode.java
+++ b/server/src/org/netbeans/modules/server/ui/node/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
+++ b/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/wizard/AvailableProvidersPanel.java
+++ b/server/src/org/netbeans/modules/server/ui/wizard/AvailableProvidersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/wizard/ServerWizardPanel.java
+++ b/server/src/org/netbeans/modules/server/ui/wizard/ServerWizardPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/modules/server/ui/wizard/ServerWizardVisual.java
+++ b/server/src/org/netbeans/modules/server/ui/wizard/ServerWizardVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/spi/server/ServerInstanceFactory.java
+++ b/server/src/org/netbeans/spi/server/ServerInstanceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/spi/server/ServerInstanceImplementation.java
+++ b/server/src/org/netbeans/spi/server/ServerInstanceImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/spi/server/ServerInstanceProvider.java
+++ b/server/src/org/netbeans/spi/server/ServerInstanceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/spi/server/ServerWizardProvider.java
+++ b/server/src/org/netbeans/spi/server/ServerWizardProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/src/org/netbeans/spi/server/package-info.java
+++ b/server/src/org/netbeans/spi/server/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/api/server/properties/InstancePropertiesTest.java
+++ b/server/test/unit/src/org/netbeans/api/server/properties/InstancePropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/ServerRegistryTest.java
+++ b/server/test/unit/src/org/netbeans/modules/server/ServerRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/test/MockInstanceImplementation.java
+++ b/server/test/unit/src/org/netbeans/modules/server/test/MockInstanceImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/test/MockInstanceProvider.java
+++ b/server/test/unit/src/org/netbeans/modules/server/test/MockInstanceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/test/MockWizardProvider.java
+++ b/server/test/unit/src/org/netbeans/modules/server/test/MockWizardProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/ui/node/RootNodeConfigFileTest.java
+++ b/server/test/unit/src/org/netbeans/modules/server/ui/node/RootNodeConfigFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/ui/node/RootNodeHiddenActionTest.java
+++ b/server/test/unit/src/org/netbeans/modules/server/ui/node/RootNodeHiddenActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/ui/node/RootNodeTest.java
+++ b/server/test/unit/src/org/netbeans/modules/server/ui/node/RootNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/server/test/unit/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizardTest.java
+++ b/server/test/unit/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/examples/src/org/netbeans/modules/settings/examples/JavaCompilerSetting.java
+++ b/settings/examples/src/org/netbeans/modules/settings/examples/JavaCompilerSetting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/examples/src/org/netbeans/modules/settings/examples/JavaCompilerSettingBeanInfo.java
+++ b/settings/examples/src/org/netbeans/modules/settings/examples/JavaCompilerSettingBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/examples/src/org/netbeans/modules/settings/examples/ProxySettings.java
+++ b/settings/examples/src/org/netbeans/modules/settings/examples/ProxySettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/examples/src/org/netbeans/modules/settings/examples/ProxySettingsBeanInfo.java
+++ b/settings/examples/src/org/netbeans/modules/settings/examples/ProxySettingsBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/api/settings/ConvertAsJavaBean.java
+++ b/settings/src/org/netbeans/api/settings/ConvertAsJavaBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/api/settings/ConvertAsProperties.java
+++ b/settings/src/org/netbeans/api/settings/ConvertAsProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/api/settings/Factory.java
+++ b/settings/src/org/netbeans/api/settings/Factory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/api/settings/FactoryMethod.java
+++ b/settings/src/org/netbeans/api/settings/FactoryMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/api/settings/package-info.java
+++ b/settings/src/org/netbeans/api/settings/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/ContextProvider.java
+++ b/settings/src/org/netbeans/modules/settings/ContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/Env.java
+++ b/settings/src/org/netbeans/modules/settings/Env.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/InstanceProvider.java
+++ b/settings/src/org/netbeans/modules/settings/InstanceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/RecognizeInstanceObjects.java
+++ b/settings/src/org/netbeans/modules/settings/RecognizeInstanceObjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/SaveSupport.java
+++ b/settings/src/org/netbeans/modules/settings/SaveSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/ScheduledRequest.java
+++ b/settings/src/org/netbeans/modules/settings/ScheduledRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/convertors/ConvertorProcessor.java
+++ b/settings/src/org/netbeans/modules/settings/convertors/ConvertorProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/convertors/ModuleInfoManager.java
+++ b/settings/src/org/netbeans/modules/settings/convertors/ModuleInfoManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
+++ b/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/convertors/SerialDataNode.java
+++ b/settings/src/org/netbeans/modules/settings/convertors/SerialDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/convertors/XMLBeanConvertor.java
+++ b/settings/src/org/netbeans/modules/settings/convertors/XMLBeanConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertor.java
+++ b/settings/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/modules/settings/convertors/XMLSettingsSupport.java
+++ b/settings/src/org/netbeans/modules/settings/convertors/XMLSettingsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/spi/settings/Convertor.java
+++ b/settings/src/org/netbeans/spi/settings/Convertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/spi/settings/ConvertorResolver.java
+++ b/settings/src/org/netbeans/spi/settings/ConvertorResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/spi/settings/DOMConvertor.java
+++ b/settings/src/org/netbeans/spi/settings/DOMConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/src/org/netbeans/spi/settings/Saver.java
+++ b/settings/src/org/netbeans/spi/settings/Saver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/DataShadowUpdatesTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/DataShadowUpdatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/EnvTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/EnvTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/RecognizeInstanceObjectsOnModuleEnablementTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/RecognizeInstanceObjectsOnModuleEnablementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/RecognizeInstanceObjectsTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/RecognizeInstanceObjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/ScheduledRequestTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/ScheduledRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar1Setting.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar1Setting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar2Setting.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar2Setting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar3Setting.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar3Setting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar4Setting.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/Bar4Setting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/ConvertAsBeanTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/ConvertAsBeanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/FactoryMethodTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/FactoryMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/FooSetting.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/FooSetting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/InstanceDataObjectCopyTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/InstanceDataObjectCopyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/LayersTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/LayersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/MimeTypeTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/MimeTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/ObsoleteClass.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/ObsoleteClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/RemovedClass.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/RemovedClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataNodeTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorAnnotationTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorTest.java
+++ b/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/spi/settings/ConvertorTest.java
+++ b/settings/test/unit/src/org/netbeans/spi/settings/ConvertorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/settings/test/unit/src/org/netbeans/spi/settings/DOMConvertorTest.java
+++ b/settings/test/unit/src/org/netbeans/spi/settings/DOMConvertorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/api/LocaleQuery.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/api/LocaleQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/api/Spellchecker.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/api/Spellchecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/LocaleQueryImplementation.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/LocaleQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/dictionary/Dictionary.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/dictionary/Dictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/dictionary/DictionaryProvider.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/dictionary/DictionaryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/dictionary/ValidityType.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/dictionary/ValidityType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/language/TokenList.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/language/TokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/language/TokenListProvider.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/language/TokenListProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/language/support/MultiTokenList.java
+++ b/spellchecker.apimodule/src/org/netbeans/modules/spellchecker/spi/language/support/MultiTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/AbstractTokenList.java
+++ b/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/AbstractTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/HtmlTokenList.java
+++ b/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/HtmlTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/HtmlXmlTokenListProvider.java
+++ b/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/HtmlXmlTokenListProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/XmlTokenList.java
+++ b/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/XmlTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.java/src/org/netbeans/modules/spellchecker/bindings/java/JavaSemanticTokenList.java
+++ b/spellchecker.bindings.java/src/org/netbeans/modules/spellchecker/bindings/java/JavaSemanticTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.java/src/org/netbeans/modules/spellchecker/bindings/java/JavaTokenList.java
+++ b/spellchecker.bindings.java/src/org/netbeans/modules/spellchecker/bindings/java/JavaTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.java/src/org/netbeans/modules/spellchecker/bindings/java/JavaTokenListProvider.java
+++ b/spellchecker.bindings.java/src/org/netbeans/modules/spellchecker/bindings/java/JavaTokenListProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.java/test/unit/src/org/netbeans/modules/spellchecker/bindings/java/JavaSemanticTokenListTest.java
+++ b/spellchecker.bindings.java/test/unit/src/org/netbeans/modules/spellchecker/bindings/java/JavaSemanticTokenListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.java/test/unit/src/org/netbeans/modules/spellchecker/bindings/java/JavaTokenListTest.java
+++ b/spellchecker.bindings.java/test/unit/src/org/netbeans/modules/spellchecker/bindings/java/JavaTokenListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/AbstractTokenList.java
+++ b/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/AbstractTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/PropertiesTokenList.java
+++ b/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/PropertiesTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/PropertiesTokenListProvider.java
+++ b/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/PropertiesTokenListProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/ComponentPeer.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/ComponentPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/CompoundDictionary.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/CompoundDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/DefaultLocaleQueryImplementation.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/DefaultLocaleQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryImpl.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryProviderImpl.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/LookupAccessor.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/LookupAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/ProjectLocaleQueryImplementation.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/ProjectLocaleQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/SpellcheckerHighlightLayerFactory.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/SpellcheckerHighlightLayerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/TrieDictionary.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/TrieDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/Utilities.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/completion/AddToDictionaryCompletionItem.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/completion/AddToDictionaryCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/completion/WordCompletion.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/completion/WordCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/completion/WordCompletionItem.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/completion/WordCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/hints/AddToDictionaryHint.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/hints/AddToDictionaryHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/hints/DictionaryBasedHint.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/hints/DictionaryBasedHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/options/CheckBoxRenderrer.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/options/CheckBoxRenderrer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/options/DictionaryInstallerPanel.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/options/DictionaryInstallerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanelController.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/plain/PlainTokenList.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/plain/PlainTokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/src/org/netbeans/modules/spellchecker/plain/PlainTokenListProvider.java
+++ b/spellchecker/src/org/netbeans/modules/spellchecker/plain/PlainTokenListProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/ComponentPeerTest.java
+++ b/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/ComponentPeerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/DictionaryImplTest.java
+++ b/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/DictionaryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/TrieDictionaryTest.java
+++ b/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/TrieDictionaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/UnitUtilities.java
+++ b/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/UnitUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/plain/PlainTokenListTest.java
+++ b/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/plain/PlainTokenListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/ActionStub.java
+++ b/spi.actions/src/org/netbeans/spi/actions/ActionStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/ContextAction.java
+++ b/spi.actions/src/org/netbeans/spi/actions/ContextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/IndirectAction.java
+++ b/spi.actions/src/org/netbeans/spi/actions/IndirectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/LookupProviderAction.java
+++ b/spi.actions/src/org/netbeans/spi/actions/LookupProviderAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/MergeAction.java
+++ b/spi.actions/src/org/netbeans/spi/actions/MergeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/NbAction.java
+++ b/spi.actions/src/org/netbeans/spi/actions/NbAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/RetainingStub.java
+++ b/spi.actions/src/org/netbeans/spi/actions/RetainingStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/Single.java
+++ b/spi.actions/src/org/netbeans/spi/actions/Single.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/src/org/netbeans/spi/actions/SurviveSelectionChange.java
+++ b/spi.actions/src/org/netbeans/spi/actions/SurviveSelectionChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.actions/test/unit/src/org/netbeans/spi/actions/ContextActionTest.java
+++ b/spi.actions/test/unit/src/org/netbeans/spi/actions/ContextActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/apiregistry/DebuggerProcessor.java
+++ b/spi.debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/apiregistry/DebuggerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.jpda.ui/src/org/netbeans/spi/debugger/jpda/VariablesFilter.java
+++ b/spi.debugger.jpda.ui/src/org/netbeans/spi/debugger/jpda/VariablesFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.jpda.ui/src/org/netbeans/spi/debugger/jpda/VariablesFilterAdapter.java
+++ b/spi.debugger.jpda.ui/src/org/netbeans/spi/debugger/jpda/VariablesFilterAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/ComponentInfoFromBeanContext.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/ComponentInfoFromBeanContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerModule.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/PersistenceManager.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/PersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/Utils.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/WatchPanel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/WatchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/WatchesReader.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/WatchesReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/AddBreakpointAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/AddBreakpointAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/AddBreakpointPanel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/AddBreakpointPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/AddWatchAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/AddWatchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointCustomizeAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointCustomizeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointEnableAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointEnableAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointToggleActionOnBreakpoint.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointToggleActionOnBreakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointToggleActionToggleNew.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/BreakpointToggleActionToggleNew.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ConnectAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ConnectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ConnectorPanel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ConnectorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebugMainProjectAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebugMainProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebugProjectAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebugProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebuggerAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebuggerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/GestureSubmitter.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/GestureSubmitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/GoToHitAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/GoToHitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/SetCurrentThreadFromHistoryAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/SetCurrentThreadFromHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ViewActions.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ViewActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/DebuggerAnnotation.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/DebuggerAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/WatchAnnotationProvider.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/WatchAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/ButtonPopupSwitcher.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/ButtonPopupSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/CodeEvaluatorUI.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/CodeEvaluatorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTable.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTableItem.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTableItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTableModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointGroup.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointNestedGroupsDialog.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointNestedGroupsDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsActionsProvider.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsGroupExpansionFilter.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsGroupExpansionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsNodeModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsTreeModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsViewButtons.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/BreakpointsViewButtons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ColumnModels.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ColumnModels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/IdentityHashSet.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/IdentityHashSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SesionsNodeModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SesionsNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SessionsActionsProvider.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SessionsActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SessionsTableModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SessionsTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SessionsTreeModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/SessionsTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ToolTipExpansionFilter.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ToolTipExpansionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ToolTipNodeModelFilter.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ToolTipNodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ToolTipTreeModelFilter.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/ToolTipTreeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/VariablesActionsProvider.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/VariablesActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesActionsProvider.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesNodeModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesTableModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesTreeModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/models/WatchesTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/ColumnModelContextAware.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/ColumnModelContextAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DVSupportContextAware.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DVSupportContextAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DebuggerProcessor.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DebuggerProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/EvaluatorServiceContextAware.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/EvaluatorServiceContextAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/CustomView.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/CustomView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ToolTipView.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ToolTipView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/VariablesViewButtons.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/VariablesViewButtons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/View.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewComponent.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ClickableIcon.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ClickableIcon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebugTreeView.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebugTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DelegateViewport.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DelegateViewport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/FiltersDescriptor.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/FiltersDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/InfoPanel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/InfoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/KeyboardPopupSwitcher.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/KeyboardPopupSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTable.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTableItem.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTableItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTableModel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/TapPanel.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/TapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ThreadsHistoryAction.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ThreadsHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ThreadsListener.java
+++ b/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ThreadsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/AbstractExpandToolTipAction.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/AbstractExpandToolTipAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/AttachType.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/AttachType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointAnnotation.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointType.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/CodeEvaluator.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/CodeEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ColumnModelRegistration.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ColumnModelRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ColumnModelRegistrations.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ColumnModelRegistrations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/Constants.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/Controller.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/Controller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/DebuggingView.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/DebuggingView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorContextDispatcher.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorContextDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorPin.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorPin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EngineComponentsProvider.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EngineComponentsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/MethodChooser.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/MethodChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/PersistentController.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/PersistentController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/PinWatchUISupport.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/PinWatchUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ToolTipUI.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ToolTipUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ViewFactory.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ViewFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ViewLifecycle.java
+++ b/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ViewLifecycle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/apps/src/DebuggerTestApplication.java
+++ b/spi.debugger.ui/test/apps/src/DebuggerTestApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/BreakpointsTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/BreakpointsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/DebuggerActionsTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/DebuggerActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/DebuggerApiTestBase.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/DebuggerApiTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/IDEInitializer.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/IDEInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LaunchDebuggerTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LaunchDebuggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LookupTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LookupWithForPathTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LookupWithForPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/PropertiesTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/PropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/ProvidersAnnotationTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/ProvidersAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/WatchesTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/WatchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestActionProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestAttachType.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestAttachType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestBreakpointType.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestBreakpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestColumnModel.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestColumnModelsProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestColumnModelsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestDebuggerEngineProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestDebuggerEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestExtendedNodeModelFilter.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestExtendedNodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestLazyActionsManagerListenerAnnotated.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestLazyActionsManagerListenerAnnotated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestLazyDebuggerManagerListenerAnnotated.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestLazyDebuggerManagerListenerAnnotated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestMIMETypeSensitiveActionProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestMIMETypeSensitiveActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestMultiModelRegistrations.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestMultiModelRegistrations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestSessionProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestSessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestThreeModels.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/providers/TestThreeModels.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestActionsManagerListener.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestActionsManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestDICookie.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestDICookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestDebugger.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestDebugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestDebuggerManagerListener.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestDebuggerManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestEngineProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestEngineProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLazyActionsManagerListener.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLazyActionsManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLazyDebuggerManagerListener.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLazyDebuggerManagerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLookupServiceFirst.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLookupServiceFirst.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLookupServiceInterface.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLookupServiceInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLookupServiceSecond.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestLookupServiceSecond.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestNodeModel.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestNodeModelContext.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestNodeModelContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestSessionProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/TestSessionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/actions/KillActionProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/actions/KillActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/actions/StartActionProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/actions/StartActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/actions/TestDebuggerActionsProvider.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/test/actions/TestDebuggerActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/spi/debugger/ui/EditorContextDispatcherManager.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/spi/debugger/ui/EditorContextDispatcherManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.debugger.ui/test/unit/src/org/netbeans/spi/debugger/ui/EngineComponentsProviderTest.java
+++ b/spi.debugger.ui/test/unit/src/org/netbeans/spi/debugger/ui/EngineComponentsProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/modules/editor/hints/projects/settings/FileHintPreferencesProviderImpl.java
+++ b/spi.editor.hints.projects/src/org/netbeans/modules/editor/hints/projects/settings/FileHintPreferencesProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/PerProjectHintsPanel.java
+++ b/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/PerProjectHintsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/PerProjectHintsPanelUI.java
+++ b/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/PerProjectHintsPanelUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/ProjectSettings.java
+++ b/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/ProjectSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/AdvancedLocationPanel.java
+++ b/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/AdvancedLocationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/ProjectCustomizer.java
+++ b/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/ProjectCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/ProjectHintSettingPanel.java
+++ b/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/ProjectHintSettingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/StandardProjectSettings.java
+++ b/spi.editor.hints.projects/src/org/netbeans/spi/editor/hints/projects/support/StandardProjectSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/AnnotationHolder.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/AnnotationHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/ContextAccessor.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/ContextAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/FixAction.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/FixAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/FixData.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/FixData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/HighlightsLayerFactoryImpl.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/HighlightsLayerFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsControllerImpl.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsControllerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsModule.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsUI.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/NextErrorAction.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/NextErrorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/ParseErrorAnnotation.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/ParseErrorAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/StaticFixList.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/StaticFixList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ListCompletionView.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ListCompletionView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ScrollCompletionPane.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ScrollCompletionPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/settings/friend/FileHintPreferencesProvider.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/settings/friend/FileHintPreferencesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/ChangeInfo.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/ChangeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/Context.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/EnhancedFix.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/EnhancedFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescription.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescriptionFactory.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescriptionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/Fix.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/Fix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/HintsController.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/HintsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/LazyFixList.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/LazyFixList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/PositionRefresher.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/PositionRefresher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/Severity.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/Severity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/settings/FileHintPreferences.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/settings/FileHintPreferences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/test/unit/src/org/netbeans/modules/editor/hints/AnnotationHolderTest.java
+++ b/spi.editor.hints/test/unit/src/org/netbeans/modules/editor/hints/AnnotationHolderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/test/unit/src/org/netbeans/modules/editor/hints/HintsControllerImplTest.java
+++ b/spi.editor.hints/test/unit/src/org/netbeans/modules/editor/hints/HintsControllerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.editor.hints/test/unit/src/org/netbeans/spi/editor/hints/ErrorDescriptionTestSupport.java
+++ b/spi.editor.hints/test/unit/src/org/netbeans/spi/editor/hints/ErrorDescriptionTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/HintsRunner.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/HintsRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/PatternConvertor.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/PatternConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/ProjectDependencyUpgrader.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/ProjectDependencyUpgrader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/CodeHintProviderImpl.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/CodeHintProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/FSWrapper.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/FSWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/ReflectiveCustomizerProvider.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/ReflectiveCustomizerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/ClassPathBasedHintProvider.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/ClassPathBasedHintProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/ElementBasedHintProvider.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/ElementBasedHintProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescription.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescriptionFactory.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescriptionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintMetadata.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintProvider.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/PositionRefresherHelper.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/PositionRefresherHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/Trigger.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/Trigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JackpotTrees.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JackpotTrees.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JavaFixImpl.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JavaFixImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JavaHintsPositionRefresher.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JavaHintsPositionRefresher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/MessageImpl.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/MessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/RulesManager.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/RulesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/RulesManagerImpl.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/RulesManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/SPIAccessor.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/SyntheticFix.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/SyntheticFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearch.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchUtilities.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/ProgressHandleWrapper.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/ProgressHandleWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/Scopes.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/Scopes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsInvoker.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsInvoker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsTask.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/ipi/upgrade/ProjectDependencyUpgrader.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/ipi/upgrade/ProjectDependencyUpgrader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/options/HintsSettings.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/options/HintsSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/BulkSearch.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/BulkSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/CopyFinderBasedBulkSearch.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/CopyFinderBasedBulkSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFA.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearch.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/PatternCompiler.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/PatternCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/processor/JavaHintsAnnotationProcessor.java
+++ b/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/processor/JavaHintsAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/BooleanOption.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/BooleanOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/ConstraintVariableType.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/ConstraintVariableType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/CustomizerProvider.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/CustomizerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/Hint.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/Hint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/HintContext.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/HintContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/HintSeverity.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/HintSeverity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/IntegerOption.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/IntegerOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFix.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/MatcherUtilities.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/MatcherUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerOptions.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerPattern.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerPatterns.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerPatterns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerTreeKind.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/TriggerTreeKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/UseOptions.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/UseOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/support/FixFactory.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/support/FixFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/support/TransformationSupport.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/support/TransformationSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/providers/code/CodeHintProviderImplTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/providers/code/CodeHintProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/providers/code/FSWrapperTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/providers/code/FSWrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/providers/code/TestAnnotations.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/providers/code/TestAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/TestBase.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/TestCompilerSettings.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/TestCompilerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/TestUtilities.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/UtilitiesTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/UtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearchTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchUtilitiesTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/ProgressHandleWrapperTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/ProgressHandleWrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/TestUtils.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsInvokerTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsInvokerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/BulkSearchTestPerformer.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/BulkSearchTestPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/CopyFinderBasedBulkSearchTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/CopyFinderBasedBulkSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearchTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/PatternCompilerTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/PatternCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/PatternCompilerUtilities.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/PatternCompilerUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/processor/JavaHintsAnnotationProcessorTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/processor/JavaHintsAnnotationProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/MatcherUtilitiesTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/MatcherUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/matching/CopyFinderTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/matching/CopyFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/support/FixFactoryTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/support/FixFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/modules/navigator/LazyPanel.java
+++ b/spi.navigator/src/org/netbeans/modules/navigator/LazyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/modules/navigator/NavigatorController.java
+++ b/spi.navigator/src/org/netbeans/modules/navigator/NavigatorController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/modules/navigator/NavigatorPanelRegistrationProcessor.java
+++ b/spi.navigator/src/org/netbeans/modules/navigator/NavigatorPanelRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/modules/navigator/NavigatorTC.java
+++ b/spi.navigator/src/org/netbeans/modules/navigator/NavigatorTC.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/modules/navigator/ProviderRegistry.java
+++ b/spi.navigator/src/org/netbeans/modules/navigator/ProviderRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/modules/navigator/ShowNavigatorAction.java
+++ b/spi.navigator/src/org/netbeans/modules/navigator/ShowNavigatorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/NavigatorDisplayer.java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/NavigatorDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/NavigatorHandler.java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/NavigatorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupHint.java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupHint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanel.java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanelWithToolbar.java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanelWithToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanelWithUndo.java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanelWithUndo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/src/org/netbeans/spi/navigator/doc-files/BasicNavPanelImpl_java
+++ b/spi.navigator/src/org/netbeans/spi/navigator/doc-files/BasicNavPanelImpl_java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/modules/navigator/ListViewNavigatorPanel.java
+++ b/spi.navigator/test/unit/src/org/netbeans/modules/navigator/ListViewNavigatorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/modules/navigator/NavigatorControllerTest.java
+++ b/spi.navigator/test/unit/src/org/netbeans/modules/navigator/NavigatorControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/modules/navigator/NavigatorTCTest.java
+++ b/spi.navigator/test/unit/src/org/netbeans/modules/navigator/NavigatorTCTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/modules/navigator/ProviderRegistryTest.java
+++ b/spi.navigator/test/unit/src/org/netbeans/modules/navigator/ProviderRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/modules/navigator/UnitTestUtils.java
+++ b/spi.navigator/test/unit/src/org/netbeans/modules/navigator/UnitTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/modules/navigator/resources/sample_folder/subfolder1/subfolder2/Nic.my_extension
+++ b/spi.navigator/test/unit/src/org/netbeans/modules/navigator/resources/sample_folder/subfolder1/subfolder2/Nic.my_extension
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/spi/navigator/NavigatorHandlerTest.java
+++ b/spi.navigator/test/unit/src/org/netbeans/spi/navigator/NavigatorHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.navigator/test/unit/src/org/netbeans/spi/navigator/NavigatorPanelWithToolbarTest.java
+++ b/spi.navigator/test/unit/src/org/netbeans/spi/navigator/NavigatorPanelWithToolbarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ActiveEditorDropDefaultProvider.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ActiveEditorDropDefaultProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ActiveEditorDropProvider.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ActiveEditorDropProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/Category.java
+++ b/spi.palette/src/org/netbeans/modules/palette/Category.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/CategoryListener.java
+++ b/spi.palette/src/org/netbeans/modules/palette/CategoryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/CategoryNode.java
+++ b/spi.palette/src/org/netbeans/modules/palette/CategoryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/DefaultCategory.java
+++ b/spi.palette/src/org/netbeans/modules/palette/DefaultCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/DefaultItem.java
+++ b/spi.palette/src/org/netbeans/modules/palette/DefaultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/DefaultModel.java
+++ b/spi.palette/src/org/netbeans/modules/palette/DefaultModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/DefaultSettings.java
+++ b/spi.palette/src/org/netbeans/modules/palette/DefaultSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/Item.java
+++ b/spi.palette/src/org/netbeans/modules/palette/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ItemNode.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ItemNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/Model.java
+++ b/spi.palette/src/org/netbeans/modules/palette/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ModelListener.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/PaletteEnvironmentProvider.java
+++ b/spi.palette/src/org/netbeans/modules/palette/PaletteEnvironmentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/PaletteItemHandler.java
+++ b/spi.palette/src/org/netbeans/modules/palette/PaletteItemHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/PaletteItemNode.java
+++ b/spi.palette/src/org/netbeans/modules/palette/PaletteItemNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/PaletteItemRegistrationProcessor.java
+++ b/spi.palette/src/org/netbeans/modules/palette/PaletteItemRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/RootNode.java
+++ b/spi.palette/src/org/netbeans/modules/palette/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/Settings.java
+++ b/spi.palette/src/org/netbeans/modules/palette/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ShowPaletteAction.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ShowPaletteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/Utils.java
+++ b/spi.palette/src/org/netbeans/modules/palette/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/AutoscrollSupport.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/AutoscrollSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/CategoryButton.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/CategoryButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/CategoryDescriptor.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/CategoryDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/CategoryList.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/CategoryList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/CheckListener.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/CheckListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/CheckRenderer.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/CheckRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/Customizer.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/Customizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/DnDSupport.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/DnDSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/DropGlassPane.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/DropGlassPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/PalettePanel.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/PalettePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/TextImporter.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/TextImporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/modules/palette/ui/TextImporterUI.java
+++ b/spi.palette/src/org/netbeans/modules/palette/ui/TextImporterUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/DragAndDropHandler.java
+++ b/spi.palette/src/org/netbeans/spi/palette/DragAndDropHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteActions.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteController.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteFactory.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteFilter.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistration.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistrations.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistrations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteModule.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteSwitch.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteTopComponent.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/src/org/netbeans/spi/palette/PaletteVisibility.java
+++ b/spi.palette/src/org/netbeans/spi/palette/PaletteVisibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/modules/palette/PaletteItemRegistrationProcessorTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/modules/palette/PaletteItemRegistrationProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/modules/palette/UtilsTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/modules/palette/UtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/AbstractPaletteTestHid.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/AbstractPaletteTestHid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/CategoryTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/CategoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/DragAndDropHandlerTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/DragAndDropHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyActions.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyItemDataObject.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyItemDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyItemLoader.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyItemLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyPalette.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/DummyPalette.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/FooItem.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/FooItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/HelpTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/HelpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/IDEInitializer.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/IDEInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/ItemTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/ItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/ModelTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/ModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/MyLayerPaletteFactory.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/MyLayerPaletteFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteControllerTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteFactoryTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteItemTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteSwitchTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/ProxyModel.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/ProxyModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/RepositoryImpl.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.palette/test/unit/src/org/netbeans/spi/palette/SettingsTest.java
+++ b/spi.palette/test/unit/src/org/netbeans/spi/palette/SettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/AbstractQuickSearchComboBar.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/AbstractQuickSearchComboBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/Accessor.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/CategoryResult.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/CategoryResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/CommandEvaluator.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/CommandEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/ProviderModel.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/ProviderModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchAction.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchComboBar.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchComboBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchPopup.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/ResultsModel.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/ResultsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/SearchResultRender.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/SearchResultRender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/recent/RecentProvider.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/recent/RecentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/recent/RecentSearches.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/recent/RecentSearches.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Item.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Query.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Result.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Result.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/WebQuickSearchProviderImpl.java
+++ b/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/WebQuickSearchProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/spi/quicksearch/AccessorImpl.java
+++ b/spi.quicksearch/src/org/netbeans/spi/quicksearch/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchProvider.java
+++ b/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchRequest.java
+++ b/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchResponse.java
+++ b/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/AbstractQuickSearchComboBarTest.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/AbstractQuickSearchComboBarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/CategoryResultTest.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/CategoryResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/CommandEvaluatorTest.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/CommandEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ObsoleteSupportTest.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ObsoleteSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ProviderModelTest.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ProviderModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ResultsModelTest.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ResultsModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/SlowProviderTest.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/SlowProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/UnitTestUtils.java
+++ b/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/UnitTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/Accessor.java
+++ b/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/EmptyScanningScope.java
+++ b/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/EmptyScanningScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/TaskGroup.java
+++ b/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/TaskGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/TaskGroupFactory.java
+++ b/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/TaskGroupFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/TaskManager.java
+++ b/spi.tasklist/src/org/netbeans/modules/tasklist/trampoline/TaskManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/spi/tasklist/AccessorImpl.java
+++ b/spi.tasklist/src/org/netbeans/spi/tasklist/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/spi/tasklist/FileTaskScanner.java
+++ b/spi.tasklist/src/org/netbeans/spi/tasklist/FileTaskScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/spi/tasklist/PushTaskScanner.java
+++ b/spi.tasklist/src/org/netbeans/spi/tasklist/PushTaskScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/spi/tasklist/Task.java
+++ b/spi.tasklist/src/org/netbeans/spi/tasklist/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/src/org/netbeans/spi/tasklist/TaskScanningScope.java
+++ b/spi.tasklist/src/org/netbeans/spi/tasklist/TaskScanningScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/EmptyScanningScopeTest.java
+++ b/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/EmptyScanningScopeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/IDEInitializer.java
+++ b/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/IDEInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/TaskGroupFactoryTest.java
+++ b/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/TaskGroupFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/TaskGroupTest.java
+++ b/spi.tasklist/test/unit/src/org/netbeans/modules/tasklist/trampoline/TaskGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/test/unit/src/org/netbeans/spi/tasklist/IDEInitializer.java
+++ b/spi.tasklist/test/unit/src/org/netbeans/spi/tasklist/IDEInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/test/unit/src/org/netbeans/spi/tasklist/ScannerCallbackTest.java
+++ b/spi.tasklist/test/unit/src/org/netbeans/spi/tasklist/ScannerCallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.tasklist/test/unit/src/org/netbeans/spi/tasklist/TaskTest.java
+++ b/spi.tasklist/test/unit/src/org/netbeans/spi/tasklist/TaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/examples/TreeModelExample1.java
+++ b/spi.viewmodel/examples/TreeModelExample1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/examples/TreeModelExample2.java
+++ b/spi.viewmodel/examples/TreeModelExample2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/examples/TreeModelExample3.java
+++ b/spi.viewmodel/examples/TreeModelExample3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/examples/TreeModelExample4.java
+++ b/spi.viewmodel/examples/TreeModelExample4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/AsynchronousModel.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/AsynchronousModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/Column.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/Column.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/DefaultColumn.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/DefaultColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/DefaultTreeExpansionManager.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/DefaultTreeExpansionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/DelegatingCellEditor.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/DelegatingCellEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/DelegatingCellRenderer.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/DelegatingCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/ExceptionNode.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/ExceptionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/HyperColumnModel.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/HyperColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/HyperCompoundModel.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/HyperCompoundModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/ModelRootChangeListener.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/ModelRootChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/OutlineTable.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/OutlineTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelHyperNode.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelHyperNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelNode.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelRoot.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/AsynchronousModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/AsynchronousModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/CachedChildrenTreeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/CachedChildrenTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/CheckNodeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/CheckNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/CheckNodeModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/CheckNodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/ColumnModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/ColumnModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/DnDNodeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/DnDNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/DnDNodeModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/DnDNodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/ExtendedNodeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/ExtendedNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/ExtendedNodeModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/ExtendedNodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/Model.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/ModelEvent.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/ModelEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/ModelListener.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/ModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/Models.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/Models.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeActionsProvider.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeActionsProviderFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeActionsProviderFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/NodeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/ReorderableTreeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/ReorderableTreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/ReorderableTreeModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/ReorderableTreeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/SuperNodeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/SuperNodeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableHTMLModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableHTMLModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableHTMLModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableHTMLModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TablePropertyEditorsModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TablePropertyEditorsModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TablePropertyEditorsModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TablePropertyEditorsModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableRendererModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableRendererModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableRendererModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TableRendererModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeExpansionModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeExpansionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeExpansionModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeExpansionModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeModel.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeModelFilter.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/TreeModelFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/src/org/netbeans/spi/viewmodel/UnknownTypeException.java
+++ b/spi.viewmodel/src/org/netbeans/spi/viewmodel/UnknownTypeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/AsynchronousTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/AsynchronousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/BasicTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/CachedChildrenTreeModelTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/CachedChildrenTreeModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/CountedModel.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/CountedModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/HyperModelSingleAccessTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/HyperModelSingleAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/ModelEventTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/ModelEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/MultiFiringTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/MultiFiringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/ReorderableTreeModelTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/ReorderableTreeModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/TableRendererTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/TableRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/YardaTest.java
+++ b/spi.viewmodel/test/unit/src/org/netbeans/modules/viewmodel/YardaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/Action.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/SpringUtilities.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/SpringUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/ConfigFileGroup.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/ConfigFileGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/ConfigFileManager.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/ConfigFileManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringAnnotations.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringConstants.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringScope.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/AbstractModelImplementation.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/AbstractModelImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/FileSpringBeans.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/FileSpringBeans.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/Location.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/Location.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/ModelUnit.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/ModelUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringBean.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringBeanProperty.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringBeanProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringBeans.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringBeans.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringConfigModel.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringConfigModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringMetaModelSupport.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringMetaModelSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringModel.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringModelFactory.java
+++ b/spring.beans/src/org/netbeans/modules/spring/api/beans/model/SpringModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/BeansAttributes.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/BeansAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/BeansElements.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/BeansElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ConfigFileManagerAccessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ConfigFileManagerAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ConfigFileManagerImplementation.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ConfigFileManagerImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ProjectConfigFileManagerImpl.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ProjectConfigFileManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ProjectSpringScopeProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ProjectSpringScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/RecommendedTemplatesImpl.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/RecommendedTemplatesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/SpringConfigFileLocationProviderImpl.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/SpringConfigFileLocationProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/SpringConfigModelAccessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/SpringConfigModelAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/SpringScopeAccessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/SpringScopeAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/catalog/SpringCatalog.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/catalog/SpringCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletionContext.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/Completor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/Completor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletorFactory.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletorRegistry.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletorUtils.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/LazyTypeCompletionItem.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/LazyTypeCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/OpenTagCompletionProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/OpenTagCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/OptionCodeCompletionSettings.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/OptionCodeCompletionSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringCompletionResult.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringCompletionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionDoc.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionDoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionItem.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/AttributeValueCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/AttributeValueCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/AttributeValueCompletorFactory.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/AttributeValueCompletorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeanDependsOnCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeanDependsOnCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeanIdCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeanIdCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeansRefCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeansRefCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeansRefCompletorFactory.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/BeansRefCompletorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/FactoryMethodCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/FactoryMethodCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/GenericCompletorFactory.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/GenericCompletorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/InitDestroyMethodCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/InitDestroyMethodCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/JavaClassCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/JavaClassCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/JavaMethodCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/JavaMethodCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/JavaPackageCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/JavaPackageCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/PNamespaceBeanRefCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/PNamespaceBeanRefCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/PNamespaceCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/PNamespaceCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/PropertyCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/PropertyCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/ResourceCompletor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/completion/completors/ResourceCompletor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/editor/BeanClassFinder.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/editor/BeanClassFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/editor/ContextUtilities.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/editor/ContextUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/editor/DocumentContext.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/editor/DocumentContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/editor/SpringXMLConfigEditorUtils.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/editor/SpringXMLConfigEditorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/BeansRefHyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/BeansRefHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/FactoryMethodHyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/FactoryMethodHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/HyperlinkEnv.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/HyperlinkEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/HyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/HyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/JavaClassHyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/JavaClassHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/JavaMethodHyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/JavaMethodHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/PHyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/PHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/PropertyHyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/PropertyHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/ResourceHyperlinkProcessor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/ResourceHyperlinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/SpringXMLConfigHyperlinkProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/hyperlink/SpringXMLConfigHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/index/SpringBinaryIndexer.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/index/SpringBinaryIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/index/SpringIndex.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/index/SpringIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/AbstractBeanTypeDescriptor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/AbstractBeanTypeDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/BeanAliasTypeDescriptor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/BeanAliasTypeDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/BeanTypeDescriptor.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/BeanTypeDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/GoToBeanAction.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/GoToBeanAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/SpringBeansTypeProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/jumpto/SpringBeansTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataLoader.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataLoaderBeanInfo.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataNode.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataObject.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/loader/SpringXMLConfigDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/ConfigModelSpringBeans.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/ConfigModelSpringBeans.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/ExclusiveAccess.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/ExclusiveAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringBeanSource.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringBeanSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringConfigFileModelController.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringConfigFileModelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringConfigFileModelManager.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringConfigFileModelManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringConfigModelController.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/SpringConfigModelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileLocation.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBean.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBeanProperty.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBeanProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBeanSource.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBeanSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ObjectProviders.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/ObjectProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/Refreshable.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/Refreshable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringAnnotatedBeanLocation.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringAnnotatedBeanLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringBeanImpl.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringBeanImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringModelImplementation.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringModelImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringModelProviderFactoryImpl.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringModelProviderFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringModelProviderImpl.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/model/impl/SpringModelProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/AttributeFinder.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/AttributeFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/AttributeValueFinder.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/AttributeValueFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/JavaElementRefFinder.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/JavaElementRefFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Occurrences.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Occurrences.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/PropertyChildFinder.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/PropertyChildFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/PropertyRefFinder.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/PropertyRefFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/SpringRefactoringElement.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/SpringRefactoringElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/SpringRefactorings.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/SpringRefactorings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringBeansRefactoringPluginFactory.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringBeansRefactoringPluginFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringFindUsagesPlugin.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringFindUsagesPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringMovePlugin.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringMovePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringRenamePlugin.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/plugins/SpringRenamePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/ConfigFilesUIs.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/ConfigFilesUIs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/CustomizerCategoryProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/CustomizerCategoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/SelectConfigFilesPanel.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/SelectConfigFilesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/SpringCustomizerPanel.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/ui/customizer/SpringCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/utils/ElementSeekerTask.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/utils/ElementSeekerTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/utils/StringUtils.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/utils/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/wizards/NewSpringXMLConfigWizardIterator.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/wizards/NewSpringXMLConfigWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigGroupPanel.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigGroupPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigGroupVisual.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigGroupVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigNamespacesPanel.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigNamespacesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigNamespacesVisual.java
+++ b/spring.beans/src/org/netbeans/modules/spring/beans/wizards/SpringXMLConfigNamespacesVisual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/FieldNamesCalculator.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/FieldNamesCalculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/JavaUtils.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/JavaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/MatchType.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/MatchType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/Property.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/Property.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/PropertyFinder.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/PropertyFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/PropertyType.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/PropertyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/Public.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/Public.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/java/Static.java
+++ b/spring.beans/src/org/netbeans/modules/spring/java/Static.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringConfigFileLocationProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringConfigFileLocationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringConfigFileProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringConfigFileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringModelProvider.java
+++ b/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringModelProviderFactory.java
+++ b/spring.beans/src/org/netbeans/modules/spring/spi/beans/SpringModelProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/util/ConfigFiles.java
+++ b/spring.beans/src/org/netbeans/modules/spring/util/ConfigFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/util/SpringBeansUIs.java
+++ b/spring.beans/src/org/netbeans/modules/spring/util/SpringBeansUIs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/util/fcs/FileChangeSupport.java
+++ b/spring.beans/src/org/netbeans/modules/spring/util/fcs/FileChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/util/fcs/FileChangeSupportEvent.java
+++ b/spring.beans/src/org/netbeans/modules/spring/util/fcs/FileChangeSupportEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/src/org/netbeans/modules/spring/util/fcs/FileChangeSupportListener.java
+++ b/spring.beans/src/org/netbeans/modules/spring/util/fcs/FileChangeSupportListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/DefaultConfigFileManagerImpl.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/DefaultConfigFileManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/SpringScopeTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/SpringScopeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/CommonAnnotationTestCase.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/CommonAnnotationTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/ModelUnitTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/ModelUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/SpringConfigModelTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/SpringConfigModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/SpringModelAnnotationsTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/SpringModelAnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/SpringModelFactoryTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/api/beans/model/SpringModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/ConfigFileTestCase.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/ConfigFileTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/TestUtils.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/completion/CompletionContextTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/completion/CompletionContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/hyperlink/SpringXMLConfigHyperlinkProviderTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/hyperlink/SpringXMLConfigHyperlinkProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/model/ConfigModelSpringBeansTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/model/ConfigModelSpringBeansTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/model/SpringConfigFileModelControllerTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/model/SpringConfigFileModelControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBeanSourceTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/model/impl/ConfigFileSpringBeanSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/AttributeFinderTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/AttributeFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/AttributeValueFinderTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/AttributeValueFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/JavaElementRefFinderTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/JavaElementRefFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/PropertyChildFinderTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/refactoring/PropertyChildFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/utils/StringUtilsTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/utils/StringUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/spring.beans/test/unit/src/org/netbeans/modules/spring/java/FieldNamesCalculatorTest.java
+++ b/spring.beans/test/unit/src/org/netbeans/modules/spring/java/FieldNamesCalculatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/Annotator.java
+++ b/subversion/src/org/netbeans/modules/subversion/Annotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/DiskMapTurboProvider.java
+++ b/subversion/src/org/netbeans/modules/subversion/DiskMapTurboProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/FileInformation.java
+++ b/subversion/src/org/netbeans/modules/subversion/FileInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/FileStatusCache.java
+++ b/subversion/src/org/netbeans/modules/subversion/FileStatusCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/FileStatusProvider.java
+++ b/subversion/src/org/netbeans/modules/subversion/FileStatusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/FilesystemHandler.java
+++ b/subversion/src/org/netbeans/modules/subversion/FilesystemHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/HistoryProvider.java
+++ b/subversion/src/org/netbeans/modules/subversion/HistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ModuleLifecycleManager.java
+++ b/subversion/src/org/netbeans/modules/subversion/ModuleLifecycleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/OutputLogger.java
+++ b/subversion/src/org/netbeans/modules/subversion/OutputLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/RepositoryFile.java
+++ b/subversion/src/org/netbeans/modules/subversion/RepositoryFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/Subversion.java
+++ b/subversion/src/org/netbeans/modules/subversion/Subversion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/SubversionVCS.java
+++ b/subversion/src/org/netbeans/modules/subversion/SubversionVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/SubversionVisibilityQuery.java
+++ b/subversion/src/org/netbeans/modules/subversion/SubversionVisibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/SvnFileNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/SvnFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/SvnMetadataFolderLoader.java
+++ b/subversion/src/org/netbeans/modules/subversion/SvnMetadataFolderLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/SvnModuleConfig.java
+++ b/subversion/src/org/netbeans/modules/subversion/SvnModuleConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/VersionsCache.java
+++ b/subversion/src/org/netbeans/modules/subversion/VersionsCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/WorkingCopyAttributesCache.java
+++ b/subversion/src/org/netbeans/modules/subversion/WorkingCopyAttributesCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/api/Subversion.java
+++ b/subversion/src/org/netbeans/modules/subversion/api/Subversion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/AcceptCertificatePanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/AcceptCertificatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/CommandReport.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/CommandReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/JhlClientCallback.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/JhlClientCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/MissingClient.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/MissingClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/MissingClientPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/MissingClientPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/PanelProgressSupport.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/PanelProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/PropertiesClient.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/PropertiesClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClient.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClientCallback.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClientCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClientDescriptor.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClientDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClientExceptionHandler.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClientExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClientFactory.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClientFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandler.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClientRefreshHandler.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClientRefreshHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnKitClientCallback.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnKitClientCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnProgressSupport.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/WizardStepProgressSupport.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/WizardStepProgressSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/CLIStatus.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/CLIStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/CommandNotificationListener.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/CommandNotificationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/Commandline.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/Commandline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/CommandlineClient.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/CommandlineClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/Parser.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/SvnCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/SvnCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/AddCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/AddCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/BlameCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/BlameCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CatCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CatCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CheckoutCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CheckoutCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CleanupCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CleanupCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CommitCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CommitCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CopyCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/CopyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ExportCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ExportCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ImportCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ImportCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/InfoCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/InfoCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ListCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ListCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ListPropertiesCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ListPropertiesCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/LogCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/LogCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/MergeCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/MergeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/MkdirCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/MkdirCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/MoveCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/MoveCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/PropertyDelCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/PropertyDelCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/PropertyGetCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/PropertyGetCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/PropertySetCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/PropertySetCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/RelocateCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/RelocateCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/RemoveCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/RemoveCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ResolvedCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/ResolvedCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/RevertCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/RevertCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/StatusCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/StatusCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/SwitchToCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/SwitchToCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/UpdateCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/UpdateCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/UpgradeCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/UpgradeCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/ConflictDescriptionParser.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/ConflictDescriptionParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/EntriesCache.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/EntriesCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/LocalSubversionException.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/LocalSubversionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/ParserSvnInfo.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/ParserSvnInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/ParserSvnStatus.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/ParserSvnStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/SvnWcParser.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/SvnWcParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/SvnWcUtils.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/SvnWcUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/client/parser/WorkingCopyDetails.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/parser/WorkingCopyDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/config/CertificateFile.java
+++ b/subversion/src/org/netbeans/modules/subversion/config/CertificateFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/config/KVFile.java
+++ b/subversion/src/org/netbeans/modules/subversion/config/KVFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/config/PasswordFile.java
+++ b/subversion/src/org/netbeans/modules/subversion/config/PasswordFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/config/SVNCredentialFile.java
+++ b/subversion/src/org/netbeans/modules/subversion/config/SVNCredentialFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/config/Scrambler.java
+++ b/subversion/src/org/netbeans/modules/subversion/config/Scrambler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/config/SvnConfigFiles.java
+++ b/subversion/src/org/netbeans/modules/subversion/config/SvnConfigFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/kenai/KenaiNotificationListener.java
+++ b/subversion/src/org/netbeans/modules/subversion/kenai/KenaiNotificationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/kenai/SvnKenaiAccessor.java
+++ b/subversion/src/org/netbeans/modules/subversion/kenai/SvnKenaiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/notifications/NotificationsManager.java
+++ b/subversion/src/org/netbeans/modules/subversion/notifications/NotificationsManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/AnnotationColorProvider.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/AnnotationColorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/AnnotationExpression.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/AnnotationExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/AnnotationSettings.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/AnnotationSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/AnnotationSettingsPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/AnnotationSettingsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/EditAnnotationPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/EditAnnotationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/LabelsPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/LabelsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/SvnOptions.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/SvnOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/actions/AbstractAllAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/actions/AbstractAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/actions/ActionUtils.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/actions/ActionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/actions/ContextAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/actions/ContextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotateLine.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotateLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationBar.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationBarManager.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationBarManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationMark.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationMarkInstaller.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationMarkInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationMarkProvider.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/AnnotationMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/BlameAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/BlameAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/LinesReader.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/LinesReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/blame/TooltipWindow.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/blame/TooltipWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/Browser.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/Browser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/BrowserAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/BrowserAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/BrowserClient.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/BrowserClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/BrowserPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/BrowserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/ControlPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/ControlPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/CreateFolderAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/CreateFolderAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/RepositoryPathNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/RepositoryPathNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/RepositoryPaths.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/RepositoryPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/SelectPathAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/SelectPathAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/browser/WaitNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/browser/WaitNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/checkout/CheckoutAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/checkout/CheckoutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitOptions.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitTable.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitTableModel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/ConflictResolvedAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/ConflictResolvedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/DeleteLocalAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/DeleteLocalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/commit/ExcludeFromCommitAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/commit/ExcludeFromCommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/BranchPicker.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/BranchPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/BranchPickerPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/BranchPickerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/CopyDialog.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/CopyDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/CreateCopy.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/CreateCopy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/CreateCopyAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/CreateCopyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/CreateCopyPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/CreateCopyPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/Merge.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/Merge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeBranchPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeBranchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeOneFolderPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeOneFolderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/MergePanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/MergePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeSinceOriginPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeSinceOriginPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeTwoFoldersPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/MergeTwoFoldersPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/OneFolderPreviewPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/OneFolderPreviewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/ReintegrateBranchPreviewPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/ReintegrateBranchPreviewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/SinceOriginPreviewPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/SinceOriginPreviewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/SwitchTo.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/SwitchTo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/SwitchToAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/SwitchToAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/SwitchToPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/SwitchToPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/copy/TwoFoldersPreviewPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/copy/TwoFoldersPreviewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffFileTable.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffFileTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffSetupSource.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffSetupSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffStreamSource.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffStreamSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffToAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffToAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffTopComponent.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/DiffTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/ExportDiffAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/ExportDiffAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/MultiDiffPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/MultiDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/RevisionSetupsSupport.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/RevisionSetupsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/SelectDiffTree.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/SelectDiffTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/SelectDiffTreePanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/SelectDiffTreePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/diff/Setup.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/diff/Setup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/export/Export.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/export/Export.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/export/ExportAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/export/ExportAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/export/ExportPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/export/ExportPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/DiffResultsView.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/DiffResultsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/DiffResultsViewForLine.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/DiffResultsViewForLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/DiffStreamSource.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/DiffStreamSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/DiffTreeTable.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/DiffTreeTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/RepositoryRevision.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/RepositoryRevision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/RevisionNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/RevisionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/RevisionNodeChildren.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/RevisionNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/SearchCriteriaPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/SearchCriteriaPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/SearchExecutor.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/SearchExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryTopComponent.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/history/SummaryView.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/history/SummaryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/ignore/IgnoreAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/ignore/IgnoreAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/lock/LockAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/lock/LockAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/lock/LockPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/lock/LockPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/lock/LockParams.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/lock/LockParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/lock/UnlockAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/lock/UnlockAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/menu/CopyMenu.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/menu/CopyMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/menu/DiffMenu.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/menu/DiffMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/menu/DynamicMenu.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/menu/DynamicMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/menu/IgnoreMenu.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/menu/IgnoreMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/menu/PatchesMenu.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/menu/PatchesMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/menu/UpdateMenu.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/menu/UpdateMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/menu/WorkingCopyMenu.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/menu/WorkingCopyMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/project/ImportAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/project/ImportAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/properties/PropertiesPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/properties/PropertiesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/properties/PropertiesTable.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/properties/PropertiesTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/properties/PropertiesTableModel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/properties/PropertiesTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnProperties.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnPropertiesAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnPropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnPropertiesNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnPropertiesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/properties/VersioningInfoAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/properties/VersioningInfoAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/relocate/RelocateAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/relocate/RelocateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/relocate/RelocatePanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/relocate/RelocatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/ConnectionType.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/ConnectionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/HttpPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/HttpPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/Repository.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/Repository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/RepositoryConnection.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/RepositoryConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/RepositoryDialogPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/RepositoryDialogPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/RepositoryPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/RepositoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/SvnSSHCliPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/SvnSSHCliPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/repository/SvnSSHSvnKitPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/repository/SvnSSHSvnKitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/search/SvnSearch.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/search/SvnSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/search/SvnSearchPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/search/SvnSearchPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/search/SvnSearchView.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/search/SvnSearchView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/shelve/ShelveChangesAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/shelve/ShelveChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/OpenInEditorAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/OpenInEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/OpenVersioningAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/OpenVersioningAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/ShowAllChangesAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/ShowAllChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/StatusAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/StatusAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/SvnVersioningTopComponent.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/SvnVersioningTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/SyncFileNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/SyncFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/SyncTable.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/SyncTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/status/VersioningPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/status/VersioningPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/FileUpdateInfo.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/FileUpdateInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/ResolveConflictsAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/ResolveConflictsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/ResolveConflictsExecutor.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/ResolveConflictsExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/RevertModifications.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/RevertModifications.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/RevertModificationsAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/RevertModificationsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/RevertModificationsPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/RevertModificationsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateResultNode.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateResultNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateResults.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateResultsTable.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateResultsTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateTo.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateTo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateToAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateToAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateToPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateToPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateWithDependenciesAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/update/UpdateWithDependenciesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wcadmin/CleanupAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wcadmin/CleanupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wcadmin/UpgradeAction.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wcadmin/UpgradeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/AbstractStep.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/AbstractStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/CheckoutWizard.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/CheckoutWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/ImportWizard.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/ImportWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/URLPatternWizard.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/URLPatternWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/checkoutstep/CheckoutPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/checkoutstep/CheckoutPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/checkoutstep/CheckoutStep.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/checkoutstep/CheckoutStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/ImportPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/ImportPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/ImportPreviewStep.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/ImportPreviewStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/ImportStep.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/ImportStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/PreviewPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/importstep/PreviewPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/repositorystep/RepositoryStep.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/repositorystep/RepositoryStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/repositorystep/RepositoryStepPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/repositorystep/RepositoryStepPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/urlpatternstep/URLPatternPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/urlpatternstep/URLPatternPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/ui/wizards/urlpatternstep/URLPatternStep.java
+++ b/subversion/src/org/netbeans/modules/subversion/ui/wizards/urlpatternstep/URLPatternStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/util/CheckoutCompleted.java
+++ b/subversion/src/org/netbeans/modules/subversion/util/CheckoutCompleted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/util/ClientCheckSupport.java
+++ b/subversion/src/org/netbeans/modules/subversion/util/ClientCheckSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/util/Context.java
+++ b/subversion/src/org/netbeans/modules/subversion/util/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/util/NotifyHtmlPanel.java
+++ b/subversion/src/org/netbeans/modules/subversion/util/NotifyHtmlPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/util/SvnSearchHistorySupport.java
+++ b/subversion/src/org/netbeans/modules/subversion/util/SvnSearchHistorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/src/org/netbeans/modules/subversion/util/SvnUtils.java
+++ b/subversion/src/org/netbeans/modules/subversion/util/SvnUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/SubversionStableTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/SubversionStableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/archeology/AnnotationsTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/archeology/AnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/archeology/SearchHistoryUITest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/archeology/SearchHistoryUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/archeology/SearchRevisionsTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/archeology/SearchRevisionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/CopyTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/CopyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/CopyUiTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/CopyUiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/MergeUiTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/MergeUiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/RevertUiTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/RevertUiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/SwitchUiTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/branches/SwitchUiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/CheckoutContentTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/CheckoutContentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/CheckoutUITest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/CheckoutUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/CreateProjectVersionedDirTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/CreateProjectVersionedDirTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/ImportUITest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/ImportUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/ProxySettingsUITest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/checkout/ProxySettingsUITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/commit/CommitDataTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/commit/CommitDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/commit/CommitUiTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/commit/CommitUiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/commit/IgnoreTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/commit/IgnoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/DeleteTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/DeleteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/FilesViewDoubleRefTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/FilesViewDoubleRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/FilesViewRefTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/FilesViewRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/RefactoringTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/delete/RefactoringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/diff/DiffTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/diff/DiffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/diff/ExportDiffPatchTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/diff/ExportDiffPatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/properties/SvnPropertiesTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/properties/SvnPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/relocate/RelocateTest.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/main/relocate/RelocateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CheckoutWizardOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CheckoutWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CommitOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CommitOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CommitStepOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CommitStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CopyToOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CopyToOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CreateNewFolderOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/CreateNewFolderOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/DiffOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/DiffOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/FolderToImportStepOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/FolderToImportStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/ImportWizardOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/ImportWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeOneRepoOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeOneRepoOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeOriginOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeOriginOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeTwoRepoOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/MergeTwoRepoOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/NewJavaFileNameLocationStepOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/NewJavaFileNameLocationStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/NewJavaProjectNameLocationStepOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/NewJavaProjectNameLocationStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/ProxyConfigurationOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/ProxyConfigurationOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RefactoringOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RefactoringOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RelocateOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RelocateOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryBrowserImpOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryBrowserImpOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryBrowserOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryBrowserOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryBrowserSearchHistoryOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryBrowserSearchHistoryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryStepOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RepositoryStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RevertModificationsOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/RevertModificationsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SearchHistoryOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SearchHistoryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SearchRevisionsOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SearchRevisionsOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SourcePackagesNode.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SourcePackagesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SvnPropertiesOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SvnPropertiesOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SwitchOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/SwitchOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/VersioningOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/VersioningOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/WorkDirStepOperator.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/WorkDirStepOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/CheckoutAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/CheckoutAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/CommitAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/CommitAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/CopyAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/CopyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/ImportAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/ImportAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/MergeAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/MergeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/RefactoringAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/RefactoringAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/RelocateAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/RelocateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/RevertAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/RevertAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SearchHistoryAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SearchHistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SvnAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SvnAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SvnPropertiesAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SvnPropertiesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SwitchAction.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/operators/actions/SwitchAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/RelocateTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/RelocateTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/archeologyTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/archeologyTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/branchesTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/branchesTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/checkoutTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/checkoutTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/commitTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/commitTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/deleteTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/deleteTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/diffTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/diffTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/svnPropertiesTestSuite.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/testsuites/svnPropertiesTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/MessageHandler.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/MessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/RepositoryMaintenance.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/RepositoryMaintenance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/StreamHandler.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/StreamHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/TestKit.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/TestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/svnExistsChecker.java
+++ b/subversion/test/qa-functional/src/org/netbeans/test/subversion/utils/svnExistsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/AbstractSvnTestCase.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/AbstractSvnTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/ApiTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/ApiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/InteceptorTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/InteceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/MissingBeforeDeleteTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/MissingBeforeDeleteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/SvnFileSystemTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/SvnFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/SvnFileSystemTestStat.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/SvnFileSystemTestStat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/TestAnnotationProvider.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/TestAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/TestKit.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/TestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/VersionsCacheTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/VersionsCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/api/SearchHistoryTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/api/SearchHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/AbstractCommandTestCase.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/AbstractCommandTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/AvailabilityTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/AvailabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/CLIClientTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/CLIClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/ClientSwitchTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/ClientSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/JhlClientTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/JhlClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandlerTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/SvnKitClientTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/SvnKitClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/AddTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/AddTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/BlameTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/BlameTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CancelTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CancelTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CatTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CatTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CheckoutTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CheckoutTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CommitTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CommitTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CopyTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/CopyTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/DifferentWorkingDirsTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/DifferentWorkingDirsTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ImportTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ImportTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/InfoTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/InfoTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ListTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ListTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/LogTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/LogTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/MergeTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/MergeTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/MkdirTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/MkdirTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/MoveTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/MoveTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ParsedStatusTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ParsedStatusTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/PropertyTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/PropertyTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/RelocateTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/RelocateTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/RemoveTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/RemoveTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ResolvedTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/ResolvedTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/RevertTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/RevertTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/StatusTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/StatusTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/SwitchToTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/SwitchToTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/TreeConflictsTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/TreeConflictsTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/UpdateTestHidden.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/UpdateTestHidden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/parser/ConflictDescriptionParserTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/parser/ConflictDescriptionParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/parser/SvnWcParserTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/parser/SvnWcParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/config/SvnConfigFilesTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/config/SvnConfigFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/ui/copy/CopyDialogTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/ui/copy/CopyDialogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/ui/diff/RevisionSetupSupportTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/ui/diff/RevisionSetupSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/util/SvnUtilsTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/util/SvnUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/utils/TestUtilities.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/utils/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/swing.validation/src/org/netbeans/api/validation/adapters/DialogBuilder.java
+++ b/swing.validation/src/org/netbeans/api/validation/adapters/DialogBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/swing.validation/src/org/netbeans/api/validation/adapters/DialogDescriptorAdapter.java
+++ b/swing.validation/src/org/netbeans/api/validation/adapters/DialogDescriptorAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/swing.validation/src/org/netbeans/api/validation/adapters/NotificationLineSupportAdapter.java
+++ b/swing.validation/src/org/netbeans/api/validation/adapters/NotificationLineSupportAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/swing.validation/src/org/netbeans/api/validation/adapters/WizardDescriptorAdapter.java
+++ b/swing.validation/src/org/netbeans/api/validation/adapters/WizardDescriptorAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
+++ b/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/target.iterator/src/org/netbeans/modules/target/iterator/api/TargetChooserPanel.java
+++ b/target.iterator/src/org/netbeans/modules/target/iterator/api/TargetChooserPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/target.iterator/src/org/netbeans/modules/target/iterator/api/TargetChooserPanelGUI.java
+++ b/target.iterator/src/org/netbeans/modules/target/iterator/api/TargetChooserPanelGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/target.iterator/src/org/netbeans/modules/target/iterator/spi/TargetPanelProvider.java
+++ b/target.iterator/src/org/netbeans/modules/target/iterator/spi/TargetPanelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/target.iterator/src/org/netbeans/modules/target/iterator/spi/TargetPanelUIManager.java
+++ b/target.iterator/src/org/netbeans/modules/target/iterator/spi/TargetPanelUIManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/EmptyIterator.java
+++ b/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/EmptyIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/FileObjectIterator.java
+++ b/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/FileObjectIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/MainProjectIterator.java
+++ b/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/MainProjectIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/MainProjectScanningScope.java
+++ b/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/MainProjectScanningScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/OpenedProjectsIterator.java
+++ b/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/OpenedProjectsIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/OpenedProjectsScanningScope.java
+++ b/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/OpenedProjectsScanningScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/Utils.java
+++ b/tasklist.projectint/src/org/netbeans/modules/tasklist/projectint/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/SourceCodeCommentParser.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/SourceCodeCommentParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/TodoTaskScanner.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/TodoTaskScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/CommentTags.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/CommentTags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ExtensionIdentifier.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ExtensionIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/FileIdentifier.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/FileIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/IdentifierPickerPanel.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/IdentifierPickerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/MimeIdentifier.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/MimeIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/Settings.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ToDoCustomizer.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ToDoCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ToDoOptionsController.java
+++ b/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ToDoOptionsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/test/unit/src/org/netbeans/modules/tasklist/todo/ToDoTest.java
+++ b/tasklist.todo/test/unit/src/org/netbeans/modules/tasklist/todo/ToDoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/test/unit/src/org/netbeans/modules/tasklist/todo/TopComponentRegistryMock.java
+++ b/tasklist.todo/test/unit/src/org/netbeans/modules/tasklist/todo/TopComponentRegistryMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.todo/test/unit/src/org/netbeans/modules/tasklist/todo/WindowManagerMock.java
+++ b/tasklist.todo/test/unit/src/org/netbeans/modules/tasklist/todo/WindowManagerMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/AppliedFilterCondition.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/AppliedFilterCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/ConditionPanel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/ConditionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterCondition.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterEditor.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterRepository.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterSubpanel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/FilterSubpanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/KeywordsFilter.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/KeywordsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/KeywordsPanel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/KeywordsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/OneOfFilterCondition.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/OneOfFilterCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/StringFilterCondition.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/StringFilterCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskFilter.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskGroupCondition.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskGroupCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskProperties.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskProperty.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TaskProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TypesFilter.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TypesFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TypesPanel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/TypesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/filter/Util.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/filter/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/Accessor.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/CurrentEditorScanningScope.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/CurrentEditorScanningScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/FileScanningWorker.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/FileScanningWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/Loader.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/Loader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/OpenTaskAction.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/OpenTaskAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScanMonitor.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScanMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScannerDescriptor.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScannerDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScannerList.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScannerList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScanningScopeList.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/ScanningScopeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskComparator.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskIndexer.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskIndexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskIndexerFactory.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskIndexerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskManagerImpl.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/CountStatusBar.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/CountStatusBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/FiltersMenuButton.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/FiltersMenuButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/FoldingTaskListModel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/FoldingTaskListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/MenuToggleButton.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/MenuToggleButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/ScopeButton.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/ScopeButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/ScopeStatusBar.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/ScopeStatusBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/Settings.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListModel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTable.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTableUI.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTableUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTopComponent.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/Util.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/AbstractCheckListModel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/AbstractCheckListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/CheckList.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/CheckList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/CheckListModel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/CheckListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/DefaultCheckListCellRenderer.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/DefaultCheckListCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/DefaultCheckListModel.java
+++ b/tasklist.ui/src/org/netbeans/modules/tasklist/ui/checklist/DefaultCheckListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/tasklist.ui/test/unit/src/org/netbeans/modules/tasklist/impl/TaskManagerImplTest.java
+++ b/tasklist.ui/test/unit/src/org/netbeans/modules/tasklist/impl/TaskManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/AttachmentPanel.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/AttachmentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/AttachmentsPanel.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/AttachmentsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/AutoupdatePanel.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/AutoupdatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/AutoupdateSupport.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/AutoupdateSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/CollapsibleSectionPanel.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/CollapsibleSectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/FileToRepoMappingStorage.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/FileToRepoMappingStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/FindTypesSupport.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/FindTypesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/HyperlinkSupport.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/HyperlinkSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/IssueSettingsStorage.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/IssueSettingsStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/JiraUpdater.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/JiraUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/LinkButton.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/LinkButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/ListValuePicker.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/ListValuePicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/NBBugzillaUtils.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/NBBugzillaUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/NoContentPanel.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/NoContentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/PatchUtils.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/PatchUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/SaveQueryPanel.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/SaveQueryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/SectionPanel.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/SectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/SimpleIssueFinder.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/SimpleIssueFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/StackTraceSupport.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/StackTraceSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/Support.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/Support.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/TextUtils.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/TextUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/TransparentSectionButton.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/TransparentSectionButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/UIUtils.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/UIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/UndoRedoSupport.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/UndoRedoSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/Util.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/bugtracking/commons/WebUrlHyperlinkSupport.java
+++ b/team.commons/src/org/netbeans/modules/bugtracking/commons/WebUrlHyperlinkSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/ColorManager.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/ColorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/LogUtils.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/LogUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/resources/package-info.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/resources/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/AbstractListUI.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/AbstractListUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/AsynchronousNode.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/AsynchronousNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/LeafNode.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/LeafNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/LinkButton.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/LinkButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/ListListener.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/ListListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/ListNode.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/ListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/ListRendererPanel.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/ListRendererPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/ProgressLabel.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/ProgressLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/RendererPanel.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/RendererPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/SelectionList.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/SelectionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeLabel.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeList.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListListener.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListModel.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListModelListener.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListNode.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListUI.java
+++ b/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/ide/spi/IDEProject.java
+++ b/team.commons/src/org/netbeans/modules/team/ide/spi/IDEProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/ide/spi/IDEServices.java
+++ b/team.commons/src/org/netbeans/modules/team/ide/spi/IDEServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/ide/spi/ProjectServices.java
+++ b/team.commons/src/org/netbeans/modules/team/ide/spi/ProjectServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/ide/spi/SettingsServices.java
+++ b/team.commons/src/org/netbeans/modules/team/ide/spi/SettingsServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/ide/spi/TeamDashboardComponentProvider.java
+++ b/team.commons/src/org/netbeans/modules/team/ide/spi/TeamDashboardComponentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/NBRepositoryProvider.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/NBRepositoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/OwnerInfo.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/OwnerInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/RepositoryUser.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/RepositoryUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/RepositoryUserRenderer.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/RepositoryUserRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/TeamAccessor.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/TeamAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/TeamAccessorUtils.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/TeamAccessorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/TeamBugtrackingConnector.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/TeamBugtrackingConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/src/org/netbeans/modules/team/spi/TeamProject.java
+++ b/team.commons/src/org/netbeans/modules/team/spi/TeamProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/AutoupdatePluginUCTestCase.java
+++ b/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/AutoupdatePluginUCTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/AutoupdateSupportTest.java
+++ b/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/AutoupdateSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/FindTypesSupportTest.java
+++ b/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/FindTypesSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/SimpleIssueFinderTest.java
+++ b/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/SimpleIssueFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/StackTraceSupportTest.java
+++ b/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/StackTraceSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/TextUtilsTest.java
+++ b/team.commons/test/unit/src/org/netbeans/modules/bugtracking/commons/TextUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.ide/src/org/netbeans/modules/team/ide/IDEServicesImpl.java
+++ b/team.ide/src/org/netbeans/modules/team/ide/IDEServicesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.ide/src/org/netbeans/modules/team/ide/PatchContextChooser.java
+++ b/team.ide/src/org/netbeans/modules/team/ide/PatchContextChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.ide/src/org/netbeans/modules/team/ide/ProjectServicesImpl.java
+++ b/team.ide/src/org/netbeans/modules/team/ide/ProjectServicesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/team.ide/src/org/netbeans/modules/team/ide/SettingsServicesImpl.java
+++ b/team.ide/src/org/netbeans/modules/team/ide/SettingsServicesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templates/src/org/netbeans/modules/templates/PropertiesProvider.java
+++ b/templates/src/org/netbeans/modules/templates/PropertiesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templates/src/org/netbeans/modules/templates/actions/TemplatesAction.java
+++ b/templates/src/org/netbeans/modules/templates/actions/TemplatesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templates/src/org/netbeans/modules/templates/ui/RenameTemplatePanel.java
+++ b/templates/src/org/netbeans/modules/templates/ui/RenameTemplatePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templates/src/org/netbeans/modules/templates/ui/TemplatesPanel.java
+++ b/templates/src/org/netbeans/modules/templates/ui/TemplatesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templates/test/unit/src/org/netbeans/modules/templates/PropertiesProviderTest.java
+++ b/templates/test/unit/src/org/netbeans/modules/templates/PropertiesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templates/test/unit/src/org/netbeans/modules/templates/ui/TemplatesPanelTest.java
+++ b/templates/test/unit/src/org/netbeans/modules/templates/ui/TemplatesPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/src/org/netbeans/modules/templatesui/AbstractWizard.java
+++ b/templatesui/src/org/netbeans/modules/templatesui/AbstractWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/src/org/netbeans/modules/templatesui/HTMLPanel.java
+++ b/templatesui/src/org/netbeans/modules/templatesui/HTMLPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/src/org/netbeans/modules/templatesui/HTMLWizard.java
+++ b/templatesui/src/org/netbeans/modules/templatesui/HTMLWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/ChooserPanelTest.java
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/ChooserPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/CompatibilityKitTest.java
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/CompatibilityKitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/HTMLJavaTemplateTest.java
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/HTMLJavaTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/HTMLTemplateTest.java
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/HTMLTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/RunTCK.java
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/RunTCK.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/datastep.js
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/datastep.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/manual.js
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/manual.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/validation.js
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/validation.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/templatesui/test/unit/src/org/netbeans/modules/templatesui/x.js
+++ b/templatesui/test/unit/src/org/netbeans/modules/templatesui/x.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOTerm.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOTermSupport.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOTermSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOTopComponent.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOVisibility.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOVisibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOVisibilityControl.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/api/ui/IOVisibilityControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/api/ui/TerminalContainer.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/api/ui/TerminalContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/iocontainer/TerminalContainerCommon.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/iocontainer/TerminalContainerCommon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/iocontainer/TerminalContainerMuxable.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/iocontainer/TerminalContainerMuxable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/iocontainer/TerminalContainerTabbed.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/iocontainer/TerminalContainerTabbed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Catalog.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Catalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Task.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/TerminalIOProvider.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/TerminalIOProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/TerminalInputOutput.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/TerminalInputOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/PinPanel.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/PinPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/TermAdvancedOption.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/TermAdvancedOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/TerminalPinnedTabOptions.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/TerminalPinnedTabOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/ActionFactory.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/ActionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/ClearAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/ClearAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/CloseAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/CloseAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/CopyAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/CopyAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/DumpSequencesAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/DumpSequencesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/FindAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/FindAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/LargerFontAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/LargerFontAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/NewTabAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/NewTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/PasteAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/PasteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/PinTabAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/PinTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SetTitleAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SetTitleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SmallerFontAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SmallerFontAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SwitchTabAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SwitchTabAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/TerminalAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/TerminalAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/WrapAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/WrapAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/spi/ui/ExternalCommandActionProvider.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/spi/ui/ExternalCommandActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/support/OpenInEditorAction.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/support/OpenInEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/src/org/netbeans/modules/terminal/support/TerminalPinSupport.java
+++ b/terminal.nb/src/org/netbeans/modules/terminal/support/TerminalPinSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T1_Close_Test.java
+++ b/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T1_Close_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T2_CloseVeto_Test.java
+++ b/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T2_CloseVeto_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T3_HardClose_Test.java
+++ b/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T3_HardClose_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T4_Attribute_Test.java
+++ b/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T4_Attribute_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T5_MTStress_Test.java
+++ b/terminal.nb/test/unit/src/org/netbeans/modules/terminal/T5_MTStress_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal.nb/test/unit/src/org/netbeans/modules/terminal/TestSupport.java
+++ b/terminal.nb/test/unit/src/org/netbeans/modules/terminal/TestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal/src/org/netbeans/modules/terminal/api/IOConnect.java
+++ b/terminal/src/org/netbeans/modules/terminal/api/IOConnect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal/src/org/netbeans/modules/terminal/api/IOEmulation.java
+++ b/terminal/src/org/netbeans/modules/terminal/api/IOEmulation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal/src/org/netbeans/modules/terminal/api/IONotifier.java
+++ b/terminal/src/org/netbeans/modules/terminal/api/IONotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal/src/org/netbeans/modules/terminal/api/IOResizable.java
+++ b/terminal/src/org/netbeans/modules/terminal/api/IOResizable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal/src/org/netbeans/modules/terminal/api/IOTerm.java
+++ b/terminal/src/org/netbeans/modules/terminal/api/IOTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/terminal/src/org/netbeans/modules/terminal/test/IOTest.java
+++ b/terminal/src/org/netbeans/modules/terminal/test/IOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/src/org/netbeans/modules/testng/ant/AntSessionInfo.java
+++ b/testng.ant/src/org/netbeans/modules/testng/ant/AntSessionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/src/org/netbeans/modules/testng/ant/AntTestNGSupport.java
+++ b/testng.ant/src/org/netbeans/modules/testng/ant/AntTestNGSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/src/org/netbeans/modules/testng/ant/RegexpUtils.java
+++ b/testng.ant/src/org/netbeans/modules/testng/ant/RegexpUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/src/org/netbeans/modules/testng/ant/TestNGAntLogger.java
+++ b/testng.ant/src/org/netbeans/modules/testng/ant/TestNGAntLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/src/org/netbeans/modules/testng/ant/TestNGExecutionManager.java
+++ b/testng.ant/src/org/netbeans/modules/testng/ant/TestNGExecutionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/src/org/netbeans/modules/testng/ant/TestNGOutputReader.java
+++ b/testng.ant/src/org/netbeans/modules/testng/ant/TestNGOutputReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/src/org/netbeans/modules/testng/ant/TestNGTestSession.java
+++ b/testng.ant/src/org/netbeans/modules/testng/ant/TestNGTestSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/test/unit/src/org/netbeans/modules/testng/ant/RegexpUtilsTest.java
+++ b/testng.ant/test/unit/src/org/netbeans/modules/testng/ant/RegexpUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/test/unit/src/org/netbeans/modules/testng/ant/TestNGOutputReaderTest.java
+++ b/testng.ant/test/unit/src/org/netbeans/modules/testng/ant/TestNGOutputReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ant/test/unit/src/org/netbeans/modules/testng/ant/impl/ProjectImpl.java
+++ b/testng.ant/test/unit/src/org/netbeans/modules/testng/ant/impl/ProjectImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.maven/src/org/netbeans/modules/testng/maven/MavenTestNGSupport.java
+++ b/testng.maven/src/org/netbeans/modules/testng/maven/MavenTestNGSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.maven/src/org/netbeans/modules/testng/maven/TestNGActionsProvider.java
+++ b/testng.maven/src/org/netbeans/modules/testng/maven/TestNGActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/CallstackFrameNode.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/CallstackFrameNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/JumpAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/JumpAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/TestMethodNodeAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/TestMethodNodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/TestNGManagerProvider.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/TestNGManagerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/TestNGMethodNode.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/TestNGMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/TestNGNodeOpener.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/TestNGNodeOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/TestNGSuiteNode.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/TestNGSuiteNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/TestNGTestNodeFactory.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/TestNGTestNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/XmlSuiteHandler.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/XmlSuiteHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/DebugSuiteAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/DebugSuiteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/DebugTestClassAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/DebugTestClassAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/DebugTestMethodAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/DebugTestMethodAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/RerunFailedTestsAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/RerunFailedTestsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/RunSuiteAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/RunSuiteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/RunTestMethodAction.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/RunTestMethodAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestClassInfoTask.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestClassInfoTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGActionProvider.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGMethodDebuggerProvider.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGMethodDebuggerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGMethodRunnerProvider.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGMethodRunnerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGTestCreatorProvider.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGTestCreatorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestSingleMethodSupport.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestSingleMethodSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/wizards/EmptyTestStepLocation.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/wizards/EmptyTestStepLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestSuiteWizardIterator.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestSuiteWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestWizardIterator.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGEntityResolver.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGEntityResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGSuiteDataObject.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGSuiteDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGSuiteHyperlingProvider.java
+++ b/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGSuiteHyperlingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/RetoucheTestBase.java
+++ b/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/RetoucheTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/RunTestMethodActionTest.java
+++ b/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/RunTestMethodActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/TestActionT.java
+++ b/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/TestActionT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/TestClassInfoTaskTest.java
+++ b/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/TestClassInfoTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/impl/ProjectImpl.java
+++ b/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/impl/ProjectImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/impl/TestNGImpl.java
+++ b/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/impl/TestNGImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/AbstractTestGenerator.java
+++ b/testng/src/org/netbeans/modules/testng/AbstractTestGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/ClassMap.java
+++ b/testng/src/org/netbeans/modules/testng/ClassMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/DefaultPlugin.java
+++ b/testng/src/org/netbeans/modules/testng/DefaultPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/GoToOppositeAction.java
+++ b/testng/src/org/netbeans/modules/testng/GoToOppositeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/ProgressIndicator.java
+++ b/testng/src/org/netbeans/modules/testng/ProgressIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestConfigAccessor.java
+++ b/testng/src/org/netbeans/modules/testng/TestConfigAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestCreator.java
+++ b/testng/src/org/netbeans/modules/testng/TestCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestGenerator.java
+++ b/testng/src/org/netbeans/modules/testng/TestGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestGeneratorSetup.java
+++ b/testng/src/org/netbeans/modules/testng/TestGeneratorSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestMethodNameGenerator.java
+++ b/testng/src/org/netbeans/modules/testng/TestMethodNameGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestNGPlugin.java
+++ b/testng/src/org/netbeans/modules/testng/TestNGPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestNGPluginTrampoline.java
+++ b/testng/src/org/netbeans/modules/testng/TestNGPluginTrampoline.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestNGSettings.java
+++ b/testng/src/org/netbeans/modules/testng/TestNGSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestUtil.java
+++ b/testng/src/org/netbeans/modules/testng/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestabilityJudge.java
+++ b/testng/src/org/netbeans/modules/testng/TestabilityJudge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TestabilityResult.java
+++ b/testng/src/org/netbeans/modules/testng/TestabilityResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TopClassFinder.java
+++ b/testng/src/org/netbeans/modules/testng/TopClassFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/TypeNameIdGenerator.java
+++ b/testng/src/org/netbeans/modules/testng/TypeNameIdGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/api/TestNGSupport.java
+++ b/testng/src/org/netbeans/modules/testng/api/TestNGSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/api/TestNGTest.java
+++ b/testng/src/org/netbeans/modules/testng/api/TestNGTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/api/TestNGTestSuite.java
+++ b/testng/src/org/netbeans/modules/testng/api/TestNGTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/api/TestNGTestcase.java
+++ b/testng/src/org/netbeans/modules/testng/api/TestNGTestcase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/api/TestNGUtils.java
+++ b/testng/src/org/netbeans/modules/testng/api/TestNGUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/api/XmlOutputParser.java
+++ b/testng/src/org/netbeans/modules/testng/api/XmlOutputParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/api/XmlResult.java
+++ b/testng/src/org/netbeans/modules/testng/api/XmlResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/spi/TestConfig.java
+++ b/testng/src/org/netbeans/modules/testng/spi/TestConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/spi/TestNGSupportImplementation.java
+++ b/testng/src/org/netbeans/modules/testng/spi/TestNGSupportImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/src/org/netbeans/modules/testng/spi/XMLSuiteSupport.java
+++ b/testng/src/org/netbeans/modules/testng/spi/XMLSuiteSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/data/projects/tngTestProject/src/tngtestproject/Main.java
+++ b/testng/test/unit/data/projects/tngTestProject/src/tngtestproject/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/data/projects/tngTestProject/test/test/CleanUpTest.java
+++ b/testng/test/unit/data/projects/tngTestProject/test/test/CleanUpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/data/projects/tngTestProject/test/test/FailPassSkipTest.java
+++ b/testng/test/unit/data/projects/tngTestProject/test/test/FailPassSkipTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/data/projects/tngTestProject/test/test/FailingTest.java
+++ b/testng/test/unit/data/projects/tngTestProject/test/test/FailingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/data/projects/tngTestProject/test/test/NewTestNGTest.java
+++ b/testng/test/unit/data/projects/tngTestProject/test/test/NewTestNGTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/data/projects/tngTestProject/test/test/PassSkipTest.java
+++ b/testng/test/unit/data/projects/tngTestProject/test/test/PassSkipTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/data/projects/tngTestProject/test/test/SetUpTest.java
+++ b/testng/test/unit/data/projects/tngTestProject/test/test/SetUpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/testng/test/unit/src/org/netbeans/modules/testng/api/XmlOutputParserTest.java
+++ b/testng/test/unit/src/org/netbeans/modules/testng/api/XmlOutputParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/src/org/netbeans/modules/timers/Install.java
+++ b/timers/src/org/netbeans/modules/timers/Install.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/src/org/netbeans/modules/timers/InstanceWatcher.java
+++ b/timers/src/org/netbeans/modules/timers/InstanceWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/src/org/netbeans/modules/timers/ObjectListRenderer.java
+++ b/timers/src/org/netbeans/modules/timers/ObjectListRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/src/org/netbeans/modules/timers/OpenTimeComponentAction.java
+++ b/timers/src/org/netbeans/modules/timers/OpenTimeComponentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/src/org/netbeans/modules/timers/TimeComponent.java
+++ b/timers/src/org/netbeans/modules/timers/TimeComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/src/org/netbeans/modules/timers/TimeComponentPanel.java
+++ b/timers/src/org/netbeans/modules/timers/TimeComponentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/src/org/netbeans/modules/timers/TimesCollectorPeer.java
+++ b/timers/src/org/netbeans/modules/timers/TimesCollectorPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/test/unit/src/org/netbeans/modules/timers/HandlerTest.java
+++ b/timers/test/unit/src/org/netbeans/modules/timers/HandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/test/unit/src/org/netbeans/modules/timers/InstanceWatcherTest.java
+++ b/timers/test/unit/src/org/netbeans/modules/timers/InstanceWatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/test/unit/src/org/netbeans/modules/timers/ObjectListRendererTest.java
+++ b/timers/test/unit/src/org/netbeans/modules/timers/ObjectListRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/timers/test/unit/src/org/netbeans/modules/timers/TimesCollectorPeerTest.java
+++ b/timers/test/unit/src/org/netbeans/modules/timers/TimesCollectorPeerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler.exceptionreporter/src/org/netbeans/modules/uihandler/exceptionreporter/Installer.java
+++ b/uihandler.exceptionreporter/src/org/netbeans/modules/uihandler/exceptionreporter/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/exceptions/ExceptionsSettings.java
+++ b/uihandler/src/org/netbeans/modules/exceptions/ExceptionsSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/exceptions/ReportPanel.java
+++ b/uihandler/src/org/netbeans/modules/exceptions/ReportPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/exceptions/ReporterResultTopComponent.java
+++ b/uihandler/src/org/netbeans/modules/exceptions/ReporterResultTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/AfterRestartExceptions.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/AfterRestartExceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/BuildInfo.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/BuildInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/ButtonsHTMLParser.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/ButtonsHTMLParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/CPUInfo.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/CPUInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/ConnectionErrorDlg.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/ConnectionErrorDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/DataConsistentFileOutputStream.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/DataConsistentFileOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/EarlyHandler.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/EarlyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/EnabledModulesCollector.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/EnabledModulesCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/Installer.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/MetricsHandler.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/MetricsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/ReminderPanel.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/ReminderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/ScreenSize.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/ScreenSize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/SelfSampleVFS.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/SelfSampleVFS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/SlownessData.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/SlownessData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/SlownessReporter.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/SlownessReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/SubmitPanel.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/SubmitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/TimeToFailure.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/TimeToFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/UIHandler.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/UIHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/UIHandlerClosing.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/UIHandlerClosing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/UINode.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/UINode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/VisualData.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/VisualData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/api/Activated.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/api/Activated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/api/Controller.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/api/Controller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/src/org/netbeans/modules/uihandler/api/Deactivated.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/api/Deactivated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/exceptions/ExceptionsSettingsTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/exceptions/ExceptionsSettingsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/ActivatedDeativatedTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/ActivatedDeativatedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/AutoSubmitTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/AutoSubmitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/BugTriggersTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/BugTriggersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/BuildInfoTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/BuildInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/ButtonsHTMLParserTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/ButtonsHTMLParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/ConnectionErrorDlgTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/ConnectionErrorDlgTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/EarlyHandlerTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/EarlyHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/EnabledModulesCollectorTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/EnabledModulesCollectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/EucJPReadPageTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/EucJPReadPageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/ExceptionsTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/ExceptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerInitTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerInitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerLittleTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerLittleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerReadPageTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerReadPageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/InstallerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/LogFileIsKeptAtSizeOf1000Test.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/LogFileIsKeptAtSizeOf1000Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/LogsTooEarlyTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/LogsTooEarlyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/LogsTooLateTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/LogsTooLateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/MemoryURL.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/MemoryURL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/ScreenSizeTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/ScreenSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/SelfSampleVFSTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/SelfSampleVFSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/ServerTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/ServerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/ShutdownFromAWTTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/ShutdownFromAWTTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/SlownessReporterTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/SlownessReporterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/TimeToFailureTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/TimeToFailureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/UIHandlerTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/UIHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/UIHandlerWhenInterruptedTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/UIHandlerWhenInterruptedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/UINodeTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/UINodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/UploadLogsTest.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/UploadLogsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/uihandler/test/unit/src/org/netbeans/modules/uihandler/WritablePreferences131128Test.java
+++ b/uihandler/test/unit/src/org/netbeans/modules/uihandler/WritablePreferences131128Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/src/org/netbeans/modules/updatecenters/resources/NetBeansClusterCreator.java
+++ b/updatecenters/src/org/netbeans/modules/updatecenters/resources/NetBeansClusterCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/src/org/netbeans/modules/updatecenters/resources/NetBeansKeyStoreProvider.java
+++ b/updatecenters/src/org/netbeans/modules/updatecenters/resources/NetBeansKeyStoreProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/test/unit/src/org/netbeans/updatecenters/CountsStruct.java
+++ b/updatecenters/test/unit/src/org/netbeans/updatecenters/CountsStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/test/unit/src/org/netbeans/updatecenters/OperationUtils.java
+++ b/updatecenters/test/unit/src/org/netbeans/updatecenters/OperationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/test/unit/src/org/netbeans/updatecenters/install/InstallTest.java
+++ b/updatecenters/test/unit/src/org/netbeans/updatecenters/install/InstallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/test/unit/src/org/netbeans/updatecenters/uninstall/UninstallTest.java
+++ b/updatecenters/test/unit/src/org/netbeans/updatecenters/uninstall/UninstallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/test/unit/src/org/netbeans/updatecenters/uninstall/ValidateUninstallTest.java
+++ b/updatecenters/test/unit/src/org/netbeans/updatecenters/uninstall/ValidateUninstallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/test/unit/src/org/netbeans/updatecenters/update/UpdateTest.java
+++ b/updatecenters/test/unit/src/org/netbeans/updatecenters/update/UpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/updatecenters/test/unit/src/org/netbeans/updatecenters/update/ValidateUpdateTest.java
+++ b/updatecenters/test/unit/src/org/netbeans/updatecenters/update/ValidateUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/colorpicker/ColorPicker.java
+++ b/usersguide/demosrc/examples/colorpicker/ColorPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/colorpicker/ColorPreview.java
+++ b/usersguide/demosrc/examples/colorpicker/ColorPreview.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/colorpicker/ColorPreviewBeanInfo.java
+++ b/usersguide/demosrc/examples/colorpicker/ColorPreviewBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/imageviewer/ImageFrame.java
+++ b/usersguide/demosrc/examples/imageviewer/ImageFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/imageviewer/ImageViewer.java
+++ b/usersguide/demosrc/examples/imageviewer/ImageViewer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/texteditor/About.java
+++ b/usersguide/demosrc/examples/texteditor/About.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/texteditor/Finder.java
+++ b/usersguide/demosrc/examples/texteditor/Finder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/usersguide/demosrc/examples/texteditor/Ted.java
+++ b/usersguide/demosrc/examples/texteditor/Ted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/AbstractProjectSearchScope.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/AbstractProjectSearchScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/ProjectOpenFileImpl.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/ProjectOpenFileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/ProjectSearchScopeDefinitionProvider.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/ProjectSearchScopeDefinitionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/SearchInfoHelper.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/SearchInfoHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/SearchScopeCurrentProject.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/SearchScopeCurrentProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/SearchScopeMainProject.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/SearchScopeMainProject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/SearchScopeNodeSelection.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/SearchScopeNodeSelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/SearchScopeOpenProjects.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/SearchScopeOpenProjects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/search/project/spi/CompatibilityUtils.java
+++ b/utilities.project/src/org/netbeans/modules/search/project/spi/CompatibilityUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/src/org/netbeans/modules/utilities/project/CopyPathToClipboardAction.java
+++ b/utilities.project/src/org/netbeans/modules/utilities/project/CopyPathToClipboardAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/test/unit/src/org/netbeans/modules/search/project/CompatibilityUtilsTest.java
+++ b/utilities.project/test/unit/src/org/netbeans/modules/search/project/CompatibilityUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/test/unit/src/org/netbeans/modules/search/project/OpenProjectCLITest.java
+++ b/utilities.project/test/unit/src/org/netbeans/modules/search/project/OpenProjectCLITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities.project/test/unit/src/org/netbeans/modules/utilities/project/CopyPathToClipboardActionTest.java
+++ b/utilities.project/test/unit/src/org/netbeans/modules/utilities/project/CopyPathToClipboardActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/DefaultExternalDropHandler.java
+++ b/utilities/src/org/netbeans/modules/openfile/DefaultExternalDropHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/DefaultOpenFileImpl.java
+++ b/utilities/src/org/netbeans/modules/openfile/DefaultOpenFileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/Handler.java
+++ b/utilities/src/org/netbeans/modules/openfile/Handler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/OpenFile.java
+++ b/utilities/src/org/netbeans/modules/openfile/OpenFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/OpenFileAction.java
+++ b/utilities/src/org/netbeans/modules/openfile/OpenFileAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/OpenFileDialogFilter.java
+++ b/utilities/src/org/netbeans/modules/openfile/OpenFileDialogFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/OpenFileImpl.java
+++ b/utilities/src/org/netbeans/modules/openfile/OpenFileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/PackagePanel.java
+++ b/utilities/src/org/netbeans/modules/openfile/PackagePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/RecentFileAction.java
+++ b/utilities/src/org/netbeans/modules/openfile/RecentFileAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/openfile/RecentFiles.java
+++ b/utilities/src/org/netbeans/modules/openfile/RecentFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/pdf/LinkProcessor.java
+++ b/utilities/src/org/netbeans/modules/pdf/LinkProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/pdf/PDFDataLoader.java
+++ b/utilities/src/org/netbeans/modules/pdf/PDFDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/pdf/PDFDataLoaderBeanInfo.java
+++ b/utilities/src/org/netbeans/modules/pdf/PDFDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/pdf/PDFDataNode.java
+++ b/utilities/src/org/netbeans/modules/pdf/PDFDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/pdf/PDFDataObject.java
+++ b/utilities/src/org/netbeans/modules/pdf/PDFDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/pdf/PDFOpenSupport.java
+++ b/utilities/src/org/netbeans/modules/pdf/PDFOpenSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/pdf/SetCommandForm.java
+++ b/utilities/src/org/netbeans/modules/pdf/SetCommandForm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/url/EncodingQueryImpl.java
+++ b/utilities/src/org/netbeans/modules/url/EncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/url/URLDataLoader.java
+++ b/utilities/src/org/netbeans/modules/url/URLDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/url/URLDataLoaderBeanInfo.java
+++ b/utilities/src/org/netbeans/modules/url/URLDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/url/URLDataObject.java
+++ b/utilities/src/org/netbeans/modules/url/URLDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/url/URLPresenter.java
+++ b/utilities/src/org/netbeans/modules/url/URLPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/src/org/netbeans/modules/utilities/Installer.java
+++ b/utilities/src/org/netbeans/modules/utilities/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/test/unit/src/org/netbeans/modules/openfile/DefaultExternalDropHandlerTest.java
+++ b/utilities/test/unit/src/org/netbeans/modules/openfile/DefaultExternalDropHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/test/unit/src/org/netbeans/modules/openfile/OpenCLITest.java
+++ b/utilities/test/unit/src/org/netbeans/modules/openfile/OpenCLITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/test/unit/src/org/netbeans/modules/openfile/RecentFilesTest.java
+++ b/utilities/test/unit/src/org/netbeans/modules/openfile/RecentFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/utilities/test/unit/src/org/netbeans/modules/url/URLDataObjectTest.java
+++ b/utilities/test/unit/src/org/netbeans/modules/url/URLDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/APIAccessor.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/APIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/Accessor.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/DelegatingVCS.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/DelegatingVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/FileProxyBasedVCSProvider.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/FileProxyBasedVCSProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/FlatFolder.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/FlatFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/NoVCSMenuItem.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/NoVCSMenuItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/ProjectMenuItem.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/ProjectMenuItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/SPIAccessor.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/SPIAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/ShowTextAnnotationsAction.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/ShowTextAnnotationsAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/Utils.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VCSRegistrationProcessor.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VCSRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VcsCollocationQueryImplementation.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VcsCollocationQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VcsVisibilityQueryImplementation.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VcsVisibilityQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VersioningAnnotationProvider.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VersioningAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VersioningConfig.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VersioningConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VersioningMainMenu.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VersioningMainMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VersioningManager.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VersioningManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/VersioningQueryImplementationImpl.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/VersioningQueryImplementationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/api/APIAccessorImpl.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/api/APIAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/api/VCSFileProxy.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/api/VCSFileProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/api/VersioningSupport.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/api/VersioningSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/filesystems/VCSFileProxyOperations.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/filesystems/VCSFileProxyOperations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/filesystems/VCSFilesystemInterceptor.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/filesystems/VCSFilesystemInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/SPIAccessorImpl.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/SPIAccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSAnnotator.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSContext.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSForbiddenFolderProvider.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSForbiddenFolderProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSHistoryProvider.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSHistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSInterceptor.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSVisibilityQuery.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSVisibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/spi/VersioningSystem.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/spi/VersioningSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/util/Utils.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/util/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/src/org/netbeans/modules/versioning/core/util/VCSSystemProvider.java
+++ b/versioning.core/src/org/netbeans/modules/versioning/core/util/VCSSystemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/qa-functional/src/org/netbeans/test/versioning/VersioningSystemTest.java
+++ b/versioning.core/test/qa-functional/src/org/netbeans/test/versioning/VersioningSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/AbstractFSTestCase.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/AbstractFSTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/AfterDeleteAfterMoveEndsTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/AfterDeleteAfterMoveEndsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTestAnnotationProvider.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTestAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSAnnotationProviderTestCase.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSAnnotationProviderTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSInterceptorTestCase.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSInterceptorTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSOwnerCacheTestCase.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSOwnerCacheTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSOwnerTestCase.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/VCSOwnerTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/VersioningQueryTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/VersioningQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/ConnectDisconnectTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/ConnectDisconnectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/DelegatingVCSTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/DelegatingVCSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/FSInterceptorTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/FSInterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/api/VCSFileProxyTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/api/VCSFileProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSAnnotatorTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSAnnotatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSCollocationQueryTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSCollocationQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSContextTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSHistoryTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSVisibilityQueryTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VCSVisibilityQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VersioningSupportTest.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/VersioningSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCS.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSAnnotator.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSCollocationQuery.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSCollocationQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSHistoryProvider.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSHistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSInterceptor.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSVisibilityQuery.java
+++ b/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSVisibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.indexingbridge/src/org/netbeans/modules/versioning/indexingbridge/Bridge.java
+++ b/versioning.indexingbridge/src/org/netbeans/modules/versioning/indexingbridge/Bridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.masterfs/src/org/netbeans/modules/versioning/masterfs/FilesystemInterceptor.java
+++ b/versioning.masterfs/src/org/netbeans/modules/versioning/masterfs/FilesystemInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.masterfs/src/org/netbeans/modules/versioning/masterfs/VersioningAnnotationProvider.java
+++ b/versioning.masterfs/src/org/netbeans/modules/versioning/masterfs/VersioningAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.masterfs/test/unit/src/org/netbeans/modules/versioning/masterfs/FileVCSTest.java
+++ b/versioning.masterfs/test/unit/src/org/netbeans/modules/versioning/masterfs/FileVCSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/CvsInstallDialog.java
+++ b/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/CvsInstallDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/CvsInstaller.java
+++ b/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/CvsInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/CvsInstallerModuleConfig.java
+++ b/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/CvsInstallerModuleConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/util/Utils.java
+++ b/versioning.system.cvss.installer/src/org/netbeans/modules/versioning/system/cvss/installer/util/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffActionTooltipWindow.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffActionTooltipWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffMark.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffMarkProviderCreator.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffMarkProviderCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebar.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebarDiffPanel.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebarDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebarFactory.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebarFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebarManager.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebarManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffTooltipActionsPanel.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffTooltipActionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffTooltipContentPanel.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffTooltipContentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/ShowDiffSidebarAction.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/ShowDiffSidebarAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/DiffPanel.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/DiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/History.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/History.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryComponent.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryDiffView.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryDiffView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryEntry.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryFileView.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryFileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryRootNode.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistorySettings.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistorySettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryUtils.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/MsgTooltipWindow.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/MsgTooltipWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/RevisionNode.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/RevisionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/history/TableEntry.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/history/TableEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralAdvancedOption.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralAdvancedOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanel.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanelController.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/options/HistoryOptions.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/options/HistoryOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/options/HistoryOptionsController.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/options/HistoryOptionsController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/src/org/netbeans/modules/versioning/ui/options/HistoryOptionsPanel.java
+++ b/versioning.ui/src/org/netbeans/modules/versioning/ui/options/HistoryOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/test/unit/src/org/netbeans/modules/versioning/ui/history/HistoryTestKit.java
+++ b/versioning.ui/test/unit/src/org/netbeans/modules/versioning/ui/history/HistoryTestKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/test/unit/src/org/netbeans/modules/versioning/ui/history/VCSCoreSPIHistoryTest.java
+++ b/versioning.ui/test/unit/src/org/netbeans/modules/versioning/ui/history/VCSCoreSPIHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.ui/test/unit/src/org/netbeans/modules/versioning/ui/history/VCSSPIHistoryTest.java
+++ b/versioning.ui/test/unit/src/org/netbeans/modules/versioning/ui/history/VCSSPIHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/proxy/Base64Encoder.java
+++ b/versioning.util/src/org/netbeans/modules/proxy/Base64Encoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/proxy/ConnectivitySettings.java
+++ b/versioning.util/src/org/netbeans/modules/proxy/ConnectivitySettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/proxy/InterruptibleInputStream.java
+++ b/versioning.util/src/org/netbeans/modules/proxy/InterruptibleInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/proxy/ProxySocketFactory.java
+++ b/versioning.util/src/org/netbeans/modules/proxy/ProxySocketFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/CacheIndex.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/CacheIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/CustomProviders.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/CustomProviders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/DefaultTurboProvider.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/DefaultTurboProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/Memory.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/Memory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/Statistics.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/Statistics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/Turbo.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/Turbo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/TurboListener.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/TurboListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/TurboProvider.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/TurboProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/turbo/keys/DiskFileKey.java
+++ b/versioning.util/src/org/netbeans/modules/turbo/keys/DiskFileKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationBar.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationBarManager.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationBarManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationMark.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationMark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationMarkInstaller.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationMarkInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationMarkProvider.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/AnnotationMarkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/LinesReader.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/LinesReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotateAction.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotation.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotations.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotationsProvider.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/annotate/VcsAnnotationsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/AbstractDiffSetup.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/AbstractDiffSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/DiffLookup.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/DiffLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/DiffUtils.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/DiffUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/DiffViewModeSwitcher.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/DiffViewModeSwitcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/EditorSaveCookie.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/EditorSaveCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/ExpandableMessage.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/ExpandableMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/FilesModifiedConfirmation.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/FilesModifiedConfirmation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/SaveBeforeClosingDiffConfirmation.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/SaveBeforeClosingDiffConfirmation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/SaveBeforeCommitConfirmation.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/SaveBeforeCommitConfirmation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/diff/ScrollableMessagesList.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/diff/ScrollableMessagesList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/history/AbstractSummaryView.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/history/AbstractSummaryView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/history/HistoryAction.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/history/HistoryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/history/HistoryActionSupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/history/HistoryActionSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/history/HistoryActionVCSProxyBased.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/history/HistoryActionVCSProxyBased.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/history/LinkButton.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/history/LinkButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/history/RevisionItemCell.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/history/RevisionItemCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/history/SummaryCellRenderer.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/history/SummaryCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/historystore/Entry.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/historystore/Entry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/historystore/Storage.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/historystore/Storage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/historystore/StorageManager.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/historystore/StorageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/GitHook.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/GitHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/GitHookContext.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/GitHookContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/GitHookFactory.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/GitHookFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/HgHook.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/HgHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/HgHookContext.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/HgHookContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/HgHookFactory.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/HgHookFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/HgQueueHook.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/HgQueueHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/HgQueueHookContext.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/HgQueueHookContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/HgQueueHookFactory.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/HgQueueHookFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/SvnHook.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/SvnHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/SvnHookContext.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/SvnHookContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/SvnHookFactory.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/SvnHookFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHook.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHookContext.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHookContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHookFactory.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHookFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHooks.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveChangesActionsRegistry.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveChangesActionsRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveChangesPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveChangesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveChangesSupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveChangesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveUtils.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/ShelveUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/PatchStorage.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/PatchStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/ShelveChangesMenu.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/ShelveChangesMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/UnshelveChangesAction.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/UnshelveChangesAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/UnshelveChangesPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/shelve/impl/UnshelveChangesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/AccessibleJFileChooser.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/AccessibleJFileChooser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/AutoResizingPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/AutoResizingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/CollectionUtils.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/CollectionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/CommandReport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/CommandReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/DelayScanRegistry.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/DelayScanRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/DelegatingUndoRedo.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/DelegatingUndoRedo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/DialogBoundsPreserver.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/DialogBoundsPreserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/ExportDiffPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/ExportDiffPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/ExportDiffSupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/ExportDiffSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/FileCollection.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/FileCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/FilePathCellRenderer.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/FilePathCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/FileSelector.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/FileSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/FileUtils.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/IdentityHashSet.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/IdentityHashSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/IndexingBridge.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/IndexingBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/KeyringSupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/KeyringSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/ListenersSupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/ListenersSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/NoContentPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/NoContentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/OpenInEditorAction.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/OpenInEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/OpenVersioningOutputAction.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/OpenVersioningOutputAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/OptionsPanelColorProvider.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/OptionsPanelColorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/PlaceholderPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/PlaceholderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/ProjectUtilities.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/ProjectUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/RootsToFile.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/RootsToFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/SearchHistorySupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/SearchHistorySupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/SimpleLookup.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/SimpleLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/SortedTable.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/SortedTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/StringSelector.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/StringSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/SystemActionBridge.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/SystemActionBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/TableSorter.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/TableSorter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/TemplatesPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/TemplatesPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/UndoRedoSupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/UndoRedoSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/Utils.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VCSBugtrackingAccessor.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VCSBugtrackingAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VCSHyperlinkProvider.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VCSHyperlinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VCSHyperlinkSupport.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VCSHyperlinkSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VCSKenaiAccessor.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VCSKenaiAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VCSNotificationDisplayer.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VCSNotificationDisplayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VCSOptionsKeywordsProvider.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VCSOptionsKeywordsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VcsAdvancedOptions.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VcsAdvancedOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VcsAdvancedOptionsPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VcsAdvancedOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VersioningEvent.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VersioningEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VersioningInfo.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VersioningInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VersioningListener.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VersioningListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VersioningOutputManager.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VersioningOutputManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VersioningOutputTopComponent.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VersioningOutputTopComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/VerticallyNonResizingPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/VerticallyNonResizingPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/WideButton.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/WideButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/CollapsiblePanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/CollapsiblePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/CommitMessageMouseAdapter.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/CommitMessageMouseAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/CommitPopupBuilder.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/CommitPopupBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/FileTreeView.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/FileTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/FileViewComponent.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/FileViewComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/SectionButton.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/SectionButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitDiffProvider.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitDiffProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitFilter.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitOptions.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitPanelModifier.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitPanelModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitParameters.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitTable.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitTableModel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSFileInformation.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSFileInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSFileNode.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/options/AnnotationColorsPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/options/AnnotationColorsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/options/CategoryRenderer.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/options/CategoryRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/projects/CheckoutCompletedPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/projects/CheckoutCompletedPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/projects/OpenProjectsPanel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/projects/OpenProjectsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/projects/ProjectOpener.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/projects/ProjectOpener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/projects/ProjectsView.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/projects/ProjectsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/queries/DiffFileEncodingQueryImpl.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/queries/DiffFileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/status/VCSStatusNode.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/status/VCSStatusNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/status/VCSStatusTable.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/status/VCSStatusTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/src/org/netbeans/modules/versioning/util/status/VCSStatusTableModel.java
+++ b/versioning.util/src/org/netbeans/modules/versioning/util/status/VCSStatusTableModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/turbo/CacheIndexTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/turbo/CacheIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/turbo/MemoryCacheProvider.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/turbo/MemoryCacheProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/turbo/TurboTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/turbo/TurboTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/turbo/keys/DiskFileKeyTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/turbo/keys/DiskFileKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/versioning/diff/DiffUtilsTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/versioning/diff/DiffUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/versioning/historystore/StorageTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/versioning/historystore/StorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/versioning/hooks/TestVCSHookFactoryA.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/versioning/hooks/TestVCSHookFactoryA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/versioning/hooks/TestVCSHookFactoryB.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/versioning/hooks/TestVCSHookFactoryB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/versioning/hooks/VCSHookTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/versioning/hooks/VCSHookTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/versioning/util/KeyringSupportTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/versioning/util/KeyringSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning.util/test/unit/src/org/netbeans/modules/versioning/util/UtilsTest.java
+++ b/versioning.util/test/unit/src/org/netbeans/modules/versioning/util/UtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/Accessor.java
+++ b/versioning/src/org/netbeans/modules/versioning/Accessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/DelegatingVCS.java
+++ b/versioning/src/org/netbeans/modules/versioning/DelegatingVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/FileBasedVCSProvider.java
+++ b/versioning/src/org/netbeans/modules/versioning/FileBasedVCSProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/VCSRegistrationProcessor.java
+++ b/versioning/src/org/netbeans/modules/versioning/VCSRegistrationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/AccessorImpl.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/AccessorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/VCSAnnotator.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/VCSAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/VCSContext.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/VCSContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/VCSHistoryProvider.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/VCSHistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/VCSInterceptor.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/VCSInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/VCSVisibilityQuery.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/VCSVisibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/VersioningSupport.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/VersioningSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/src/org/netbeans/modules/versioning/spi/VersioningSystem.java
+++ b/versioning/src/org/netbeans/modules/versioning/spi/VersioningSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/qa-functional/src/org/netbeans/test/versioning/VersioningSystemTest.java
+++ b/versioning/test/qa-functional/src/org/netbeans/test/versioning/VersioningSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/DelegatingVCSTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/DelegatingVCSTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTestAnnotationProvider.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/DeleteCreateTestAnnotationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/GetAnnotatedOwnerTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/GetAnnotatedOwnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/GetOwnerTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/GetOwnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/VersioningAnnotationProviderTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/VersioningAnnotationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSAnnotatorTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSAnnotatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSCollocationQueryTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSCollocationQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSContextTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSHistoryTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSInterceptorTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSInterceptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSVisibilityQueryTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VCSVisibilityQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VersioningSupportTest.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/VersioningSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestAnnotatedVCS.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestAnnotatedVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCS.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSAnnotator.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSCollocationQuery.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSCollocationQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSHistoryProvider.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSHistoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSInterceptor.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSVisibilityQuery.java
+++ b/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSVisibilityQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/Helper.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/Helper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserFamilyId.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserFamilyId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserPickerPopup.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserPickerPopup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserSupport.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserUISupport.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserUISupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/Page.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/Page.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/PageInspector.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/PageInspector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/ResizeOption.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/ResizeOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/ResizeOptions.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/ResizeOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowser.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserFactoryDescriptor.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserFactoryDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserFeatures.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserFeatures.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserPane.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowsers.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowsers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/BrowserURLMapperImplementation.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/BrowserURLMapperImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/BrowserURLMapperProvider.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/BrowserURLMapperProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/EnhancedBrowser.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/EnhancedBrowser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/EnhancedBrowserFactory.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/EnhancedBrowserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/ExternalModificationsSupport.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/ExternalModificationsSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/MessageDispatcher.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/MessageDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/PageInspectionHandle.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/PageInspectionHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/PageInspectorCustomizer.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/PageInspectorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/ProjectBrowserProvider.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/ProjectBrowserProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/Resizable.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/Resizable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/ScriptExecutor.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/ScriptExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/URLDisplayerImplementation.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/URLDisplayerImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/spi/Zoomable.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/spi/Zoomable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/BrowserResizeButton.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/BrowserResizeButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/DeveloperHtmlBrowserComponent.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/DeveloperHtmlBrowserComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/DeveloperToolbar.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/DeveloperToolbar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/HtmlPreviewElement.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/HtmlPreviewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/ResizeOptionsCustomizer.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/ResizeOptionsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/BrowserCombo.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/BrowserCombo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/BrowserMenu.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/BrowserMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/ListItem.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/ListItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/RendererImpl.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/RendererImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionList.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionListFactory.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionListFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionListImpl.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionModel.java
+++ b/web.browser.api/src/org/netbeans/modules/web/browser/ui/picker/SelectionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/ExternalExecutionUserWarningImpl.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/ExternalExecutionUserWarningImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/ImportantFiles.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/ImportantFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/api/CssPreprocessorUI.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/api/CssPreprocessorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/api/CssPreprocessorsUI.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/api/CssPreprocessorsUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/api/ExternalExecutable.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/api/ExternalExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/api/ExternalExecutableValidator.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/api/ExternalExecutableValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/api/FileReferenceCompletion.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/api/FileReferenceCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/api/WebUIUtils.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/api/WebUIUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPrepOptionsPanel.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPrepOptionsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPrepOptionsPanelController.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPrepOptionsPanelController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorAccessor.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsAccessor.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsCustomizer.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsCustomizerPanel.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsProblemProvider.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/cssprep/CssPreprocessorsProblemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/refactoring/FolderActionsImplementationProvider.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/refactoring/FolderActionsImplementationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/refactoring/RenamePanel.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/refactoring/RenamePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/refactoring/RenameRefactoringUI.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/refactoring/RenameRefactoringUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/remote/RemoteFSDecoratorUI.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/remote/RemoteFSDecoratorUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/src/org/netbeans/modules/web/common/ui/spi/CssPreprocessorUIImplementation.java
+++ b/web.common.ui/src/org/netbeans/modules/web/common/ui/spi/CssPreprocessorUIImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common.ui/test/unit/src/org/netbeans/modules/web/common/ui/api/WebUIUtilsTest.java
+++ b/web.common.ui/test/unit/src/org/netbeans/modules/web/common/ui/api/WebUIUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/ByteStack.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/ByteStack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/Constants.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/CssPreprocessor.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/CssPreprocessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/CssPreprocessors.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/CssPreprocessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/CssPreprocessorsListener.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/CssPreprocessorsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/DependenciesGraph.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/DependenciesGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/DependencyType.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/DependencyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/DependentFileQuery.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/DependentFileQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/FileReference.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/FileReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/FileReferenceModification.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/FileReferenceModification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/FileReferenceType.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/FileReferenceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/LexerUtils.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/LexerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/Lines.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/Lines.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/RemoteFileCache.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/RemoteFileCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/ServerURLMapping.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/ServerURLMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/UsageLogger.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/UsageLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/ValidationResult.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/ValidationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/ValueCompletion.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/ValueCompletion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/Version.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/Version.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/WebPageMetadata.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/WebPageMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/WebServer.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/WebServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/api/WebUtils.java
+++ b/web.common/src/org/netbeans/modules/web/common/api/WebUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/cssprep/CssPreprocessorAccessor.java
+++ b/web.common/src/org/netbeans/modules/web/common/cssprep/CssPreprocessorAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/cssprep/CssPreprocessorsAccessor.java
+++ b/web.common/src/org/netbeans/modules/web/common/cssprep/CssPreprocessorsAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/remote/RemoteFS.java
+++ b/web.common/src/org/netbeans/modules/web/common/remote/RemoteFS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/remote/RemoteFilesCache.java
+++ b/web.common/src/org/netbeans/modules/web/common/remote/RemoteFilesCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/remote/RemoteURLMapper.java
+++ b/web.common/src/org/netbeans/modules/web/common/remote/RemoteURLMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/sourcemap/Mapping.java
+++ b/web.common/src/org/netbeans/modules/web/common/sourcemap/Mapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/sourcemap/MappingTokenizer.java
+++ b/web.common/src/org/netbeans/modules/web/common/sourcemap/MappingTokenizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMap.java
+++ b/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMapsScanner.java
+++ b/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMapsScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMapsTranslator.java
+++ b/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMapsTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMapsTranslatorImpl.java
+++ b/web.common/src/org/netbeans/modules/web/common/sourcemap/SourceMapsTranslatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/CssPreprocessorImplementation.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/CssPreprocessorImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/CssPreprocessorImplementationListener.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/CssPreprocessorImplementationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/DependentFileQueryImplementation.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/DependentFileQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/ExternalExecutableUserWarning.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/ExternalExecutableUserWarning.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/ImportantFilesImplementation.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/ImportantFilesImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/ImportantFilesSupport.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/ImportantFilesSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/ProjectWebRootProvider.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/ProjectWebRootProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/ProjectWebRootQuery.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/ProjectWebRootQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/RemoteFSDecorator.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/RemoteFSDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/RemoteFileCacheImplementation.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/RemoteFileCacheImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/ServerURLMappingImplementation.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/ServerURLMappingImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/spi/WebPageMetadataProvider.java
+++ b/web.common/src/org/netbeans/modules/web/common/spi/WebPageMetadataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/taginfo/AttrValueType.java
+++ b/web.common/src/org/netbeans/modules/web/common/taginfo/AttrValueType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/taginfo/LibraryMetadata.java
+++ b/web.common/src/org/netbeans/modules/web/common/taginfo/LibraryMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/taginfo/TagAttrMetadata.java
+++ b/web.common/src/org/netbeans/modules/web/common/taginfo/TagAttrMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/src/org/netbeans/modules/web/common/taginfo/TagMetadata.java
+++ b/web.common/src/org/netbeans/modules/web/common/taginfo/TagMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/ByteStackTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/ByteStackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/FileReferenceTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/FileReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/LexerUtilsTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/LexerUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/LinesTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/LinesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/ServerURLMappingTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/ServerURLMappingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/UsageLoggerTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/UsageLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/WebServerTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/WebServerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/api/WebUtilsTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/api/WebUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/sourcemap/SourceMapTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/sourcemap/SourceMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.common/test/unit/src/org/netbeans/modules/web/common/sourcemap/SourceMapsTranslatorTest.java
+++ b/web.common/test/unit/src/org/netbeans/modules/web/common/sourcemap/SourceMapsTranslatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/LexUtilities.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/LexUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/embedding/JoinedTokenSequence.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/embedding/JoinedTokenSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/embedding/VirtualSource.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/embedding/VirtualSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/support/AbstractIndenter.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/support/AbstractIndenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/support/IndentCommand.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/support/IndentCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/support/IndenterContextData.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/support/IndenterContextData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/support/IndenterFormattingContext.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/support/IndenterFormattingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.indent/src/org/netbeans/modules/web/indent/api/support/MarkupAbstractIndenter.java
+++ b/web.indent/src/org/netbeans/modules/web/indent/api/support/MarkupAbstractIndenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/APIFactory.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/APIFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/LiveHTML.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/LiveHTML.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/TransportHelper.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/TransportHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/BreakpointException.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/BreakpointException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/Debugger.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/Debugger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/Runtime.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/Runtime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/TransportStateException.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/TransportStateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/WebKitDebugging.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/WebKitDebugging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/WebKitUIManager.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/WebKitUIManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/Console.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/Console.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/ConsoleMessage.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/ConsoleMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/PropertyMessage.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/PropertyMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/RemoteObjectMessage.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/console/RemoteObjectMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/CSS.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/CSS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/ComputedStyleProperty.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/ComputedStyleProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/InheritedStyleEntry.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/InheritedStyleEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/InlineStyles.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/InlineStyles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/MatchedStyles.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/MatchedStyles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Media.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Media.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Property.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Property.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/PropertyInfo.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/PropertyInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Rule.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/RuleId.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/RuleId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Selector.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Selector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/SourceRange.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/SourceRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Style.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Style.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleId.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetBody.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetHeader.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetOrigin.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetOrigin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/AbstractObject.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/AbstractObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/Breakpoint.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/Breakpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/CallFrame.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/CallFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/PropertyDescriptor.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/PropertyDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/RemoteObject.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/RemoteObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/Scope.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/Scope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/Script.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/debugger/Script.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/DOM.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/DOM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/HighlightConfig.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/HighlightConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/Node.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/NodeAnnotator.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/NodeAnnotator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/network/Network.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/network/Network.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/page/Page.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/page/Page.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/BrowserConsoleLoggerFactory.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/BrowserConsoleLoggerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/Command.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/Factory.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/Factory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/JavaScriptDebuggerFactory.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/JavaScriptDebuggerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/LiveHTMLImplementation.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/LiveHTMLImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/NetworkMonitorFactory.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/NetworkMonitorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/Response.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/Response.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/ResponseCallback.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/ResponseCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/TransportImplementation.java
+++ b/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/spi/TransportImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/test/unit/src/org/netbeans/modules/web/webkit/debugging/api/dom/DOMTest.java
+++ b/web.webkit.debugging/test/unit/src/org/netbeans/modules/web/webkit/debugging/api/dom/DOMTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/web.webkit.debugging/test/unit/src/org/netbeans/modules/web/webkit/debugging/api/dom/HighlightConfigTest.java
+++ b/web.webkit.debugging/test/unit/src/org/netbeans/modules/web/webkit/debugging/api/dom/HighlightConfigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSOperation.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSParameter.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSPort.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSReference.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSService.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSTransferable.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/WSTransferable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/java/JavaMethod.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/java/JavaMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/java/JavaParameter.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/java/JavaParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/java/JavaType.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/java/JavaType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/wsdlmodel/WsdlModel.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/wsdlmodel/WsdlModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/wsdlmodel/WsdlModelProvider.java
+++ b/websvc.jaxwsmodelapi/src/org/netbeans/modules/websvc/jaxwsmodelapi/wsdlmodel/WsdlModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/CustomSaas.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/CustomSaas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/CustomSaasMethod.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/CustomSaasMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/Saas.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/Saas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasCatalog.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasGroup.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasMethod.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasServicesModel.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/SaasServicesModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WadlSaas.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WadlSaas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WadlSaasMethod.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WadlSaasMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WadlSaasResource.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WadlSaasResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WsdlSaas.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WsdlSaas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WsdlSaasMethod.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WsdlSaasMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WsdlSaasPort.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/WsdlSaasPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/Utils.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlErrorHandler.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModel.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelListener.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModeler.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModeler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelerFactory.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlOperation.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlParameter.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlPort.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlService.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/ConsumerFlavorProvider.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/ConsumerFlavorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/MethodNodeActionsProvider.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/MethodNodeActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/SaasNodeActionsProvider.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/SaasNodeActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/SaasViewProvider.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/SaasViewProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/ServiceData.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/ServiceData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlData.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlDataManager.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlServiceData.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlServiceData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlServiceProxyDescriptor.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/spi/websvcmgr/WsdlServiceProxyDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/SaasTransferable.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/SaasTransferable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/SaasUtil.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/SaasUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/TypeUtil.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/TypeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/WsdlUtil.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/util/WsdlUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WebServiceListManager.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WebServiceListManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WebServiceManager.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WebServiceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WsdlDataImpl.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WsdlDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WsdlDataManagerImpl.java
+++ b/websvc.saas.api/src/org/netbeans/modules/websvc/saas/wsdl/websvcmgr/WsdlDataManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/model/SaasServicesModelTest.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/model/SaasServicesModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/model/WadlSaasMethodTest.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/model/WadlSaasMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/model/WadlSaasTest.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/model/WadlSaasTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/DialogDisplayerNotifier.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/DialogDisplayerNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/InstalledFileLocatorImpl.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/InstalledFileLocatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SaasUtilTest.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SaasUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SchemaTestBase.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SchemaTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SetupData.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SetupData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SetupUtil.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/SetupUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/TestRetriever.java
+++ b/websvc.saas.api/test/unit/src/org/netbeans/modules/websvc/saas/util/TestRetriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/CustomClientPojoCodeGenerator.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/CustomClientPojoCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/RestClientPojoCodeGenerator.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/RestClientPojoCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/SaasClientJavaAuthenticationGenerator.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/SaasClientJavaAuthenticationGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/SoapClientPojoCodeGenerator.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/SoapClientPojoCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/WadlSaasEx.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/WadlSaasEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/AbstractTask.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/AbstractTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/JavaSourceHelper.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/JavaSourceHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/JavaUtil.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/JavaUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/LibrariesHelper.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/LibrariesHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SoapClientJavaOperationInfo.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SoapClientJavaOperationInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/Xsd2Java.java
+++ b/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/Xsd2Java.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/Constants.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientAuthenticationGenerator.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientAuthenticationGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerationManager.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerator.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/CustomClientSaasBean.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/CustomClientSaasBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/GenericResourceBean.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/GenericResourceBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/RestClientSaasBean.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/RestClientSaasBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SaasBean.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SaasBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SoapClientOperationInfo.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SoapClientOperationInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SoapClientSaasBean.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SoapClientSaasBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/spi/SaasClientCodeGenerationProvider.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/spi/SaasClientCodeGenerationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CodeSetupPanel.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CodeSetupPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CustomClientEditorDrop.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CustomClientEditorDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CustomClientFlavorProvider.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CustomClientFlavorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/ProgressDialog.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/ProgressDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/RestClientEditorDrop.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/RestClientEditorDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/RestClientFlavorProvider.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/RestClientFlavorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapClientEditorDrop.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapClientEditorDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapClientFlavorProvider.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapClientFlavorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapServiceClientEditorDrop.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapServiceClientEditorDrop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Inflector.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Inflector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/UniqueVariableNameFinder.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/UniqueVariableNameFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Util.java
+++ b/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/InstalledFileLocatorImpl.java
+++ b/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/InstalledFileLocatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/JavaCodeGenerationTest.java
+++ b/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/JavaCodeGenerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerationProviderTest.java
+++ b/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/SetupUtil.java
+++ b/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/SetupUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/TestUtils.java
+++ b/websvc.saas.codegen/test/unit/src/org/netbeans/modules/websvc/saas/codegen/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/AddGroupAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/AddGroupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/AddServiceAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/AddServiceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/DeleteGroupAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/DeleteGroupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/DeleteServiceAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/DeleteServiceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/RefreshServiceAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/RefreshServiceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/RenameGroupAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/RenameGroupAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/ViewApiDocAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/ViewApiDocAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/ViewWSDLAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/ViewWSDLAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/ViewWadlAction.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/actions/ViewWadlAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/CustomMethodNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/CustomMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/CustomSaasNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/CustomSaasNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/CustomSaasNodeChildren.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/CustomSaasNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/ResourceNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/ResourceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/ResourceNodeChildren.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/ResourceNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasGroupNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasGroupNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasGroupNodeChildren.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasGroupNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasMethodNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasNodeChildren.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasServicesRootNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasServicesRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasView.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/SaasView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlMethodNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlSaasNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlSaasNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlSaasNodeChildren.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlSaasNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlMethodNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlMethodNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlPortNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlPortNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlPortNodeChildren.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlPortNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNode.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNodeChildren.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNodeChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/wizards/AddWebServiceDlg.java
+++ b/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/wizards/AddWebServiceDlg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/release/docs/netbeans.css
+++ b/welcome/release/docs/netbeans.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/FeedbackSurvey.java
+++ b/welcome/src/org/netbeans/modules/welcome/FeedbackSurvey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/Installer.java
+++ b/welcome/src/org/netbeans/modules/welcome/Installer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ShowWelcomeAction.java
+++ b/welcome/src/org/netbeans/modules/welcome/ShowWelcomeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/WelcomeComponent.java
+++ b/welcome/src/org/netbeans/modules/welcome/WelcomeComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/WelcomeOptions.java
+++ b/welcome/src/org/netbeans/modules/welcome/WelcomeOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/ActionButton.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/ActionButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/BundleSupport.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/BundleSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/ButtonBorder.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/ButtonBorder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/CombinationRSSFeed.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/CombinationRSSFeed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/Constants.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/ContentSection.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/ContentSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/HttpProxySettings.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/HttpProxySettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/LinkButton.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/LinkButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/Logo.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/Logo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/RSSFeed.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/RSSFeed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/RSSFeedReaderPanel.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/RSSFeedReaderPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/RecentProjectsPanel.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/RecentProjectsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/Utils.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/content/WebLink.java
+++ b/welcome/src/org/netbeans/modules/welcome/content/WebLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/AbstractTab.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/AbstractTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/ArticlesAndNews.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/ArticlesAndNews.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/Blogs.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/Blogs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/BottomBar.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/BottomBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/ContentHeader.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/ContentHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/DemoPanel.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/DemoPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/GetStarted.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/GetStarted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/InstallConfig.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/InstallConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/LearnAndDiscoverTab.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/LearnAndDiscoverTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/MyNetBeansTab.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/MyNetBeansTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/PluginsPanel.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/PluginsPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/SampleProjectAction.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/SampleProjectAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/ShowNextTime.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/ShowNextTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/StartPageContent.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/StartPageContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/TabContentPane.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/TabContentPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/TabbedPane.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/TabbedPane.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/Tutorials.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/Tutorials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/src/org/netbeans/modules/welcome/ui/WhatsNewTab.java
+++ b/welcome/src/org/netbeans/modules/welcome/ui/WhatsNewTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/test/unit/src/org/netbeans/modules/welcome/FeedbackSurveyTest.java
+++ b/welcome/test/unit/src/org/netbeans/modules/welcome/FeedbackSurveyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/welcome/test/unit/src/org/netbeans/modules/welcome/MemoryURL.java
+++ b/welcome/test/unit/src/org/netbeans/modules/welcome/MemoryURL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/api/whitelist/WhiteListQuery.java
+++ b/whitelist/src/org/netbeans/api/whitelist/WhiteListQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/api/whitelist/index/WhiteListIndex.java
+++ b/whitelist/src/org/netbeans/api/whitelist/index/WhiteListIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/api/whitelist/index/WhiteListIndexEvent.java
+++ b/whitelist/src/org/netbeans/api/whitelist/index/WhiteListIndexEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/api/whitelist/index/WhiteListIndexListener.java
+++ b/whitelist/src/org/netbeans/api/whitelist/index/WhiteListIndexListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/api/whitelist/support/WhiteListSupport.java
+++ b/whitelist/src/org/netbeans/api/whitelist/support/WhiteListSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/modules/whitelist/ProjectWhiteListQueryImpl.java
+++ b/whitelist/src/org/netbeans/modules/whitelist/ProjectWhiteListQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/modules/whitelist/WhiteListQueryImplementationMerged.java
+++ b/whitelist/src/org/netbeans/modules/whitelist/WhiteListQueryImplementationMerged.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/modules/whitelist/WhiteListQueryMerger.java
+++ b/whitelist/src/org/netbeans/modules/whitelist/WhiteListQueryMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/modules/whitelist/index/WhiteListIndexAccessor.java
+++ b/whitelist/src/org/netbeans/modules/whitelist/index/WhiteListIndexAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/modules/whitelist/index/WhiteListIndexerPlugin.java
+++ b/whitelist/src/org/netbeans/modules/whitelist/index/WhiteListIndexerPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/modules/whitelist/project/WhiteListCategoryPanel.java
+++ b/whitelist/src/org/netbeans/modules/whitelist/project/WhiteListCategoryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/modules/whitelist/project/WhiteListLookupProvider.java
+++ b/whitelist/src/org/netbeans/modules/whitelist/project/WhiteListLookupProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/spi/whitelist/WhiteListQueryImplementation.java
+++ b/whitelist/src/org/netbeans/spi/whitelist/WhiteListQueryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/spi/whitelist/support/WhiteListImplementationBuilder.java
+++ b/whitelist/src/org/netbeans/spi/whitelist/support/WhiteListImplementationBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/src/org/netbeans/spi/whitelist/support/WhiteListQueryMergerSupport.java
+++ b/whitelist/src/org/netbeans/spi/whitelist/support/WhiteListQueryMergerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/test/unit/src/org/netbeans/api/whitelist/WhiteListQueryTest.java
+++ b/whitelist/test/unit/src/org/netbeans/api/whitelist/WhiteListQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/test/unit/src/org/netbeans/api/whitelist/support/WhiteListSupportTest.java
+++ b/whitelist/test/unit/src/org/netbeans/api/whitelist/support/WhiteListSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/whitelist/test/unit/src/org/netbeans/modules/whitelist/project/WhiteListCategoryPanelTest.java
+++ b/whitelist/test/unit/src/org/netbeans/modules/whitelist/project/WhiteListCategoryPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AXIComponent.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AXIComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AXIComponentFactory.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AXIComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AXIContainer.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AXIContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AXIDocument.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AXIDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AXIModel.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AXIModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AXIModelFactory.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AXIModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AXIType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AXIType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AbstractAttribute.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AbstractAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AbstractElement.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AbstractElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AnyAttribute.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AnyAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/AnyElement.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/AnyElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/Attribute.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/Compositor.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/Compositor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/ContentModel.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/ContentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/Element.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/SchemaGenerator.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/SchemaGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/SchemaGeneratorFactory.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/SchemaGeneratorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/SchemaReference.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/SchemaReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/AnyType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/AnyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/AnyURIType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/AnyURIType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/Base64BinaryType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/Base64BinaryType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/BinaryBase.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/BinaryBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/BooleanType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/BooleanType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/ByteType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/ByteType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/CustomDatatype.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/CustomDatatype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/Datatype.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/Datatype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DatatypeFactory.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DatatypeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DateTimeType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DateTimeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DateType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DateType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DecimalType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DecimalType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DoubleType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DoubleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DurationType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/DurationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/EntitiesType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/EntitiesType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/EntityType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/EntityType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/FloatType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/FloatType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GDayType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GDayType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GMonthDayType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GMonthDayType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GMonthType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GMonthType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GYearMonthType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GYearMonthType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GYearType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/GYearType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/HexBinaryType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/HexBinaryType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IdRefType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IdRefType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IdRefsType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IdRefsType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IdType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IdType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IntType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IntType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IntegerType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/IntegerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/LanguageType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/LanguageType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/LongType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/LongType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NameType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NameType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NcNameType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NcNameType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NegativeIntegerType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NegativeIntegerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NmTokenType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NmTokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NmTokensType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NmTokensType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NonNegativeIntegerType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NonNegativeIntegerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NonPositiveIntegerType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NonPositiveIntegerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NormalizedStringType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NormalizedStringType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NotationType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NotationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NumberBase.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/NumberBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/PositiveIntegerType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/PositiveIntegerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/QNameType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/QNameType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/ShortType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/ShortType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/StringBase.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/StringBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/StringType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/StringType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/TimeBase.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/TimeBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/TimeType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/TimeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/TokenType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/TokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnionType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedByteType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedByteType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedIntType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedIntType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedLongType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedLongType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedShortType.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/datatype/UnsignedShortType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIComponentCreator.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIComponentCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIComponentProxy.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIComponentProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIDocumentImpl.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIDocumentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelBuilder.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelBuilderQuery.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelBuilderQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelImpl.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelListener.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelUpdater.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AbstractModelBuilder.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AbstractModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AnyAttributeProxy.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AnyAttributeProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AnyElementProxy.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AnyElementProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AttributeImpl.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AttributeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AttributeProxy.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AttributeProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/AttributeRef.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/AttributeRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/CompositorProxy.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/CompositorProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/DatatypeBuilder.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/DatatypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/DatatypeFactoryImpl.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/DatatypeFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/DefaultSchemaGenerator.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/DefaultSchemaGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementImpl.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementProxy.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementRef.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/GardenOfEden.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/GardenOfEden.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/MixedPattern.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/MixedPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/ModelAccessImpl.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/ModelAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/OtherAXIModelListener.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/OtherAXIModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/PeerValidator.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/PeerValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/Preview.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/Preview.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/RussianDoll.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/RussianDoll.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/SalamiSlice.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/SalamiSlice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaGeneratorFactoryImpl.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaGeneratorFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaGeneratorUtil.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaGeneratorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaModelListener.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaReferenceProxy.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaReferenceProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaUpdate.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/SchemaUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/Util.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/impl/VenetianBlind.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/impl/VenetianBlind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/visitor/AXINonCyclicVisitor.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/visitor/AXINonCyclicVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/visitor/AXIVisitor.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/visitor/AXIVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/visitor/AXIVisitor2.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/visitor/AXIVisitor2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/visitor/DeepAXITreeVisitor.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/visitor/DeepAXITreeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/visitor/DefaultVisitor.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/visitor/DefaultVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/visitor/FindUsageVisitor.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/visitor/FindUsageVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/src/org/netbeans/modules/xml/axi/visitor/PrintAXITreeVisitor.java
+++ b/xml.axi/src/org/netbeans/modules/xml/axi/visitor/PrintAXITreeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AXIModelExTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AXIModelExTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AXIModelPerfTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AXIModelPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AXIModelTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AXIModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AbstractTestCase.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/AbstractTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/CheckParentTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/CheckParentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/ContentModelTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/ContentModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/CyclicModelTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/CyclicModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/DesignPatternTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/DesignPatternTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/ProxyComponentTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/ProxyComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/RefactorRenameTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/RefactorRenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorDatatypesTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorDatatypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorPerf2Test.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorPerf2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorPerfTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaTransformPerfTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaTransformPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaTransformTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/SchemaTransformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/TestCatalogModel.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/TestCatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/datatype/DatatypeFactoryTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/datatype/DatatypeFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/datatype/DatatypePerfTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/datatype/DatatypePerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/datatype/DatatypeTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/datatype/DatatypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/AbstractSyncTestCase.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/AbstractSyncTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/MultiFileSyncTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/MultiFileSyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SimulationTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SimulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/StateChangeTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/StateChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SyncDeadlockTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SyncDeadlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SyncElementTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SyncElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SyncTest.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/sync/SyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/AXITreeVisitor.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/AXITreeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/FileUtil.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/FileUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/ModelValidator.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/ModelValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/SimulationHelper.java
+++ b/xml.axi/test/unit/src/org/netbeans/modules/xml/axi/util/SimulationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/AddCatalogEntryAction.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/AddCatalogEntryAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntry.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryBeanInfo.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryNode.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryPanel.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterModel.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterPanel.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogPanel.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/RefreshAction.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/RefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/Refreshable.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/Refreshable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogCustomizer.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogReaderBeanInfo.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogReaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogBeanInfo.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogCustomizer.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/res/Bundle.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/res/Bundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogBeanInfo.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogCustomizer.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/res/Bundle.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/res/Bundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/StreamEnvironment.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/StreamEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/URLEnvironment.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/URLEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/Util.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptor.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/user/UserXMLCatalog.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/user/UserXMLCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/user/UserXMLCatalogBeanInfo.java
+++ b/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/user/UserXMLCatalogBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/CatalogEntityResolver.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/CatalogEntityResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/AbstractCatalog.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/AbstractCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogProvider.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogReader.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/SystemCatalogReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/WellKnownSchemaCatalog.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/WellKnownSchemaCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalog.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalogProvider.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalogProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/Catalog.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/Catalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/SunCatalogProvider.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/SunCatalogProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/lib/Categorizer.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/lib/Categorizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/lib/FilterIterator.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/lib/FilterIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/lib/IteratorIterator.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/lib/IteratorIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/settings/CatalogSettings.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/settings/CatalogSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptor2.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptor2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptorBase.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptorBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogListener.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogListenerAdapter.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogListenerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogProvider.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogReader.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogWriter.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/CatalogWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/ProvidersRegistry.java
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/spi/ProvidersRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/AbstractNode.java
+++ b/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/AbstractNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogEntryNode.java
+++ b/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogEntryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogNode.java
+++ b/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/XMLEntityCatalogsNode.java
+++ b/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/nodes/XMLEntityCatalogsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/operators/MountCatalogDialogOperator.java
+++ b/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/operators/MountCatalogDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/operators/UserCatalogOperator.java
+++ b/xml.catalog/test/qa-functional/src/org/netbeans/jellytools/modules/xml/catalog/operators/UserCatalogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/qa-functional/src/org/netbeans/xml/test/catalog/CatalogTest.java
+++ b/xml.catalog/test/qa-functional/src/org/netbeans/xml/test/catalog/CatalogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogTest.java
+++ b/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/EncodingUtil.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/EncodingUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/XmlFileEncodingQueryImpl.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/XmlFileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/DTDUtil.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/DTDUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/DescriptionSource.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/DescriptionSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/ExtendedGrammarQuery.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/ExtendedGrammarQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/GrammarEnvironment.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/GrammarEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQuery.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/GrammarResult.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/GrammarResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/api/model/HintContext.java
+++ b/xml.core/src/org/netbeans/modules/xml/api/model/HintContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/core/lib/AbstractUtil.java
+++ b/xml.core/src/org/netbeans/modules/xml/core/lib/AbstractUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/core/lib/EncodingHelper.java
+++ b/xml.core/src/org/netbeans/modules/xml/core/lib/EncodingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/core/lib/UnicodeReader.java
+++ b/xml.core/src/org/netbeans/modules/xml/core/lib/UnicodeReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
+++ b/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
+++ b/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammarQueryProvider.java
+++ b/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammarQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
+++ b/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/spi/dom/AbstractNode.java
+++ b/xml.core/src/org/netbeans/modules/xml/spi/dom/AbstractNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/spi/dom/NamedNodeMapImpl.java
+++ b/xml.core/src/org/netbeans/modules/xml/spi/dom/NamedNodeMapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/spi/dom/NodeListImpl.java
+++ b/xml.core/src/org/netbeans/modules/xml/spi/dom/NodeListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/spi/dom/ROException.java
+++ b/xml.core/src/org/netbeans/modules/xml/spi/dom/ROException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/src/org/netbeans/modules/xml/spi/dom/UOException.java
+++ b/xml.core/src/org/netbeans/modules/xml/spi/dom/UOException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/test/unit/src/org/netbeans/modules/xml/api/EncodingUtilTest.java
+++ b/xml.core/test/unit/src/org/netbeans/modules/xml/api/EncodingUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/test/unit/src/org/netbeans/modules/xml/api/XmlFileEncodingQueryImplTest.java
+++ b/xml.core/test/unit/src/org/netbeans/modules/xml/api/XmlFileEncodingQueryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/test/unit/src/org/netbeans/modules/xml/api/model/GrammarQueryManagerTest.java
+++ b/xml.core/test/unit/src/org/netbeans/modules/xml/api/model/GrammarQueryManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/test/unit/src/org/netbeans/modules/xml/api/model/SampleGrammarQueryManager.java
+++ b/xml.core/test/unit/src/org/netbeans/modules/xml/api/model/SampleGrammarQueryManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/test/unit/src/org/netbeans/modules/xml/core/AbstractUtilTest.java
+++ b/xml.core/test/unit/src/org/netbeans/modules/xml/core/AbstractUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/test/unit/src/org/netbeans/modules/xml/dtd/grammar/ContentModelTest.java
+++ b/xml.core/test/unit/src/org/netbeans/modules/xml/dtd/grammar/ContentModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.core/test/unit/src/org/netbeans/modules/xml/dtd/grammar/DTDParserTest.java
+++ b/xml.core/test/unit/src/org/netbeans/modules/xml/dtd/grammar/DTDParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/JAXBWizard.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/JAXBWizard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBDeleteSchemaAction.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBDeleteSchemaAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBRefreshAction.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBRefreshAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBRegenerateCodeAction.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBRegenerateCodeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBWizardOpenXSDIntoEditorAction.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/JAXBWizardOpenXSDIntoEditorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/OpenJAXBCustomizerAction.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/actions/OpenJAXBCustomizerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/JAXBWizModel.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/JAXBWizModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/events/JAXBWizEvent.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/events/JAXBWizEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/events/JAXBWizEventListener.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/events/JAXBWizEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/events/JAXBWizEventListenerAdapter.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/api/model/events/JAXBWizEventListenerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/catalog/MappingCatalog.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/catalog/MappingCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Binding.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Binding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Bindings.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Bindings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Catalog.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Catalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schema.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/SchemaSource.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/SchemaSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/SchemaSources.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/SchemaSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schemas.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schemas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/XjcOption.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/XjcOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/XjcOptions.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/XjcOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/model/JAXBWizModelImpl.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/model/JAXBWizModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/model/JAXBWizProjectOpenedHookImpl.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/model/JAXBWizProjectOpenedHookImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/model/events/JAXBWizEventImpl.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/model/events/JAXBWizEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/spi/JAXBWizModuleConstants.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/spi/JAXBWizModuleConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/spi/SchemaCompiler.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/spi/SchemaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/spi/SchemaCompilerProvider.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/spi/SchemaCompilerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/AntSchemaCompiler.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/AntSchemaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/AntSchemaCompilerProvider.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/AntSchemaCompilerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/CompilerFinder.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/CompilerFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/FileListPanel.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/FileListPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBBindingInfoPnl.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBBindingInfoPnl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBBindingSupportFileNode.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBBindingSupportFileNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBNodeFactory.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizBindingCfgPanel.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizBindingCfgPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardIterator.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardRootNode.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardRootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardSchemaNode.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardSchemaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/util/FileSysUtil.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/util/FileSysUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/util/JavaSourceUtil.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/util/JavaSourceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/src/org/netbeans/modules/xml/jaxb/util/ProjectHelper.java
+++ b/xml.jaxb/src/org/netbeans/modules/xml/jaxb/util/ProjectHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCase.java
+++ b/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCaseDTD.java
+++ b/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCaseDTD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCaseWSDL.java
+++ b/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCaseWSDL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCaseXSD.java
+++ b/xml.jaxb/test/qa-functional/src/org/netbeans/test/xml/jaxb/AcceptanceTestCaseXSD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.jaxb/test/unit/src/org/netbeans/modules/xml/jaxb/util/XSLTest.java
+++ b/xml.jaxb/test/unit/src/org/netbeans/modules/xml/jaxb/util/XSLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/src/org/netbeans/api/xml/lexer/DTDTokenId.java
+++ b/xml.lexer/src/org/netbeans/api/xml/lexer/DTDTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/src/org/netbeans/api/xml/lexer/XMLTokenId.java
+++ b/xml.lexer/src/org/netbeans/api/xml/lexer/XMLTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/src/org/netbeans/lib/xml/lexer/DTDLexer.java
+++ b/xml.lexer/src/org/netbeans/lib/xml/lexer/DTDLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/src/org/netbeans/lib/xml/lexer/UnicodeClasses.java
+++ b/xml.lexer/src/org/netbeans/lib/xml/lexer/UnicodeClasses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/src/org/netbeans/lib/xml/lexer/XMLLexer.java
+++ b/xml.lexer/src/org/netbeans/lib/xml/lexer/XMLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/AbstractTestCase.java
+++ b/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/AbstractTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/BrokenXMLTest.java
+++ b/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/BrokenXMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/DTDTokenIdTest.java
+++ b/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/DTDTokenIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/XMLTokenIdTest.java
+++ b/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/XMLTokenIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/AbstractMultiViewElement.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/AbstractMultiViewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/DesignMultiViewDesc.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/DesignMultiViewDesc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/EncodingHelper.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/EncodingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/Error.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/Error.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemCheckBoxHelper.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemCheckBoxHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemComboBoxHelper.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemComboBoxHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemEditorHelper.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemEditorHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemOptionHelper.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemOptionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/Refreshable.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/Refreshable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/SectionNode.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/SectionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ToolBarMultiViewElement.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ToolBarMultiViewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/TreePanelMultiViewElement.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/TreePanelMultiViewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/Utils.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataSynchronizer.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataSynchronizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewElement.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/cookies/ErrorLocator.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/cookies/ErrorLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/cookies/LinkCookie.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/cookies/LinkCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/cookies/SectionFocusCookie.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/cookies/SectionFocusCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/AbstractDesignEditor.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/AbstractDesignEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/BoxPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/BoxPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ConfirmDialog.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ConfirmDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ContainerPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ContainerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/DefaultTablePanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/DefaultTablePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/EditDialog.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/EditDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ErrorPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ErrorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/InnerPanelFactory.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/InnerPanelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/LinkButton.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/LinkButton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/NodeSectionPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/NodeSectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/PanelView.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/PanelView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/RefreshDialog.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/RefreshDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/RefreshSaveDialog.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/RefreshSaveDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionContainer.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionContainerNode.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionContainerNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionInnerPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionInnerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeInnerPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeInnerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodePanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeView.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionVisualTheme.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionVisualTheme.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SimpleDialogPanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SimpleDialogPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/StructureTreeView.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/StructureTreeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ToolBarDesignEditor.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/ToolBarDesignEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreeNode.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanel.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelDesignEditor.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelDesignEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelView.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookDataLoader.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookDataObject.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookPanel.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookToolBarMVElement.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookToolBarMVElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookTreePanel.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookTreePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookTreePanelMVElement.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/BookTreePanelMVElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/ChapterPanel.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/ChapterPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/ChapterTreePanel.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/ChapterTreePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/PanelFactory.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/PanelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/XmlMultiViewEditorTest.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/XmlMultiViewEditorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/bookmodel/Book.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/bookmodel/Book.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/bookmodel/Chapter.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/bookmodel/Chapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/util/Helper.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/util/Helper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/util/StepIterator.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/util/StepIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/ui/SimpleDialogPanelTest.java
+++ b/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/ui/SimpleDialogPanelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/DocumentParserFactory.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/DocumentParserFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/DocumentTypeParser.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/DocumentTypeParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/RetrieveEntry.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/RetrieveEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/Retriever.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/Retriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/RetrieverEngine.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/RetrieverEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/XMLCatalogProvider.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/XMLCatalogProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogAttribute.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogElement.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogEntry.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogWriteModel.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogWriteModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogWriteModelFactory.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/CatalogWriteModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/LSResourceResolverFactory.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/LSResourceResolverFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/ProjectCatalogSupport.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/ProjectCatalogSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/Utilities.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogEntryImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogEntryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogFileWrapper.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogFileWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogFileWrapperDOMImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogFileWrapperDOMImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelFactoryImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogWriteModelImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogWriteModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/LSResourceResolverImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/LSResourceResolverImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/XAMCatalogWriteModelImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/XAMCatalogWriteModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/Catalog.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/Catalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogAttributes.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogComponent.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogComponentFactory.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogModel.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogModelFactory.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogQNames.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogQNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogVisitor.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/CatalogVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/NextCatalog.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/NextCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/System.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/System.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogComponentFactoryImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogComponentImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogModelImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/CatalogModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/NextCatalogImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/NextCatalogImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/SyncUpdateVisitor.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/SyncUpdateVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/SystemImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/model/impl/SystemImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/CertificationPanel.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/CertificationPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/DocumentTypeSchemaWsdlParser.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/DocumentTypeSchemaWsdlParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/FileResourceRetriever.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/FileResourceRetriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/IConstants.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/IConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/ResourceRedirectException.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/ResourceRedirectException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/ResourceRetriever.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/ResourceRetriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/ResourceRetrieverFactory.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/ResourceRetrieverFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverEngineImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverEngineImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverImpl.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverTask.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/SecureURLResourceRetriever.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/SecureURLResourceRetriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/URLResourceRetriever.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/URLResourceRetriever.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/Util.java
+++ b/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/RetrieverTest.java
+++ b/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/RetrieverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelTest.java
+++ b/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/impl/XAMCatalogWriteModelTest.java
+++ b/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/impl/XAMCatalogWriteModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/model/TestUtil.java
+++ b/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/model/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/model/XAMCatalogModelTest.java
+++ b/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/model/XAMCatalogModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/test/ModelSourceTest.java
+++ b/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/test/ModelSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/test/TestCatalogModel.java
+++ b/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/test/TestCatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/AttributeResultItem.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/AttributeResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionPaintComponent.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionPaintComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionQuery.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionResultItem.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/DocumentationItem.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/DocumentationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/DocumentationQuery.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/DocumentationQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/ElementResultItem.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/ElementResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/EndTagResultItem.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/EndTagResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/RuntimeCatalogModel.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/RuntimeCatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/SchemaBasedCompletionProvider.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/SchemaBasedCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/TagLastCharResultItem.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/TagLastCharResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/ToolTipQuery.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/ToolTipQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/ValueResultItem.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/ValueResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/spi/CompletionContext.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/spi/CompletionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/spi/CompletionModelProvider.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/spi/CompletionModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CatalogModelProvider.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CatalogModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionContextImpl.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionModelEx.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionModelEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/DefaultModelProvider.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/DefaultModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/MetaSchemaModelProvider.java
+++ b/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/MetaSchemaModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/AbstractElementTest.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/AbstractElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/AbstractTestCase.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/AbstractTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/BasicCompletionTest.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/BasicCompletionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/CompletionPerfTest.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/CompletionPerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/MiscellaneousTest.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/MiscellaneousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/Util.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/util/TestCatalogModel.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/util/TestCatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/util/TestCatalogModelProvider.java
+++ b/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/util/TestCatalogModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/All.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/All.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Annotation.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Annotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Any.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Any.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AnyAttribute.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AnyAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AnyElement.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AnyElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AppInfo.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AppInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Attribute.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AttributeGroupReference.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AttributeGroupReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AttributeReference.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/AttributeReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/BoundaryFacet.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/BoundaryFacet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Cardinality.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Cardinality.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Choice.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Choice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexContent.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexContentDefinition.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexContentDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexContentRestriction.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexContentRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexExtension.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexExtensionDefinition.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexExtensionDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexTypeDefinition.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ComplexTypeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Constraint.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Constraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Derivation.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Derivation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Documentation.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Documentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Element.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ElementReference.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ElementReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Enumeration.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Enumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Extension.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Extension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Field.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Field.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Form.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Form.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/FractionDigits.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/FractionDigits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalAttribute.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalAttributeGroup.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalAttributeGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalComplexType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalComplexType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalElement.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalGroup.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalSimpleType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalSimpleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GlobalType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GroupReference.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/GroupReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Import.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Include.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Include.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Key.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Key.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/KeyRef.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/KeyRef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Length.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Length.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LengthFacet.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LengthFacet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/List.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/List.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalAttribute.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalAttributeContainer.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalAttributeContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalComplexType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalComplexType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalElement.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalGroupDefinition.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalGroupDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalSimpleType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalSimpleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/LocalType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MaxExclusive.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MaxExclusive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MaxInclusive.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MaxInclusive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MaxLength.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MaxLength.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MinExclusive.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MinExclusive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MinInclusive.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MinInclusive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MinLength.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/MinLength.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/NameableSchemaComponent.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/NameableSchemaComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Notation.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Notation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Occur.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Occur.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Pattern.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Redefine.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Redefine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ReferenceableSchemaComponent.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/ReferenceableSchemaComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Schema.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Schema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaComponent.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaComponentFactory.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaComponentReference.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaComponentReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaModel.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaModelFactory.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SchemaModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Selector.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Selector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Sequence.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Sequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SequenceDefinition.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SequenceDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleContent.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleContentDefinition.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleContentDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleContentRestriction.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleContentRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleExtension.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleRestriction.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleType.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleTypeDefinition.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleTypeDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleTypeRestriction.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/SimpleTypeRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/TotalDigits.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/TotalDigits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/TypeContainer.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/TypeContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Union.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Union.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Unique.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Unique.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Whitespace.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/Whitespace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AllImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AllImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AnnotationImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AnnotationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AnyAttributeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AnyAttributeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AnyImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AnyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AppInfoImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AppInfoImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AttributeGroupReferenceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AttributeGroupReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AttributeReferenceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/AttributeReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/BoundaryElement.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/BoundaryElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ChoiceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ChoiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonAnyImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonAnyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonAttributeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonAttributeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonComplexTypeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonComplexTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonExtensionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonExtensionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonLength.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonLength.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonSimpleRestrictionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonSimpleRestrictionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonSimpleTypeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/CommonSimpleTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ComplexContentImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ComplexContentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ComplexContentRestrictionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ComplexContentRestrictionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ComplexExtensionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ComplexExtensionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ConstraintImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ConstraintImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/DerivationsImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/DerivationsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/DocumentationImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/DocumentationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ElementImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ElementReferenceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ElementReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/EmbeddedSchemaModelImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/EmbeddedSchemaModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/EnumerationImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/EnumerationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/FieldImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/FieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/FractionDigitsImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/FractionDigitsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalAttributeGroupImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalAttributeGroupImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalAttributeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalAttributeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalComplexTypeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalComplexTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalComponentsIndexSupport.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalComponentsIndexSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalElementImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalGroupImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalGroupImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalReferenceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalSimpleTypeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GlobalSimpleTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GroupReferenceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/GroupReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ImportImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ImportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/IncludeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/IncludeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/KeyImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/KeyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/KeyRefImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/KeyRefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LengthImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LengthImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ListImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/ListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalAttributeBaseImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalAttributeBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalAttributeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalAttributeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalComplexTypeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalComplexTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalElementBaseImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalElementBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalElementImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalSimpleTypeImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/LocalSimpleTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MaxExclusiveImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MaxExclusiveImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MaxInclusiveImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MaxInclusiveImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MaxLengthImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MaxLengthImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MinExclusiveImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MinExclusiveImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MinInclusiveImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MinInclusiveImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MinLengthImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/MinLengthImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/NamedImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/NamedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/NotationImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/NotationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/PatternImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/PatternImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RedefineImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RedefineImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RefCacheSupport.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RefCacheSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RefactorVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RefactorVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaAttributes.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaComponentFactoryImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaComponentImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaElementNodeVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaElementNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaElements.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaModelImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SelectorImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SelectorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SequenceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SequenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleContentImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleContentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleContentRestrictionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleContentRestrictionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleExtensionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleExtensionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleTypeRestrictionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SimpleTypeRestrictionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SyncUnitReviewVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SyncUnitReviewVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/TotalDigitsImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/TotalDigitsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/UnionImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/UnionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/UniqueImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/UniqueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/Util.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/WhitespaceImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/WhitespaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/ChamelionResolver.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/ChamelionResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/ImportResolver.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/ImportResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/IncludeResolver.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/IncludeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/MultivalueMap.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/MultivalueMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/ResolveSession.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/resolver/ResolveSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/xdm/SyncUpdateVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/xdm/SyncUpdateVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/validation/SchemaXsdBasedValidator.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/validation/SchemaXsdBasedValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/DeepSchemaVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/DeepSchemaVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/DefaultSchemaVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/DefaultSchemaVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindGlobalReferenceVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindGlobalReferenceVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindReferredConstraintVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindReferredConstraintVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindSchemaComponentFromDOM.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindSchemaComponentFromDOM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindSubstitutions.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindSubstitutions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindUsageVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/FindUsageVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/Preview.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/Preview.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/PreviewImpl.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/PreviewImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/SchemaVisitor.java
+++ b/xml.schema.model/src/org/netbeans/modules/xml/schema/model/visitor/SchemaVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/GlobalComponentsIndexTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/GlobalComponentsIndexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/IncludeTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/IncludeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/KeyRefTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/KeyRefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/NamespaceLocation.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/NamespaceLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaComponentTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaModelPerformanceTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaModelPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaModelTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaRefCacheTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaRefCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/SchemaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/TargetNamespaceCachingTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/TargetNamespaceCachingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/TestCatalogModel.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/TestCatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/Util.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/AnnotationImplTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/AnnotationImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/MultiFileTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/MultiFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/RefactorVisitorTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/RefactorVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/SchemaComponentImplTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/SchemaComponentImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/CopyPasteTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/CopyPasteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/CutPasteTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/CutPasteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/RenameTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/RenameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/ReorderTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/ReorderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/SyncTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/SyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/SyncUpdateVisitorTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/SyncUpdateVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/UndoRedoTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/UndoRedoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/XMLModelMapperVisitorTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/XMLModelMapperVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/readwrite/LoanApplicationTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/readwrite/LoanApplicationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/readwrite/PurchaseOrderTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/readwrite/PurchaseOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/readwrite/TestSchemaReadWrite.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/readwrite/TestSchemaReadWrite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/resolver/FileObjectModelAccessProvider.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/resolver/FileObjectModelAccessProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/resolver/SchemaModelResolverTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/resolver/SchemaModelResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/resolver/TestCatalogModel2.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/resolver/TestCatalogModel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/validation/SchemaXsdBasedValidatorTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/validation/SchemaXsdBasedValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/visitor/FindSubstitutionsVisitorTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/visitor/FindSubstitutionsVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/visitor/FindUsageVisitorTest.java
+++ b/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/visitor/FindUsageVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/AbstractTreeDTD.java
+++ b/xml.tax/lib/src/org/netbeans/tax/AbstractTreeDTD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/AbstractTreeDocument.java
+++ b/xml.tax/lib/src/org/netbeans/tax/AbstractTreeDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/AbstractUtil.java
+++ b/xml.tax/lib/src/org/netbeans/tax/AbstractUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/CannotMergeException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/CannotMergeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/InvalidArgumentException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/InvalidArgumentException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/InvalidStateException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/InvalidStateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/NotSupportedException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/NotSupportedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/ReadOnlyException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/ReadOnlyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeAttlistDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeAttlistDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeAttlistDeclAttributeDef.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeAttlistDeclAttributeDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeAttribute.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeCDATASection.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeCDATASection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeCharacterData.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeCharacterData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeCharacterReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeCharacterReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeChild.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeChild.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeComment.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeComment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeConditionalSection.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeConditionalSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeDTD.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeDTD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeDTDFragment.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeDTDFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeDTDRoot.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeDTDRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeData.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeDocument.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeDocumentFragment.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeDocumentFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeDocumentRoot.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeDocumentRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeDocumentType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeDocumentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeElement.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeElementDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeElementDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeEntityDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeEntityDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeEntityReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeEntityReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeGeneralEntityReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeGeneralEntityReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeName.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeNamedObjectMap.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeNamedObjectMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeNamespace.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeNamespace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeNamespaceContext.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeNamespaceContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeNode.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeNodeDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeNodeDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeNotationDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeNotationDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeObject.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeObjectList.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeObjectList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeParameterEntityReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeParameterEntityReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeParentNode.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeParentNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeProcessingInstruction.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeProcessingInstruction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeText.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeUnsupportedOperationException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeUnsupportedOperationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/TreeUtilities.java
+++ b/xml.tax/lib/src/org/netbeans/tax/TreeUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/UnicodeClasses.java
+++ b/xml.tax/lib/src/org/netbeans/tax/UnicodeClasses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/Util.java
+++ b/xml.tax/lib/src/org/netbeans/tax/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/ANYType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/ANYType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/ANYTypeBeanInfo.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/ANYTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/ChildrenType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/ChildrenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/ChoiceType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/ChoiceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/ChoiceTypeBeanInfo.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/ChoiceTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/EMPTYType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/EMPTYType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/EMPTYTypeBeanInfo.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/EMPTYTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/LeafType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/LeafType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/MixedType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/MixedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/MixedTypeBeanInfo.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/MixedTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/NameType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/NameType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/NameTypeBeanInfo.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/NameTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/SequenceType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/SequenceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/SequenceTypeBeanInfo.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/SequenceTypeBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/TypeCollection.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/TypeCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/Util.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ChildrenParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ChildrenParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ChoiceParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ChoiceParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ChoiceSeqParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ChoiceSeqParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ContentParticleParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ContentParticleParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ContentSpecParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ContentSpecParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ListParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ListParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/MixedParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/MixedParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ModelParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ModelParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/MultiplicityParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/MultiplicityParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/ParserReader.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/ParserReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/decl/parser/SequenceParser.java
+++ b/xml.tax/lib/src/org/netbeans/tax/decl/parser/SequenceParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/AttrImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/AttrImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/Children.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/Children.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/CommentImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/CommentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/DOMImplementationImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/DOMImplementationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/DocumentImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/DocumentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/DocumentTypeImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/DocumentTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/ElementImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/ElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/NamedNodeMapImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/NamedNodeMapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/NodeImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/NodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/NodeListImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/NodeListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/ROException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/ROException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/TextImpl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/TextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/UOException.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/UOException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/dom/Wrapper.java
+++ b/xml.tax/lib/src/org/netbeans/tax/dom/Wrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/event/TreeEvent.java
+++ b/xml.tax/lib/src/org/netbeans/tax/event/TreeEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/event/TreeEventChangeSupport.java
+++ b/xml.tax/lib/src/org/netbeans/tax/event/TreeEventChangeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/event/TreeEventManager.java
+++ b/xml.tax/lib/src/org/netbeans/tax/event/TreeEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/event/TreeEventModel.java
+++ b/xml.tax/lib/src/org/netbeans/tax/event/TreeEventModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/event/TreeNodeContentEventModel.java
+++ b/xml.tax/lib/src/org/netbeans/tax/event/TreeNodeContentEventModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/event/Util.java
+++ b/xml.tax/lib/src/org/netbeans/tax/event/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/grammar/Grammar.java
+++ b/xml.tax/lib/src/org/netbeans/tax/grammar/Grammar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/grammar/Validator.java
+++ b/xml.tax/lib/src/org/netbeans/tax/grammar/Validator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/Convertors.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/Convertors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/RememberingReader.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/RememberingReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/StringUtil.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/StringUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeBuilder.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeEntityManager.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeEntityManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeEntityResolver.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeEntityResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeIOFilter.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeIOFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeInputSource.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeInputSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeInputStream.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeOutputResult.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeOutputResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeReader.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeStreamBuilderErrorHandler.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeStreamBuilderErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeStreamResult.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeStreamResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/TreeWriter.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/TreeWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/Util.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/XMLStringResult.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/XMLStringResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/io/XNIBuilder.java
+++ b/xml.tax/lib/src/org/netbeans/tax/io/XNIBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/AttlistDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/AttlistDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/Attribute.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/CDATASection.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/CDATASection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/CharacterReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/CharacterReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/Comment.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/Comment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/ConditionalSection.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/ConditionalSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/DTD.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/DTD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/Document.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/Document.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/DocumentFragment.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/DocumentFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/DocumentType.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/DocumentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/Element.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/ElementDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/ElementDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/EntityDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/EntityDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/GeneralEntityReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/GeneralEntityReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/NotationDecl.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/NotationDecl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/ParameterEntityReference.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/ParameterEntityReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/ProcessingInstruction.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/ProcessingInstruction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/spec/Text.java
+++ b/xml.tax/lib/src/org/netbeans/tax/spec/Text.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/traversal/TreeNodeFilter.java
+++ b/xml.tax/lib/src/org/netbeans/tax/traversal/TreeNodeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/traversal/TreeNodeIterator.java
+++ b/xml.tax/lib/src/org/netbeans/tax/traversal/TreeNodeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/traversal/TreeNodeWalker.java
+++ b/xml.tax/lib/src/org/netbeans/tax/traversal/TreeNodeWalker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/src/org/netbeans/tax/traversal/Util.java
+++ b/xml.tax/lib/src/org/netbeans/tax/traversal/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/AbstractFactoryTest.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/AbstractFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/CreateXMLTest.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/CreateXMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/EncodingTest.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/EncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/FactoryTest.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/FactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/FactoryTestGenerator.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/FactoryTestGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/TestUtil.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/XMLCloneTest.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/XMLCloneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/io/TestUtil.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/io/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/io/TreeBuilderTest.java
+++ b/xml.tax/lib/test/qa-functional/src/org/netbeans/tax/io/TreeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/unit/src/org/netbeans/tax/dom/WrapperTest.java
+++ b/xml.tax/lib/test/unit/src/org/netbeans/tax/dom/WrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/unit/src/org/netbeans/tax/test/Attribute.java
+++ b/xml.tax/lib/test/unit/src/org/netbeans/tax/test/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/lib/test/unit/src/org/netbeans/tax/test/Simple.java
+++ b/xml.tax/lib/test/unit/src/org/netbeans/tax/test/Simple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/TAXProvider.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/TAXProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/Lib.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/Lib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/TreeObjectListProxyListener.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/TreeObjectListProxyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/Util.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/AbstractTreeCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/AbstractTreeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeAttlistDeclAttributeDefCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeAttlistDeclAttributeDefCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeAttlistDeclCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeAttlistDeclCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeAttributeCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeAttributeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeCDATASectionCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeCDATASectionCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeCharacterReferenceCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeCharacterReferenceCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeCommentCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeCommentCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeConditionalSectionCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeConditionalSectionCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDTDCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDTDCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDocumentCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDocumentCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDocumentFragmentCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDocumentFragmentCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDocumentTypeCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeDocumentTypeCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeElementCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeElementCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeElementDeclCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeElementDeclCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeEntityDeclCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeEntityDeclCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeGeneralEntityReferenceCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeGeneralEntityReferenceCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeNotationDeclCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeNotationDeclCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeParameterEntityReferenceCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeParameterEntityReferenceCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeProcessingInstructionCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeProcessingInstructionCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeTextCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/TreeTextCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/Util.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/customizer/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/EncodingEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/EncodingEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/NullChoicePropertyEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/NullChoicePropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/NullStringCustomEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/NullStringCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/NullStringEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/NullStringEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/StandaloneEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/StandaloneEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeAttlistDeclAttributeListCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeAttlistDeclAttributeListCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeAttlistDeclAttributeListEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeAttlistDeclAttributeListEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeElementAttributeListCustomizer.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeElementAttributeListCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeElementAttributeListEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeElementAttributeListEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/Util.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/VersionEditor.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/VersionEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/package-info.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/cookies/DTDTreeRepresentation.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/cookies/DTDTreeRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeDocumentCookie.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeDocumentCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookie.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeRepresentation.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/cookies/Util.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/cookies/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/cookies/XMLTreeRepresentation.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/cookies/XMLTreeRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/parser/DTDParsingSupport.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/parser/DTDParsingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParserLoader.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParserLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParsingSupport.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParsingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/parser/TreeStreamSource.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/parser/TreeStreamSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/parser/Util.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/parser/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/parser/XMLParsingSupport.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/parser/XMLParsingSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/traversal/TreeNodeFilterHandle.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/traversal/TreeNodeFilterHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/util/AbstractUtil.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/util/AbstractUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tax/src/org/netbeans/modules/xml/tax/util/TAXUtil.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/util/TAXUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/api/XMLDefaultTokenContext.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/api/XMLDefaultTokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/indent/XMLFormatter.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/indent/XMLFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/obsolete90/ComplexValueSettingsFactory.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/obsolete90/ComplexValueSettingsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/obsolete90/XMLSyntaxBridgeImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/obsolete90/XMLSyntaxBridgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/DTDSyntaxTokenMapper.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/DTDSyntaxTokenMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/DTDTokenContext.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/DTDTokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/SyntaxElement.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/SyntaxElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/UnicodeClasses.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/UnicodeClasses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLDefaultSyntax.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLDefaultSyntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxTokenMapper.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxTokenMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLTokenContext.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLTokenContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLTokenIDs.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLTokenIDs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/AttrImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/AttrImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/CDATASectionImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/CDATASectionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/CommentImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/CommentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/DOMImplementationImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/DOMImplementationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/DocumentImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/DocumentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/DocumentTypeImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/DocumentTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/EmptyTag.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/EmptyTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/EndTag.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/EndTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/EntityReferenceImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/EntityReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/ProcessingInstructionImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/ProcessingInstructionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/StartTag.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/StartTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/SyntaxNode.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/SyntaxNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/Tag.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/Tag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/TextImpl.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/TextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/Util.java
+++ b/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/dom/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/indent/XMLFormatterTest.java
+++ b/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/indent/XMLFormatterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/syntax/AbstractTestCase.java
+++ b/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/syntax/AbstractTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupportTest.java
+++ b/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/ComplexValueSettingsFactory.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/ComplexValueSettingsFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/XmlCommentHandler.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/XmlCommentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/api/XMLFormatUtil.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/api/XMLFormatUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/api/XMLTextUtils.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/api/XMLTextUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/api/dom/SyntaxElement.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/api/dom/SyntaxElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/api/dom/TagElement.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/api/dom/TagElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/api/dom/XMLSyntaxSupport.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/api/dom/XMLSyntaxSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/bracematch/XMLBraceMatcher.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/bracematch/XMLBraceMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/bracematch/XMLBraceMatcherFactory.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/bracematch/XMLBraceMatcherFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/breadcrumbs/BreadcrumbProvider.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/breadcrumbs/BreadcrumbProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/breadcrumbs/EditorRegistryMonitor.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/breadcrumbs/EditorRegistryMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/AttributeResultItem.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/AttributeResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/DefaultContext.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/DefaultContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/ElementResultItem.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/ElementResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/EmptyQuery.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/EmptyQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/EndTagAutocompletionResultItem.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/EndTagAutocompletionResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/EntityRefResultItem.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/EntityRefResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/GrammarManager.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/GrammarManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/IconStore.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/IconStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/NodeSelector.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/NodeSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/ReloadActionPerformer.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/ReloadActionPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/SyntaxQueryHelper.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/SyntaxQueryHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/ValueResultItem.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/ValueResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionProvider.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionQuery.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionResultItemPaintComponent.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionResultItemPaintComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/completion/XMLResultItem.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/completion/XMLResultItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/AttrImpl.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/AttrImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/BaseSyntaxElement.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/BaseSyntaxElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/CDATASection.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/CDATASection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/Comment.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/Comment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/Document.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/Document.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/DocumentType.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/DocumentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/EmptyTag.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/EmptyTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/EndTag.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/EndTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/EntityReference.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/EntityReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/ProcessingInstruction.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/ProcessingInstruction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/StartTag.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/StartTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/SyntaxNode.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/SyntaxNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/Tag.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/Tag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/dom/TextImpl.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/dom/TextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/folding/TokenElement.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/folding/TokenElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/folding/XmlFoldManager.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/folding/XmlFoldManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/folding/XmlFoldManagerFactory.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/folding/XmlFoldManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/folding/XmlFoldTypes.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/folding/XmlFoldTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/DTDFormatter.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/DTDFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/DTDIndentEngine.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/DTDIndentEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/DTDIndentEngineBeanInfo.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/DTDIndentEngineBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/LineBreakHook.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/LineBreakHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/XMLFormatSupport.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/XMLFormatSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentEngine.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentEngineBeanInfo.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentEngineBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentTask.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentTaskFactory.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/XMLIndentTaskFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/indent/XMLLexerFormatter.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/indent/XMLLexerFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/FilterActions.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/FilterActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/FiltersDescription.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/FiltersDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/FiltersManager.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/FiltersManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/HTMLTextEncoder.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/HTMLTextEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/NavigatorContent.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/NavigatorContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/NavigatorTreeCellRenderer.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/NavigatorTreeCellRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/TapPanel.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/TapPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/TreeNodeAdapter.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/TreeNodeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/TrivialLayout.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/TrivialLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/XMLNavigatorPanel.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/XMLNavigatorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/base/AbstractXMLNavigatorContent.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/base/AbstractXMLNavigatorContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/navigator/base/AbstractXMLNavigatorPanel.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/navigator/base/AbstractXMLNavigatorPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/structure/XMLConstants.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/structure/XMLConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/structure/XMLDocumentModelProvider.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/structure/XMLDocumentModelProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/DTDKit.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/DTDKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/ENTKit.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/ENTKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/UniKit.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/UniKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/XMLKit.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/XMLKit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/bridge/LegacySyntaxBridge.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/bridge/LegacySyntaxBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/DTDSyntax.jj
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/DTDSyntax.jj
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/XMLSyntax.jj
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/XMLSyntax.jj
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/XMLSyntaxConstants.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/XMLSyntaxConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/XMLSyntaxTokenManager.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/XMLSyntaxTokenManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/ASCIICharStream.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/ASCIICharStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/CharStream.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/CharStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJConstants.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJEditorSyntax.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJEditorSyntax.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJMapperInterface.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJMapperInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJStateInfo.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJStateInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJSyntaxInterface.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJSyntaxInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJTokenID.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/JJTokenID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/SimpleCharStream.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/SimpleCharStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/StringParserInput.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/StringParserInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/UCode_CharStream.java
+++ b/xml.text/src/org/netbeans/modules/xml/text/syntax/javacc/lib/UCode_CharStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/completion/CompletionJTest.java
+++ b/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/completion/CompletionJTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/completion/TestUtil.java
+++ b/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/completion/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/syntax/ColoringTest.java
+++ b/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/syntax/ColoringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/syntax/TestUtil.java
+++ b/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/syntax/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/AbstractTestCase.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/AbstractTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/bracematch/XMLBraceMatcherTest.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/bracematch/XMLBraceMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/completion/ElementResultItemDocumentationTest.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/completion/ElementResultItemDocumentationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/dom/XMLSyntaxSupportTest.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/dom/XMLSyntaxSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/indent/XMLLexerFormatterTest.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/indent/XMLLexerFormatterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupportTest.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/test/RepositoryImpl.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/test/RepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.text/test/unit/src/org/netbeans/modules/xml/text/test/TestBase.java
+++ b/xml.text/test/unit/src/org/netbeans/modules/xml/text/test/TestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDOMScannerAction.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDOMScannerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDocumentHandlerAction.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDocumentHandlerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/DTDGenerateSupportFactory.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/DTDGenerateSupportFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ElementBindings.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ElementBindings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ElementDeclarations.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ElementDeclarations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateSupportUtils.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateSupportUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerationUtils.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ParsletBindings.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ParsletBindings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsGenerator.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsHandler.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsHandlerImpl.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsParser.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorAbstractPanel.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorAbstractPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorCustomizer.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorFilePanel.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorFilePanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorMethodPanel.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorMethodPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorModel.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorParsletPanel.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorParsletPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorSupport.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorVersionPanel.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorVersionPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SourceUtils.java
+++ b/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/test/qa-functional/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupportTest.java
+++ b/xml.tools.java/test/qa-functional/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools.java/test/qa-functional/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorJTest.java
+++ b/xml.tools.java/test/qa-functional/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorJTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/actions/CSSStyleAction.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/actions/CSSStyleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/actions/CheckAction.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/actions/CheckAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/actions/CheckDTDAction.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/actions/CheckDTDAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/actions/ValidateAction.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/actions/ValidateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/doclet/DTDDoclet.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/doclet/DTDDoclet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/doclet/DocletAction.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/doclet/DocletAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/generator/GenerateDTDSupport.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/generator/GenerateDTDSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/generator/SelectFileDialog.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/generator/SelectFileDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/generator/Util.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/generator/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/generator/ValidatingTextField.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/generator/ValidatingTextField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/generator/XMLGenerateAction.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/generator/XMLGenerateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/generator/XMLGenerateCookie.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/generator/XMLGenerateCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/src/org/netbeans/modules/xml/tools/generator/XMLGenerateSupportFactory.java
+++ b/xml.tools/src/org/netbeans/modules/xml/tools/generator/XMLGenerateSupportFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/AbstractCheckTest.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/AbstractCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/CheckActionTest.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/CheckActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/QaIOReporter.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/QaIOReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/TestUtil.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/ValidateActionTest.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/actions/ValidateActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/doclet/DTDDocletTest.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/doclet/DTDDocletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/doclet/TestUtil.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/doclet/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/generator/GenerateDTDSupportTest.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/generator/GenerateDTDSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/generator/TestUtil.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xml/tools/generator/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xsl/action/TestUtil.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xsl/action/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.tools/test/qa-functional/src/org/netbeans/modules/xsl/action/TransformationActionTest.java
+++ b/xml.tools/test/qa-functional/src/org/netbeans/modules/xsl/action/TransformationActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Binding.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Binding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingFault.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingInput.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingOperation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingOutput.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/BindingOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Definitions.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Definitions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Documentation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Documentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/ExtensibilityElement.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/ExtensibilityElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Fault.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Fault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Import.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Import.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Input.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Input.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Message.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/NotificationOperation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/NotificationOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/OneWayOperation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/OneWayOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Operation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Operation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/OperationParameter.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/OperationParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Output.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Output.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Part.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Part.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Port.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Port.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/PortType.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/PortType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/ReferenceableExtensibilityElement.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/ReferenceableExtensibilityElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/ReferenceableWSDLComponent.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/ReferenceableWSDLComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/RequestResponseOperation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/RequestResponseOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Service.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Service.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/SolicitResponseOperation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/SolicitResponseOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Types.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/Types.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLComponent.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLComponentFactory.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLModel.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLModelFactory.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/WSDLModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPAddress.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPBinding.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPComponent.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPOperation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPQName.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPQName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPUrlEncoded.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPUrlEncoded.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPUrlReplacement.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/HTTPUrlReplacement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPAddressImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPAddressImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPAttribute.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPBindingImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPBindingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPComponentImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPElementFactoryProvider.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPElementFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPOperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPUrlEncodedImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPUrlEncodedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPUrlReplacementImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/impl/HTTPUrlReplacementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/validation/HTTPComponentValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/http/validation/HTTPComponentValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEComponent.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEContent.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEMimeXml.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEMimeXml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEMultipartRelated.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEMultipartRelated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEPart.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEPart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEQName.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/MIMEQName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEAttribute.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEComponentImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEComponentUpdater.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEComponentUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEContentImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEContentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEElementFactoryProvider.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEElementFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEMimeXmlImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEMimeXmlImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEMultipartRelatedImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEMultipartRelatedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEPartImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/MIMEPartImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/PartReference.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/impl/PartReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/validation/MIMEComponentValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/validation/MIMEComponentValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/validation/WSIAPValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/mime/validation/WSIAPValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPAddress.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPBinding.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPBinding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPBody.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPComponent.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPFault.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPHeader.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPHeaderBase.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPHeaderBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPHeaderFault.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPHeaderFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPMessageBase.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPMessageBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPOperation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPQName.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/SOAPQName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/FaultReference.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/FaultReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/PartReference.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/PartReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPAddressImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPAddressImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPAttribute.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPBindingImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPBindingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPBodyImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPBodyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPComponentImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPComponentUpdater.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPComponentUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPElementFactoryProvider.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPElementFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPFaultImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPFaultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPHeaderBaseImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPHeaderBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPHeaderFaultImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPHeaderFaultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPHeaderImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPHeaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPMessageBaseImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPMessageBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPOperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/impl/SOAPOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/MessagePart.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/MessagePart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/SOAPComponentValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/SOAPComponentValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/SOAPComponentVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/SOAPComponentVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Address.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Binding.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Binding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Body.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Body.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Component.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Component.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Fault.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Fault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Header.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Header.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12HeaderBase.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12HeaderBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12HeaderFault.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12HeaderFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12MessageBase.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12MessageBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Operation.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12Operation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12QName.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/SOAP12QName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/FaultReference.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/FaultReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/PartReference.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/PartReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12AddressImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12AddressImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12Attribute.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12BindingImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12BindingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12BodyImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12BodyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12ComponentImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12ComponentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12ComponentUpdater.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12ComponentUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12ElementFactoryProvider.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12ElementFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12FaultImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12FaultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12HeaderBaseImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12HeaderBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12HeaderFaultImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12HeaderFaultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12HeaderImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12HeaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12MessageBaseImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12MessageBaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12OperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/impl/SOAP12OperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/MessagePart.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/MessagePart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/SOAP12ComponentValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/SOAP12ComponentValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/SOAP12ComponentVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/SOAP12ComponentVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/WSDLSchema.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/WSDLSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/impl/SchemaReferenceImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/impl/SchemaReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/impl/WSDLSchemaFactory.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/impl/WSDLSchemaFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/impl/WSDLSchemaImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/xsd/impl/WSDLSchemaImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingFaultImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingFaultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingInputImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingInputImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingOperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingOutputImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/BindingOutputImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ChildComponentUpdateVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ChildComponentUpdateVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/DefinitionsImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/DefinitionsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/DocumentationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/DocumentationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ElementFactoryRegistry.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ElementFactoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/FaultImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/FaultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/GlobalReferenceImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/GlobalReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ImportImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ImportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/InputImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/InputImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/MessageImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/MessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/NamedImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/NamedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/NotificationOperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/NotificationOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OneWayOperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OneWayOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OperationParameterImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OperationParameterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OperationReference.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OperationReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OutputImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/OutputImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/PartImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/PartImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/PortImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/PortImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/PortTypeImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/PortTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/RequestResponseOperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/RequestResponseOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ServiceImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/ServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/SolicitResponseOperationImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/SolicitResponseOperationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/SyncReviewVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/SyncReviewVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/TypeCollection.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/TypeCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/TypesImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/TypesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/Util.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLAttribute.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLComponentFactoryImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLComponentFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLElementFactoryProvider.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLElementFactoryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLModelImpl.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLQNames.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/impl/WSDLQNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/ElementFactory.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/ElementFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/GenericExtensibilityElement.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/GenericExtensibilityElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/NamedExtensibilityElementBase.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/NamedExtensibilityElementBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/WSDLComponentBase.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/spi/WSDLComponentBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/ChildVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/ChildVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/DefaultVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/DefaultVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/FindReferencedVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/FindReferencedVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/FindWSDLComponent.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/FindWSDLComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/WSDLModelVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/WSDLModelVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/WSDLUtilities.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/WSDLUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/WSDLVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/visitor/WSDLVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/ValidatorSchemaFactoryRegistry.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/ValidatorSchemaFactoryRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLInlineSchemaValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLInlineSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLSchemaValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLSemanticValidator.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLSemanticValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/ValidateConfiguration.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/ValidateConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/ValidateSupport.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/ValidateSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/ValidationUtils.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/ValidationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/WSDLSemanticsVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/WSDLSemanticsVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/schema/SchemaSemanticsVisitor.java
+++ b/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/visitor/schema/SchemaSemanticsVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/DefinitionsTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/DefinitionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/ImportTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/ImportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/NamespaceLocation.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/NamespaceLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/Util.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/WSDLModelFactoryTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/WSDLModelFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/impl/ChildComponentUpdateVisitorTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/impl/ChildComponentUpdateVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/impl/SyncUpdateTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/impl/SyncUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/impl/UndoRedoTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/impl/UndoRedoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/readwrite/SchemaReadWriteTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/readwrite/SchemaReadWriteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/readwrite/SimpleTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/readwrite/SimpleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/readwrite/TestReadWrite.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/readwrite/TestReadWrite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/spi/GenericExtensibilityElementTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/spi/GenericExtensibilityElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/spi/WSDLComponentBaseTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/spi/WSDLComponentBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/visitor/FindWSDLComponentTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/visitor/FindWSDLComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/MyModelSource.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/MyModelSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/ValidationHelper.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/ValidationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/ValidatorSchemaFactoryRegistryTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/ValidatorSchemaFactoryRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLInlineSchemaValidatorTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLInlineSchemaValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLSchemaValidatorTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLSchemaValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLSemanticValidatorTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLSemanticValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/visitor/WSDLSemanticsVisitorTest.java
+++ b/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/visitor/WSDLSemanticsVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/AbstractComponent.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/AbstractComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/AbstractModel.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/AbstractModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/AbstractModelFactory.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/AbstractModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/AbstractReference.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/AbstractReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/Component.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/Component.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/ComponentEvent.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/ComponentEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/ComponentListener.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/ComponentListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/ComponentUpdater.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/ComponentUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/EmbeddableRoot.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/EmbeddableRoot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/Model.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/ModelAccess.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/ModelAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/ModelSource.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/ModelSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/Nameable.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/Nameable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/Named.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/Named.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/NamedReferenceable.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/NamedReferenceable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/Reference.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/Reference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/Referenceable.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/Referenceable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/AbstractDocumentComponent.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/AbstractDocumentComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/AbstractDocumentModel.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/AbstractDocumentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/AbstractNamedComponentReference.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/AbstractNamedComponentReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/Attribute.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/ChangeInfo.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/ChangeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/ComponentFactory.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/ComponentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentComponent.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentComponent2.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentComponent2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentModel.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentModelAccess.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentModelAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentModelAccess2.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/DocumentModelAccess2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/ElementIdentity.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/ElementIdentity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/NamedComponentReference.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/NamedComponentReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/ReadOnlyAccess.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/ReadOnlyAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/SyncUnit.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/SyncUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/dom/Utils.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/dom/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/locator/CatalogModel.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/locator/CatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/locator/CatalogModelException.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/locator/CatalogModelException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/locator/CatalogModelFactory.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/locator/CatalogModelFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/spi/DocumentModelAccessProvider.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/spi/DocumentModelAccessProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/spi/ModelAccessProvider.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/spi/ModelAccessProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/spi/Validation.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/spi/Validation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/spi/ValidationResult.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/spi/ValidationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/spi/Validator.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/spi/Validator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/src/org/netbeans/modules/xml/xam/spi/XsdBasedValidator.java
+++ b/xml.xam/src/org/netbeans/modules/xml/xam/spi/XsdBasedValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/AbstractComponentTest.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/AbstractComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/AbstractModelTest.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/AbstractModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestAttribute.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestComponent.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestComponent2.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestComponent2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestModel.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestModel2.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestModel2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestVisitor.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/TestVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/Util.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/dom/ReadOnlyAccessTest.java
+++ b/xml.xam/test/unit/src/org/netbeans/modules/xml/xam/dom/ReadOnlyAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/XDMModel.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/XDMModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/XDMModelUndoableEdit.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/XDMModelUndoableEdit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Add.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Add.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Change.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Change.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/DefaultElementIdentity.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/DefaultElementIdentity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Delete.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Delete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/DiffFinder.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/DiffFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Difference.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Difference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/MergeDiff.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/MergeDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/NodeIdDiffFinder.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/NodeIdDiffFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/NodeInfo.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/NodeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/SyncPreparation.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/SyncPreparation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/XDMTreeDiff.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/XDMTreeDiff.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/XDMUtil.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/XDMUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/package-info.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Attribute.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/CData.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/CData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Comment.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Comment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Convertors.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Convertors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Document.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Document.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Element.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Element.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NamedNodeMapImpl.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NamedNodeMapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Node.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NodeImpl.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Text.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Text.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Token.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Token.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/TokenType.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/TokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/XMLSyntaxParser.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/XMLSyntaxParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/package-info.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/package-info.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/ChildVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/ChildVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/CompareVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/CompareVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/DefaultVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/DefaultVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/EndPositionFinderVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/EndPositionFinderVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/FindNamespaceVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/FindNamespaceVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/FindVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/FindVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/FlushVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/FlushVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/HashNamespaceResolver.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/HashNamespaceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/MergeVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/MergeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/NamespaceRefactorVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/NamespaceRefactorVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/NodeByPositionVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/NodeByPositionVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/PathFromRootVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/PathFromRootVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/PositionFinderVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/PositionFinderVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/PrintVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/PrintVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/Utils.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/XMLNodeVisitor.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/XMLNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/XPathFinder.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/XPathFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/package-info.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/XDMAccess.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/XDMAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/XDMAccessProvider.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/XDMAccessProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/XDMListener.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/XDMListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/package-info.java
+++ b/xml.xdm/src/org/netbeans/modules/xml/xdm/xam/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/AbstractComponentTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/AbstractComponentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/AbstractModelTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/AbstractModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/NsPrefixCreationUndoTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/NsPrefixCreationUndoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestAttribute3.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestAttribute3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestComponent3.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestComponent3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestComponentUpdater3.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestComponentUpdater3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestModel3.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestModel3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestVisitor3.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xam/TestVisitor3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/Util.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/XDMModelTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/XDMModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/diff/DiffFinderTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/diff/DiffFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/diff/MergeDiffTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/diff/MergeDiffTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/diff/XDMUtilTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/diff/XDMUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/AttributeTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/AttributeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/CDataTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/CDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/CommentTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/CommentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/DocumentTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/DocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/ElementTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/ElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/TextTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/TextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/XMLSyntaxParserTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/nodes/XMLSyntaxParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/perf/XDMPerfNumberTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/perf/XDMPerfNumberTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/FindNamespaceVisitorTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/FindNamespaceVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/FindVisitorTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/FindVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/PathFromRootVisitorTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/PathFromRootVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/PositionFinderVisitorTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/PositionFinderVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/UtilsTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/UtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/XPathFinderTest.java
+++ b/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/visitor/XPathFinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/CoreModuleInstall.java
+++ b/xml/src/org/netbeans/modules/xml/CoreModuleInstall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/DTDDataLoader.java
+++ b/xml/src/org/netbeans/modules/xml/DTDDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/DTDDataLoaderBeanInfo.java
+++ b/xml/src/org/netbeans/modules/xml/DTDDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/DTDDataObject.java
+++ b/xml/src/org/netbeans/modules/xml/DTDDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/EntityDataLoader.java
+++ b/xml/src/org/netbeans/modules/xml/EntityDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/EntityDataLoaderBeanInfo.java
+++ b/xml/src/org/netbeans/modules/xml/EntityDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/EntityDataObject.java
+++ b/xml/src/org/netbeans/modules/xml/EntityDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/XMLDataLoader.java
+++ b/xml/src/org/netbeans/modules/xml/XMLDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/XMLDataLoaderBeanInfo.java
+++ b/xml/src/org/netbeans/modules/xml/XMLDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/XMLDataObject.java
+++ b/xml/src/org/netbeans/modules/xml/XMLDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/XMLDataObjectLook.java
+++ b/xml/src/org/netbeans/modules/xml/XMLDataObjectLook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/actions/CheckEntityAction.java
+++ b/xml/src/org/netbeans/modules/xml/actions/CheckEntityAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/actions/CollectDTDAction.java
+++ b/xml/src/org/netbeans/modules/xml/actions/CollectDTDAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
+++ b/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/actions/CollectXMLAction.java
+++ b/xml/src/org/netbeans/modules/xml/actions/CollectXMLAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/actions/InputOutputReporter.java
+++ b/xml/src/org/netbeans/modules/xml/actions/InputOutputReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/actions/XMLUpdateDocumentAction.java
+++ b/xml/src/org/netbeans/modules/xml/actions/XMLUpdateDocumentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/actions/XMLViewActions.java
+++ b/xml/src/org/netbeans/modules/xml/actions/XMLViewActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/cookies/CookieFactory.java
+++ b/xml/src/org/netbeans/modules/xml/cookies/CookieFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/cookies/CookieFactoryCreator.java
+++ b/xml/src/org/netbeans/modules/xml/cookies/CookieFactoryCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/cookies/CookieManager.java
+++ b/xml/src/org/netbeans/modules/xml/cookies/CookieManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/cookies/CookieManagerCookie.java
+++ b/xml/src/org/netbeans/modules/xml/cookies/CookieManagerCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/cookies/DataObjectCookieManager.java
+++ b/xml/src/org/netbeans/modules/xml/cookies/DataObjectCookieManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/cookies/DefaultCookieManager.java
+++ b/xml/src/org/netbeans/modules/xml/cookies/DefaultCookieManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/cookies/UpdateDocumentCookie.java
+++ b/xml/src/org/netbeans/modules/xml/cookies/UpdateDocumentCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/lib/A11YUtil.java
+++ b/xml/src/org/netbeans/modules/xml/lib/A11YUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/lib/FileUtilities.java
+++ b/xml/src/org/netbeans/modules/xml/lib/FileUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/lib/GuiUtil.java
+++ b/xml/src/org/netbeans/modules/xml/lib/GuiUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/DTDSyncSupport.java
+++ b/xml/src/org/netbeans/modules/xml/sync/DTDSyncSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
+++ b/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/EntitySyncSupport.java
+++ b/xml/src/org/netbeans/modules/xml/sync/EntitySyncSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/FileRepresentation.java
+++ b/xml/src/org/netbeans/modules/xml/sync/FileRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/Representation.java
+++ b/xml/src/org/netbeans/modules/xml/sync/Representation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/SyncRepresentation.java
+++ b/xml/src/org/netbeans/modules/xml/sync/SyncRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/SyncSupport.java
+++ b/xml/src/org/netbeans/modules/xml/sync/SyncSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/Synchronizator.java
+++ b/xml/src/org/netbeans/modules/xml/sync/Synchronizator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/sync/XMLSyncSupport.java
+++ b/xml/src/org/netbeans/modules/xml/sync/XMLSyncSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/text/DTDTextRepresentation.java
+++ b/xml/src/org/netbeans/modules/xml/text/DTDTextRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/text/EntityTextRepresentation.java
+++ b/xml/src/org/netbeans/modules/xml/text/EntityTextRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/text/TextEditorComponent.java
+++ b/xml/src/org/netbeans/modules/xml/text/TextEditorComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
+++ b/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/text/TextRepresentation.java
+++ b/xml/src/org/netbeans/modules/xml/text/TextRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/text/XMLTextRepresentation.java
+++ b/xml/src/org/netbeans/modules/xml/text/XMLTextRepresentation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/tree/ModuleEntityResolver.java
+++ b/xml/src/org/netbeans/modules/xml/tree/ModuleEntityResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/util/AbstractUtil.java
+++ b/xml/src/org/netbeans/modules/xml/util/AbstractUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/util/Convertors.java
+++ b/xml/src/org/netbeans/modules/xml/util/Convertors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/util/DefaultXmlFileEncodingQueryImpl.java
+++ b/xml/src/org/netbeans/modules/xml/util/DefaultXmlFileEncodingQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/util/LookupManager.java
+++ b/xml/src/org/netbeans/modules/xml/util/LookupManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/util/StreamFileObject.java
+++ b/xml/src/org/netbeans/modules/xml/util/StreamFileObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/util/StreamFileSystem.java
+++ b/xml/src/org/netbeans/modules/xml/util/StreamFileSystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/util/Util.java
+++ b/xml/src/org/netbeans/modules/xml/util/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/AbstractPanel.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/AbstractPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/DocumentModel.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/DocumentModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/SchemaParser.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/SchemaParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/XMLContentAttributes.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/XMLContentAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/XMLContentPanel.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/XMLContentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/XMLGeneratorVisitor.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/XMLGeneratorVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/DTDPanel.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/DTDPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/DTDParser.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/DTDParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/DTDWizardIterator.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/DTDWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/DocumentPanel.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/DocumentPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/ExternalReferenceDataNode.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/ExternalReferenceDataNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/ExternalReferenceDecorator.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/ExternalReferenceDecorator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/FolderNode.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/FolderNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/NamespaceChildren.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/NamespaceChildren.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaImportGUI.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaImportGUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaObject.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaPanel.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/WaitNode.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/WaitNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/src/org/netbeans/modules/xml/wizard/impl/XMLWizardIterator.java
+++ b/xml/src/org/netbeans/modules/xml/wizard/impl/XMLWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/actions/DTDActionsTest.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/actions/DTDActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/actions/WebPagesNode.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/actions/WebPagesNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/actions/XMLActionsTest.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/actions/XMLActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/CoreTemplatesTest.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/CoreTemplatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/Fail.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/Fail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/XMLTest.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/XMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/DTDOptionsWizardOperator.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/DTDOptionsWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/NewXMLFileTestTypeWizardOperator.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/NewXMLFileTestTypeWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/NewXMLFileWizardOperator.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/NewXMLFileWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/TransformationWizardOperator.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/TransformationWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/XSDOptionsWizardOperator.java
+++ b/xml/test/qa-functional/src/org/netbeans/xml/test/core/wizardoperator/XSDOptionsWizardOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/css/actions/CheckCSSAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/css/actions/CheckCSSAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/css/actions/CopyHTMLStyleAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/css/actions/CopyHTMLStyleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/css/actions/CopyXMLStyleAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/css/actions/CopyXMLStyleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/SelectXSLTScriptDialog.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/SelectXSLTScriptDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/SelectXSLTSourceDialog.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/SelectXSLTSourceDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/XSLTransformationDialog.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/XSLTransformationDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/ActionsTest.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/ActionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/CheckDTDAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/CheckDTDAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/CheckXMLAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/CheckXMLAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateCSSAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateCSSAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateDOMTreeScannerAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateDOMTreeScannerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateDTDAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateDTDAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateDocumentationAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/GenerateDocumentationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/MountCatalogAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/MountCatalogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewAttributeAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewAttributeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewCDATAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewCDATAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewCharRefAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewCharRefAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewCommentAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewCommentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewDoctypeAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewDoctypeAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewElementAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewEntityReferenceAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewEntityReferenceAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewPIAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewPIAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewTextAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NewTextAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NormalizeElementAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/NormalizeElementAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/RefreshCatalogAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/RefreshCatalogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/ReloadDocumentAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/ReloadDocumentAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/SAXDocumentHandlerWizardAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/SAXDocumentHandlerWizardAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/TestUtil.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/UnmountCatalogAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/UnmountCatalogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/ValidateXMLAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/ValidateXMLAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/data/CascadeStyleSheet.css
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/actions/data/CascadeStyleSheet.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/MountCatalogDialogOperator.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/MountCatalogDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/NbCatalogCustomizerDialogOperator.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/NbCatalogCustomizerDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/OASISCatalogCustomizerDialogOperator.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/OASISCatalogCustomizerDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/XMLCatalogCustomizerDialogOperator.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/XMLCatalogCustomizerDialogOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/actions/MountCatalogAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/actions/MountCatalogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/actions/UnmountCatalogAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/actions/UnmountCatalogAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/AbstractNode.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/AbstractNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogEntryNode.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogEntryNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogNode.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/CatalogNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/XMLEntityCatalogsNode.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/catalog/nodes/XMLEntityCatalogsNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/ConfirmChangesDialog.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/ConfirmChangesDialog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage1.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage2.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage3.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage4.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xml/saxwizard/SAXDocumentHandlerWizardPage4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xsl/actions/EditScenariosAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xsl/actions/EditScenariosAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xsl/actions/TransformAction.java
+++ b/xml/test/qa-lib/src/org/netbeans/jellytools/modules/xsl/actions/TransformAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/tests/xml/AbstractTemplatesTest.java
+++ b/xml/test/qa-lib/src/org/netbeans/tests/xml/AbstractTemplatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/tests/xml/AbstractTestUtil.java
+++ b/xml/test/qa-lib/src/org/netbeans/tests/xml/AbstractTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/tests/xml/JXTest.java
+++ b/xml/test/qa-lib/src/org/netbeans/tests/xml/JXTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/tests/xml/TestUtil.java
+++ b/xml/test/qa-lib/src/org/netbeans/tests/xml/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/qa-lib/src/org/netbeans/tests/xml/XTest.java
+++ b/xml/test/qa-lib/src/org/netbeans/tests/xml/XTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/InstanceDataObjectInXMLTest.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/InstanceDataObjectInXMLTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/XMLCESTest.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/XMLCESTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/XMLDataObjectMimeTypeTest.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/XMLDataObjectMimeTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/XMLDataObjectTest.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/XMLDataObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/text/TextESAccessor.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/text/TextESAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/wizard/DTDParserTest.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/wizard/DTDParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/wizard/SchemaParserTest.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/wizard/SchemaParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/wizard/TestCatalogModel.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/wizard/TestCatalogModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xml/test/unit/src/org/netbeans/modules/xml/wizard/XMLGeneratorTest.java
+++ b/xml/test/unit/src/org/netbeans/modules/xml/wizard/XMLGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/XSLDataLoader.java
+++ b/xsl/src/org/netbeans/modules/xsl/XSLDataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/XSLDataLoaderBeanInfo.java
+++ b/xsl/src/org/netbeans/modules/xsl/XSLDataLoaderBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/XSLDataObject.java
+++ b/xsl/src/org/netbeans/modules/xsl/XSLDataObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/actions/TransformAction.java
+++ b/xsl/src/org/netbeans/modules/xsl/actions/TransformAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/api/XSLCustomizer.java
+++ b/xsl/src/org/netbeans/modules/xsl/api/XSLCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/cookies/ValidateXSLSupport.java
+++ b/xsl/src/org/netbeans/modules/xsl/cookies/ValidateXSLSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/grammar/ResultAttr.java
+++ b/xsl/src/org/netbeans/modules/xsl/grammar/ResultAttr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/grammar/ResultDocument.java
+++ b/xsl/src/org/netbeans/modules/xsl/grammar/ResultDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/grammar/ResultElement.java
+++ b/xsl/src/org/netbeans/modules/xsl/grammar/ResultElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/grammar/ResultNode.java
+++ b/xsl/src/org/netbeans/modules/xsl/grammar/ResultNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQueryProvider.java
+++ b/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQueryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/settings/TransformHistory.java
+++ b/xsl/src/org/netbeans/modules/xsl/settings/TransformHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/transform/TransformPerformer.java
+++ b/xsl/src/org/netbeans/modules/xsl/transform/TransformPerformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/transform/TransformServlet.java
+++ b/xsl/src/org/netbeans/modules/xsl/transform/TransformServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/ui/TransformPanel.java
+++ b/xsl/src/org/netbeans/modules/xsl/ui/TransformPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/utils/TransformUtil.java
+++ b/xsl/src/org/netbeans/modules/xsl/utils/TransformUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/src/org/netbeans/modules/xsl/wizard/XSLWizardIterator.java
+++ b/xsl/src/org/netbeans/modules/xsl/wizard/XSLWizardIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/test/unit/src/org/netbeans/modules/xsl/settings/TransformHistoryTest.java
+++ b/xsl/test/unit/src/org/netbeans/modules/xsl/settings/TransformHistoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/test/unit/src/org/netbeans/modules/xsl/transform/TransformServletTest.java
+++ b/xsl/test/unit/src/org/netbeans/modules/xsl/transform/TransformServletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/xsl/test/unit/src/org/netbeans/modules/xsl/utils/TransformUtilTest.java
+++ b/xsl/test/unit/src/org/netbeans/modules/xsl/utils/TransformUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
The new Apache license header on all `.java`, `.cpp`, `.c`, `.js` files (etc) started with slash-star-star (the Javadoc introducer). While strictly speaking this is acceptable, the header is not a Javadoc comment, and no present or future Javadoc parser should attempt to regard as a Javadoc comment. Therefore all such occurences are changed to simple slash-star introducer.

For future reference: The following snippet was used to change the files. I tried bash+sed but it never gave me correct result, so I resorted to good old Java. As I bonus, the snippet also checks for Windows line endings.

``` java
package org.apache.netbeans.sourceutils;

import java.io.File;
import java.io.IOException;
import java.nio.charset.StandardCharsets;
import java.nio.file.FileVisitResult;
import java.nio.file.Files;
import java.nio.file.Path;
import java.nio.file.SimpleFileVisitor;
import java.nio.file.attribute.BasicFileAttributes;
import java.util.ArrayList;
import java.util.Arrays;
import java.util.HashMap;
import java.util.List;
import java.util.Map;
import java.util.Set;
import java.util.TreeSet;

public class ChgLicHeader extends SimpleFileVisitor<Path> {

    private static final List<String> EXCLUDES = new ArrayList<>(Arrays.asList(
            ".gif", ".png", ".jpg", ".PNG", ".pdf",
            ".jar", ".zip", ".ico", ".icns", ".wav",
            ".idb", ".odt", ".gz", ".jar"));

    private static final byte[] AL_JAVADOC_INTRO = "/**\n * Licensed to the Apache Software Foundation"
            .getBytes(StandardCharsets.US_ASCII);
    
    private Map<String, Set<Path>> filesChanged = new HashMap<>();
    private Set<Path> windowsLineEndingFiles = new TreeSet<>();  

    public static void main(String[] args) throws IOException {

        System.out.println("Path: " + args[0]);
        Path path = new File(args[0]).toPath();
        ChgLicHeader fileVisitor = new ChgLicHeader();
        Files.walkFileTree(path, fileVisitor);

        System.out.println("Files changed: ");
        for (String ext : fileVisitor.getFileChanged().keySet()) {
            System.out.println("  " + ext);
            for (Path file : fileVisitor.getFileChanged().get(ext)) {
                System.out.println("        " + path.relativize(file));
            }
        }

        System.out.println();
        System.out.println();

        System.out.println("Files with (supposedly) CRLF line endings: ");
        for (Path file : fileVisitor.getWindowsLineEndingFiles()) {
            System.out.println("  " + path.relativize(file));
        }
    }

    @Override
    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {

        if (attrs.isRegularFile()) {
            for (String excludedExt : EXCLUDES) {
                if (file.getFileName().toString().endsWith(excludedExt)) {
                    return FileVisitResult.CONTINUE;
                }
            }
            if (!usesUnixLineEndings(file)) {
                windowsLineEndingFiles.add(file);
            }

            checkAndRewrite(file);
        }
        return FileVisitResult.CONTINUE;
    }

    @Override
    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
        if (dir.endsWith(".git")) {
            return FileVisitResult.SKIP_SUBTREE;
        }
        return super.preVisitDirectory(dir, attrs);
    }

    private void addChangedFileByExtension(String ext, Path file) {
        Set<Path> set = filesChanged.get(ext);
        if (set == null) {
            set = new TreeSet<>();
            filesChanged.put(ext, set);
        }
        set.add(file);
    }

    private void checkAndRewrite(Path file) throws IOException {
        byte[] buf = Files.readAllBytes(file);

        if (usesApacheHeaderWithJavadocIntroducer(buf)) {
            String fileNameStr = file.getFileName().toString();
            int pos = fileNameStr.lastIndexOf('.');
            if (pos > 0) {
                addChangedFileByExtension(fileNameStr.substring(pos), file);
            }

            // New array, which is a copy but with 3rd byte excluded
            byte[] newBuf = new byte[buf.length - 1];
            System.arraycopy(buf, 0, newBuf, 0, 2);
            System.arraycopy(buf, 3, newBuf, 2, buf.length - 3);

            Files.write(file, newBuf);  // rewrite file
        }
    }

    /**
     * Check if file (as represented by byte buffer) has the ASF license header,
     * and the header begins with the Javadoc introducer.
     */
    private boolean usesApacheHeaderWithJavadocIntroducer(byte[] buf) throws IOException {

        if (buf.length >= AL_JAVADOC_INTRO.length) {
            boolean match = true;
            for (int i = 0; i < AL_JAVADOC_INTRO.length; i++) {
                if (buf[i] != AL_JAVADOC_INTRO[i]) {
                    match = false;
                    break;
                }
            }
            return match;
        }
        return false;
    }

    private boolean usesUnixLineEndings(Path file) throws IOException {
        int noOfLF = 0;
        int noOfCRLF = 0;
        byte[] buf = Files.readAllBytes(file);

        for (int i = 0; i < buf.length; i++) {

            if (buf[i] == '\n') {
                noOfLF++;
            }
            if (buf[i] == '\r') {
                i++;
                if (i < buf.length && buf[i] == '\n') {
                    noOfCRLF++;
                }
                noOfLF++;
            }
        }
        return (noOfCRLF == 0);
    }

    public Map<String, Set<Path>> getFileChanged() {
        return filesChanged;
    }

    public Set<Path> getWindowsLineEndingFiles() {
        return windowsLineEndingFiles;
    }
}
```