### PR TITLE
Fix the license header template for NetBeans modules

### DIFF
--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/resources/license-apache20-netbeans.txt
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/resources/license-apache20-netbeans.txt
@@ -1,7 +1,5 @@
 <#if licenseFirst??>
-    <#if licenseFirst == "/*">
-        <#assign licenseFirst="/**">
-    <#elseif licenseFirst == "<!--">
+    <#if licenseFirst == "<!--">
         <#assign licensePrefix="    ">
     </#if>
 ${licenseFirst}


### PR DESCRIPTION
- Don't change "/*" to "/**".

see #282