### PR TITLE
Add .gitattributes file to repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+#
+#  Defines Git attributes per file path / file pattern
+#
+
+
+
+# Define some file types explicitly as being text.
+# This makes sure that we can never inadvertently get
+# a file of this type into the repo with a line ending
+# other than the Unix-style line ending. 
+# This will also override the user's own global git settings
+# for these file types.
+
+*.css             text eol=lf
+*.dtd             text eol=lf
+*.htm             text eol=lf
+*.html            text eol=lf
+*.java            text eol=lf
+*.js              text eol=lf
+*.md              text eol=lf
+*.properties      text eol=lf
+*.scss            text eol=lf
+*.svg             text eol=lf
+*.txt             text eol=lf
+*.xml             text eol=lf
+*.xsd             test eol=lf
+
+.gitattributes    text eol=lf
+.gitignore        text eol=lf
+.travis.yml       text eol=lf
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@
 
 *.css             text eol=lf
 *.dtd             text eol=lf
+*.form            text eol=lf
 *.htm             text eol=lf
 *.html            text eol=lf
 *.java            text eol=lf


### PR DESCRIPTION
Adds a `.gitattributes` file to the repo. 

The purpose of the file is to ensure that we'll never get files into the repo with wrong line endings, at least for those file types explicitly mentioned in the `.gitattributes` file. These settings will override the user's own git settings.

It is deliberate that the file uses a whitelist, i.e. it only lists the file types where there's 100% certainty that they should always use Unix-style line endings. For file types _not_ explicitly mentioned in the `.gitattributes` file, git's behaviour will be as today.
