### PR TITLE
Drop usage of FileInput/OutputStreams - modules a* -> c*

### DIFF
--- a/api.search/src/org/netbeans/modules/search/matcher/FastMatcher.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/FastMatcher.java
@@ -31,6 +31,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -268,16 +269,9 @@ public class FastMatcher extends AbstractMatcher {
     /**
      * Check file content using Java NIO API.
      */
-    private Def checkSmall(FileObject fo, File file,
-            SearchListener listener) {
-
+    private Def checkSmall(FileObject fo, File file, SearchListener listener) {
         MappedByteBuffer bb = null;
-        FileChannel fc = null;
-        try {
-            // Open the file and then get a channel from the stream
-            FileInputStream fis = new FileInputStream(file);
-            fc = fis.getChannel();
-
+        try (FileChannel fc = FileChannel.open(file.toPath(), StandardOpenOption.READ)) {
             // Get the file's size and then map it into memory
             int sz = (int) fc.size();
             bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, sz);
@@ -304,13 +298,6 @@ public class FastMatcher extends AbstractMatcher {
             listener.generalError(e);
             return null;
         } finally {
-            if (fc != null) {
-                try {
-                    fc.close();
-                } catch (IOException ex) {
-                    listener.generalError(ex);
-                }
-            }
             unmap(bb);
         }
     }

--- a/api.search/src/org/netbeans/modules/search/matcher/MultiLineMappedMatcherBig.java
+++ b/api.search/src/org/netbeans/modules/search/matcher/MultiLineMappedMatcherBig.java
@@ -19,8 +19,6 @@
 package org.netbeans.modules.search.matcher;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.CharBuffer;
 import java.nio.MappedByteBuffer;
@@ -29,6 +27,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
+import java.nio.file.StandardOpenOption;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -140,7 +139,6 @@ public class MultiLineMappedMatcherBig extends AbstractMatcher {
     private class LongCharSequence implements CharSequence {
 
         private long fileSize;
-        private FileInputStream fileInputStream;
         private FileChannel fileChannel;
         /**
          * At which character in the file the current buffer starts (counting
@@ -191,15 +189,11 @@ public class MultiLineMappedMatcherBig extends AbstractMatcher {
          */
         private State state = State.STANDARD;
 
-        public LongCharSequence(File file, Charset charset)
-                throws FileNotFoundException {
-
+        public LongCharSequence(File file, Charset charset) throws IOException {
             decoder = prepareDecoder(charset);
-            fileInputStream = new FileInputStream(file);
-            fileChannel = fileInputStream.getChannel();
+            fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.READ);
             fileSize = file.length();
-            charBuffer = CharBuffer.allocate((int) Math.min(fileSize,
-                    SIZE_LIMIT));
+            charBuffer = CharBuffer.allocate((int) Math.min(fileSize, SIZE_LIMIT));
         }
 
         /**
@@ -443,13 +437,6 @@ public class MultiLineMappedMatcherBig extends AbstractMatcher {
             if (fileChannel != null) {
                 try {
                     fileChannel.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
-            if (fileInputStream != null) {
-                try {
-                    fileInputStream.close();
                 } catch (IOException ex) {
                     Exceptions.printStackTrace(ex);
                 }

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingModel.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteBrandingModel.java
@@ -21,12 +21,12 @@ package org.netbeans.modules.apisupport.project.suite;
 
 import org.netbeans.modules.apisupport.project.spi.BrandingSupport;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.StringTokenizer;
 import org.netbeans.api.annotations.common.NonNull;
@@ -198,22 +198,16 @@ public class SuiteBrandingModel extends BrandingModel {
     
     private static EditableProperties getEditableProperties(final File bundle) throws IOException {
         EditableProperties p = new EditableProperties(true);
-        InputStream is = new FileInputStream(bundle);
-        try {
+        try (InputStream is = Files.newInputStream(bundle.toPath())) {
             p.load(is);
-        } finally {
-            is.close();
         }
         return p;
     }
     
     private static void storeEditableProperties(final EditableProperties p, final File bundle) throws IOException {
         FileObject fo = FileUtil.toFileObject(bundle);
-        OutputStream os = null == fo ? new FileOutputStream(bundle) : fo.getOutputStream();
-        try {
+        try (OutputStream os = null == fo ? Files.newOutputStream(bundle.toPath()) : fo.getOutputStream()) {
             p.store(os);
-        } finally {
-            os.close();
         }
     }
 

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
@@ -22,10 +22,10 @@ package org.netbeans.modules.apisupport.project.universe;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -329,17 +329,12 @@ public final class ModuleList {
     private static final Map<File,File> netbeansOrgDestDirs = new HashMap<File,File>();
     private static File checkForNetBeansOrgDestDir(File properties) {
         if (properties.isFile()) {
-            try {
-                InputStream is = new FileInputStream(properties);
-                try {
-                    Properties p = new Properties();
-                    p.load(is);
-                    String d = p.getProperty(NETBEANS_DEST_DIR);
-                    if (d != null) {
-                        return new File(d);
-                    }
-                } finally {
-                    is.close();
+            try (InputStream is = Files.newInputStream(properties.toPath())) {
+                Properties p = new Properties();
+                p.load(is);
+                String d = p.getProperty(NETBEANS_DEST_DIR);
+                if (d != null) {
+                    return new File(d);
                 }
             } catch (IOException x) {
                 LOG.log(Level.INFO, "Could not read " + properties, x);
@@ -1118,11 +1113,8 @@ public final class ModuleList {
             return PropertyUtils.fixedPropertyProvider(Collections.<String,String>emptyMap());
         }
         Properties p = new Properties();
-        InputStream is = new FileInputStream(f);
-        try {
+        try (InputStream is = Files.newInputStream(f.toPath())) {
             p.load(is);
-        } finally {
-            is.close();
         }
         return PropertyUtils.fixedPropertyProvider(NbCollections.checkedMapByFilter(p, String.class, String.class, true));
     }

--- a/apisupport.harness/build.xml
+++ b/apisupport.harness/build.xml
@@ -36,7 +36,7 @@
 
     <target name="compile-jnlp-launcher" depends="init,compile">
         <mkdir dir="${build.dir}/jnlp-launcher-classes"/>
-        <nb-javac srcdir="jnlp-src" destdir="${build.dir}/jnlp-launcher-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.6" target="1.6" includeantruntime="false">
+        <nb-javac srcdir="jnlp-src" destdir="${build.dir}/jnlp-launcher-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.7" target="1.7" includeantruntime="false">
             <classpath>
                 <path path="${jnlp.cp}"/>
             </classpath>

--- a/apisupport.harness/nbproject/project.properties
+++ b/apisupport.harness/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.7
 jnlp.cp=\
     ${o.n.bootstrap.dir}/lib/boot.jar:\
     ${openide.modules.dir}/lib/org-openide-modules.jar:\

--- a/apisupport.installer.maven/nbproject/project.properties
+++ b/apisupport.installer.maven/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/apisupport.installer.maven/src/org/netbeans/modules/apisupport/installer/maven/actions/BuildInstallersAction.java
+++ b/apisupport.installer.maven/src/org/netbeans/modules/apisupport/installer/maven/actions/BuildInstallersAction.java
@@ -20,12 +20,12 @@ package org.netbeans.modules.apisupport.installer.maven.actions;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -176,14 +176,13 @@ public final class BuildInstallersAction extends AbstractAction implements Conte
                                 licenseFile.getParentFile().mkdirs();
                                 licenseFile.deleteOnExit();
 
-                                OutputStream os = new FileOutputStream(licenseFile);
-                                byte[] bytes = new byte[4096];
-                                int read = 0;
-                                while ((read = is.read(bytes)) > 0) {
-                                    os.write(bytes, 0, read);
+                                try (OutputStream os = Files.newOutputStream(licenseFile.toPath())) {
+                                    byte[] bytes = new byte[4096];
+                                    int read = 0;
+                                    while ((read = is.read(bytes)) > 0) {
+                                        os.write(bytes, 0, read);
+                                    }
                                 }
-                                os.flush();
-                                os.close();
                             } else {
                                 Logger.getLogger(BuildInstallersAction.class.getName()).log(
                                         Level.WARNING, "License resource {0} not found", licenseResource);

--- a/apisupport.installer/nbproject/project.properties
+++ b/apisupport.installer/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.module.author=Dmitry Lipin

--- a/apisupport.installer/src/org/netbeans/modules/apisupport/installer/actions/BuildInstallersAction.java
+++ b/apisupport.installer/src/org/netbeans/modules/apisupport/installer/actions/BuildInstallersAction.java
@@ -20,12 +20,12 @@ package org.netbeans.modules.apisupport.installer.actions;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -180,14 +180,13 @@ public final class BuildInstallersAction extends AbstractAction implements Conte
                                         licenseFile.getParentFile().mkdirs();
                                         licenseFile.deleteOnExit();
 
-                                        OutputStream os = new FileOutputStream(licenseFile);
-                                        byte[] bytes = new byte[4096];
-                                        int read = 0;
-                                        while ((read = is.read(bytes)) > 0) {
-                                            os.write(bytes, 0, read);
+                                        try (OutputStream os = Files.newOutputStream(licenseFile.toPath())) {
+                                            byte[] bytes = new byte[4096];
+                                            int read = 0;
+                                            while ((read = is.read(bytes)) > 0) {
+                                                os.write(bytes, 0, read);
+                                            }
                                         }
-                                        os.flush();
-                                        os.close();
                                     } else {
                                         Logger.getLogger(BuildInstallersAction.class.getName()).log(
                                                 Level.WARNING, "License resource {0} not found", licenseResource);

--- a/apisupport.project/nbproject/project.properties
+++ b/apisupport.project/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.7
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/api/ManifestManager.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/api/ManifestManager.java
@@ -143,14 +143,9 @@ public final class ManifestManager {
     
     public static ManifestManager getInstance(File manifest, boolean loadPublicPackages) {
         if (manifest.exists()) {
-            try {
-                InputStream mis = new FileInputStream(manifest); // NOI18N
-                try {
-                    Manifest mf = new Manifest(mis);
-                    return ManifestManager.getInstance(mf, loadPublicPackages);
-                } finally {
-                    mis.close();
-                }
+            try (InputStream mis = new FileInputStream(manifest)) {
+                Manifest mf = new Manifest(mis);
+                return ManifestManager.getInstance(mf, loadPublicPackages);
             } catch (IOException x) {
                 LOG.log(Level.INFO, "While opening: " + manifest, x);
             }

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingModel.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingModel.java
@@ -22,10 +22,10 @@ package org.netbeans.modules.apisupport.project.spi;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -296,11 +296,8 @@ public abstract class BrandingModel {
                     if( !iconLocation.exists() )
                         iconLocation.createNewFile();
                     FileObject fo = FileUtil.toFileObject(iconLocation);
-                    OutputStream os = fo == null ? new FileOutputStream(iconLocation) : fo.getOutputStream();
-                    try {
+                    try (OutputStream os = fo == null ? Files.newOutputStream(iconLocation.toPath()) : fo.getOutputStream()) {
                         ImageIO.write(bi, "png", os);
-                    } finally {
-                        os.close();
                     }
                 } catch (IOException ex) {
                     ErrorManager.getDefault().notify(ex);

--- a/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
+++ b/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
@@ -20,14 +20,13 @@
 package org.netbeans.modules.apisupport.project.spi;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.SoftReference;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -483,22 +482,16 @@ public abstract class BrandingSupport {
     
     private static EditableProperties getEditableProperties(final File bundle) throws IOException {
         EditableProperties p = new EditableProperties(true);
-        InputStream is = new FileInputStream(bundle);
-        try {
+        try (InputStream is = Files.newInputStream(bundle.toPath())) {
             p.load(is);
-        } finally {
-            is.close();
         }
         return p;
     }
     
     private static void storeEditableProperties(final EditableProperties p, final File bundle) throws IOException {
         FileObject fo = FileUtil.toFileObject(bundle);
-        OutputStream os = null == fo ? new FileOutputStream(bundle) : fo.getOutputStream();
-        try {
+        try (OutputStream os = null == fo ? Files.newOutputStream(bundle.toPath()) : fo.getOutputStream()) {
             p.store(os);
-        } finally {
-            os.close();
         }
     }
 

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ClusterUpdateProvider.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ClusterUpdateProvider.java
@@ -21,9 +21,9 @@ package org.netbeans.modules.autoupdate.pluginimporter;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -167,7 +167,7 @@ public class ClusterUpdateProvider implements UpdateProvider {
         Document document = null;
         InputStream is = null;
         try {
-            is = new BufferedInputStream (new FileInputStream (cf));
+            is = new BufferedInputStream(Files.newInputStream(cf.toPath()));
             InputSource xmlInputSource = new InputSource (is);
             document = XMLUtil.parse (xmlInputSource, false, false, null, EntityCatalog.getDefault ());
         } catch (SAXException saxe) {

--- a/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/PluginImporter.java
+++ b/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/PluginImporter.java
@@ -21,10 +21,10 @@ package org.netbeans.modules.autoupdate.pluginimporter;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -320,7 +320,7 @@ public class PluginImporter {
         Document document = null;
         InputStream is;
         try {
-            is = new BufferedInputStream (new FileInputStream (moduleUpdateTracking));
+            is = new BufferedInputStream(Files.newInputStream(moduleUpdateTracking.toPath()));
             InputSource xmlInputSource = new InputSource (is);
             document = XMLUtil.parse (xmlInputSource, false, false, null, org.openide.xml.EntityCatalog.getDefault ());
             if (is != null) {

--- a/autoupdate.services/libsrc/org/netbeans/updater/UpdaterFrame.java
+++ b/autoupdate.services/libsrc/org/netbeans/updater/UpdaterFrame.java
@@ -22,6 +22,7 @@ package org.netbeans.updater;
 import java.awt.*;
 import java.io.*;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -412,8 +413,8 @@ implements UpdatingContext {
     }
 
     @Override
-    public OutputStream createOS(File bckFile) throws FileNotFoundException {
-        return new FileOutputStream(bckFile);
+    public OutputStream createOS(File bckFile) throws IOException {
+        return Files.newOutputStream(bckFile.toPath());
     }
         
     static class SplashFrame extends JFrame {

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallManager.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallManager.java
@@ -21,9 +21,9 @@ package org.netbeans.modules.autoupdate.services;
 
 import java.beans.PropertyVetoException;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -191,11 +191,8 @@ public class InstallManager extends InstalledFileLocator{
                         f.getParentFile().mkdirs();
                         f.createNewFile();
                     }
-                    OutputStream os = new FileOutputStream(f);
-                    try {
+                    try (OutputStream os = Files.newOutputStream(f.toPath())) {
                         os.write(sb.toString().getBytes());
-                    } finally {
-                        os.close();
                     }
                     ERR.log (Level.FINE, "Was written new netbeans.dirs " + sb);
 

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallSupportImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallSupportImpl.java
@@ -28,6 +28,7 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.Certificate;
@@ -723,8 +724,7 @@ public class InstallSupportImpl {
                             byte[] arr = new byte[4096];
                             CRC32 check = new CRC32();
                             File external = new File(dest.getPath() + "." + Long.toHexString(crc.get()));
-                            FileOutputStream fos = new FileOutputStream(external);
-                            try {
+                            try (OutputStream fos = Files.newOutputStream(external.toPath())) {
                                 for (;;) {
                                     int len = real.read(arr);
                                     if (len == -1) {
@@ -738,8 +738,6 @@ public class InstallSupportImpl {
                                         }
                                     }
                                 }
-                            } finally {
-                                fos.close();
                             }
                             real.close();
                             if (check.getValue() != crc.get()) {
@@ -980,7 +978,7 @@ public class InstallSupportImpl {
             int c = 0;
             while (!(canceled = cancelled()) && (size = bsrc.read (bytes)) != -1) {
                 if(bdest == null) {
-                    bdest = new BufferedOutputStream (new FileOutputStream (dest));
+                    bdest = new BufferedOutputStream(Files.newOutputStream(dest.toPath()));
                 }
                 bdest.write (bytes, 0, size);
                 increment += size;

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleDeleterImpl.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleDeleterImpl.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -365,7 +366,7 @@ public final class ModuleDeleterImpl  {
         Document document = null;
         InputStream is;
         try {
-            is = new BufferedInputStream (new FileInputStream (moduleUpdateTracking));
+            is = new BufferedInputStream (Files.newInputStream(moduleUpdateTracking.toPath()));
             InputSource xmlInputSource = new InputSource (is);
             document = XMLUtil.parse (xmlInputSource, false, false, null, org.openide.xml.EntityCatalog.getDefault ());
             if (is != null) {

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.autoupdate.services;
 import java.io.*;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -373,11 +374,11 @@ public class Utilities {
         OutputStream fos = null;
         try {
             try {
-                XMLUtil.write (doc, bos, "UTF-8"); // NOI18N
-                bos.close ();
-                fos = new FileOutputStream (dest);
-                is = new ByteArrayInputStream (bos.toByteArray ());
-                FileUtil.copy (is, fos);
+                XMLUtil.write(doc, bos, "UTF-8"); // NOI18N
+                bos.close();
+                fos = Files.newOutputStream(dest.toPath());
+                is = new ByteArrayInputStream(bos.toByteArray());
+                FileUtil.copy(is, fos);
             } finally {
                 if (is != null) {
                     is.close ();
@@ -437,7 +438,7 @@ public class Utilities {
         
         try {
             try {
-                fos = new FileOutputStream (dest);
+                fos = Files.newOutputStream(dest.toPath());
                 is = new ByteArrayInputStream (content.toString().getBytes());
                 FileUtil.copy (is, fos);
             } finally {
@@ -523,7 +524,7 @@ public class Utilities {
         
         try {
             try {
-                fos = new FileOutputStream (dest);
+                fos = Files.newOutputStream(dest.toPath());
                 is = jf.getInputStream (updaterJarEntry);
                 FileUtil.copy (is, fos);
             } finally {
@@ -1090,12 +1091,9 @@ public class Utilities {
     
     private static Node getModuleConfiguration (File moduleUpdateTracking) {
         Document document;
-        InputStream is;
-        try {
-            is = new BufferedInputStream (new FileInputStream (moduleUpdateTracking));
+        try (InputStream is = new BufferedInputStream (Files.newInputStream(moduleUpdateTracking.toPath()))){
             InputSource xmlInputSource = new InputSource (is);
             document = XMLUtil.parse (xmlInputSource, false, false, null, org.openide.xml.EntityCatalog.getDefault ());
-            is.close ();
         } catch (SAXException saxe) {
             getLogger ().log (Level.INFO, "SAXException when reading " + moduleUpdateTracking, saxe);
             return null;
@@ -1380,7 +1378,7 @@ public class Utilities {
                 if (! f.exists ()) {
                     return null;
                 }
-                is = new BufferedInputStream (new FileInputStream (f));
+                is = new BufferedInputStream(Files.newInputStream(f.toPath()));
                 ks = KeyStore.getInstance (KeyStore.getDefaultType ());
                 ks.load (is, KS_USER_PASSWORD.toCharArray ());
             } catch (IOException ex) {
@@ -1408,7 +1406,7 @@ public class Utilities {
         OutputStream os = null;
         try {
             File f = new File (getCacheDirectory (), USER_KS_FILE_NAME);
-            os = new BufferedOutputStream (new FileOutputStream (f));
+            os = new BufferedOutputStream (Files.newOutputStream(f.toPath()));
             ks.store (os, KS_USER_PASSWORD.toCharArray ());
             getPreferences ().put (USER_KS_KEY, USER_KS_FILE_NAME);
         } catch (KeyStoreException ex) {

--- a/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/DownloadListener.java
+++ b/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/DownloadListener.java
@@ -21,11 +21,11 @@ package org.netbeans.modules.autoupdate.updateprovider;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -98,7 +98,7 @@ public class DownloadListener implements NetworkAccess.NetworkListener {
         int totalRead = 0;
 
         try {
-            os = new BufferedOutputStream(new FileOutputStream(temp));
+            os = new BufferedOutputStream(Files.newOutputStream(temp.toPath()));
             byte[] bytes = new byte[1024];
             while ((read = is.read(bytes)) != -1) {
                 os.write(bytes, 0, read);

--- a/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateSettings.java
+++ b/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateSettings.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -378,7 +379,7 @@ public class AutoupdateSettings {
         // read existing super Id
         InputStream is = null;
         try {
-            is = new FileInputStream (superFile);
+            is = Files.newInputStream(superFile.toPath());
             BufferedReader r = new BufferedReader (new InputStreamReader (is));
             res = r.readLine ().trim ();
             err.log (Level.FINE, "Read Super Id: " + res + " from " + superFile);

--- a/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/DashboardStorage.java
+++ b/bugtracking/src/org/netbeans/modules/bugtracking/tasks/cache/DashboardStorage.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.bugtracking.tasks.cache;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -322,7 +324,7 @@ public class DashboardStorage {
     }
 
     private DataOutputStream getCategoryOutputStream(File categoryFile) throws IOException {
-        ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(categoryFile, false)));
+        ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(categoryFile.toPath())));
         ZipEntry entry = new ZipEntry(categoryFile.getName());
         zos.putNextEntry(entry);
         return new DataOutputStream(zos);
@@ -332,13 +334,13 @@ public class DashboardStorage {
         if (!file.exists()) {
             return null;
         }
-        ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));
+        ZipInputStream zis = new ZipInputStream(new BufferedInputStream(Files.newInputStream(file.toPath())));
         zis.getNextEntry();
         return new DataInputStream(zis);
     }
 
     private DataOutputStream getClosedOutputStream(File closedFile) throws IOException {
-        ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(closedFile, false)));
+        ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(closedFile.toPath())));
         ZipEntry entry = new ZipEntry(closedFile.getName());
         zos.putNextEntry(entry);
         return new DataOutputStream(zos);
@@ -348,7 +350,7 @@ public class DashboardStorage {
         if (!closedFile.exists()) {
             return null;
         }
-        ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(closedFile)));
+        ZipInputStream zis = new ZipInputStream(new BufferedInputStream(Files.newInputStream(closedFile.toPath())));
         zis.getNextEntry();
         return new DataInputStream(zis);
     }
@@ -365,7 +367,8 @@ public class DashboardStorage {
     private void writeStorage() {
         DataOutputStream dos = null;
         try {
-            dos = new DataOutputStream(new FileOutputStream(new File(getStorageFolder(storageFolder), STORAGE_FILE), false));
+            Path path = new File(getStorageFolder(storageFolder), STORAGE_FILE).toPath();
+            dos = new DataOutputStream(Files.newOutputStream(path));
             writeString(dos, STORAGE_VERSION);
             dos.flush();
         } catch (IOException e) {

--- a/bugzilla/src/org/netbeans/modules/bugzilla/util/FileUtils.java
+++ b/bugzilla/src/org/netbeans/modules/bugzilla/util/FileUtils.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.bugzilla.util;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.logging.Level;
 import org.netbeans.modules.bugzilla.Bugzilla;
 import org.openide.filesystems.FileUtil;
@@ -227,7 +228,7 @@ public class FileUtils {
         int retry = 0;
         while (true) {   
             try {
-                return new BufferedInputStream(new FileInputStream(file));                
+                return new BufferedInputStream(Files.newInputStream(file.toPath()));
             } catch (IOException ex) {
                 retry++;
                 if (retry > 7) {
@@ -246,7 +247,7 @@ public class FileUtils {
         int retry = 0;
         while (true) {            
             try {
-                return new BufferedOutputStream(new FileOutputStream(file));                
+                return new BufferedOutputStream(Files.newOutputStream(file.toPath()));
             } catch (IOException ex) {
                 retry++;
                 if (retry > 7) {

--- a/classfile/src/org/netbeans/modules/classfile/ClassFile.java
+++ b/classfile/src/org/netbeans/modules/classfile/ClassFile.java
@@ -23,6 +23,8 @@
 package org.netbeans.modules.classfile;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.logging.Logger;
 
@@ -143,7 +145,7 @@ public class ClassFile {
         try {
             if (classFileName == null)
                 throw new IOException("input stream not specified");
-            in = new BufferedInputStream(new FileInputStream(classFileName), BUFFER_SIZE);
+            in = new BufferedInputStream(Files.newInputStream(Paths.get(classFileName)), BUFFER_SIZE);
             load(in);
         } catch (InvalidClassFormatException e) {
             throw new InvalidClassFormatException(classFileName + '(' +

--- a/core.netigso/nbproject/project.properties
+++ b/core.netigso/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/core.netigso/src/org/netbeans/core/netigso/Netigso.java
+++ b/core.netigso/src/org/netbeans/core/netigso/Netigso.java
@@ -22,10 +22,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,7 +36,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -453,9 +452,9 @@ implements Cloneable, Stamps.Updater {
             } else if (symbolicName != null) { // NOI18N
                 if (original != null) {
                     LOG.log(Level.FINE, "Updating bundle {0}", original.getLocation());
-                    FileInputStream is = new FileInputStream(m.getJarFile());
-                    original.update(is);
-                    is.close();
+                    try (InputStream is = Files.newInputStream(m.getJarFile().toPath())) {
+                        original.update(is);
+                    }
                     b = original;
                 } else {
                     BundleContext bc = framework.getBundleContext();

--- a/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
+++ b/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
@@ -21,10 +21,11 @@ package org.netbeans.core.network.proxy;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -421,10 +422,9 @@ public final class NbProxySelector extends ProxySelector {
                 }
 
                 fname = netProperties.getCanonicalPath();
-                InputStream in = new FileInputStream(fname);
-                BufferedInputStream bin = new BufferedInputStream(in);
-                props.load(bin);
-                bin.close();
+                try (InputStream bin = new BufferedInputStream(Files.newInputStream(Paths.get(fname)))) {
+                    props.load(bin);
+                }
 
                 String val = props.getProperty(propertyKey);
                 val = System.getProperty(propertyKey, val);

--- a/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
@@ -19,12 +19,10 @@
 package org.netbeans.core.network.proxy.kde;
 
 import java.io.BufferedReader;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -133,10 +131,7 @@ public class KdeNetworkProxy implements NetworkProxyResolver {
         Map<String, String> map = new HashMap<String, String>();
 
         if (kioslavercFile.exists()) {
-            try {
-                FileInputStream fis = new FileInputStream(kioslavercFile);
-                DataInputStream dis = new DataInputStream(fis);
-                BufferedReader br = new BufferedReader(new InputStreamReader(dis));
+            try (BufferedReader br = Files.newBufferedReader(kioslavercFile.toPath())) {
                 String line;
                 boolean inGroup = false;
                 while ((line = br.readLine()) != null) {
@@ -153,7 +148,6 @@ public class KdeNetworkProxy implements NetworkProxyResolver {
                         inGroup = true;
                     }
                 }
-                dis.close();
             } catch (FileNotFoundException fnfe) {
                 LOGGER.log(Level.SEVERE, "Cannot read file: ", fnfe);
             } catch (IOException ioe) {

--- a/core.osgi/nbproject/project.properties
+++ b/core.osgi/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 cp.extra=\
     ${nb_all}/libs.osgi/external/osgi.core-5.0.0.jar:\

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
@@ -20,12 +20,12 @@
 package org.netbeans.core.osgi;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -122,20 +122,13 @@ class OSGiInstalledFileLocator extends InstalledFileLocator {
                         if (!dir.isDirectory() && !dir.mkdirs()) {
                             throw new IOException("Could not make " + dir);
                         }
-                        InputStream is = resource.openStream();
-                        try {
-                            OutputStream os = new FileOutputStream(f2);
-                            try {
-                                byte[] buf = new byte[4096];
-                                int read;
-                                while ((read = is.read(buf)) != -1) {
-                                    os.write(buf, 0, read);
-                                }
-                            } finally {
-                                os.close();
+                        try (InputStream is = resource.openStream();
+                                OutputStream os = Files.newOutputStream(f2.toPath())) {
+                            byte[] buf = new byte[4096];
+                            int read;
+                            while ((read = is.read(buf)) != -1) {
+                                os.write(buf, 0, read);
                             }
-                        } finally {
-                            is.close();
                         }
                         if (execFiles.contains(name)) {
                             f2.setExecutable(true);

--- a/core.output2/nbproject/project.properties
+++ b/core.output2/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.7
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/core.output2/src/org/netbeans/core/output2/Controller.java
+++ b/core.output2/src/org/netbeans/core/output2/Controller.java
@@ -23,10 +23,10 @@ import java.awt.Container;
 import java.awt.Font;
 import java.io.CharConversionException;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -525,7 +525,7 @@ public class Controller {
                         f.delete();
                     }
                     f.createNewFile();
-                    logStream = new FileOutputStream(f);
+                    logStream = Files.newOutputStream(f.toPath());
                 } catch (Exception e) {
                     e.printStackTrace();
                     logStream = System.err;

--- a/core.startup.base/nbproject/project.properties
+++ b/core.startup.base/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.63.0
 module.jar.dir=core

--- a/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
@@ -20,7 +20,6 @@
 package org.netbeans.core.startup.layers;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,6 +29,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -241,16 +241,8 @@ public class ArchiveURLMapper extends URLMapper {
                     copy = copy.getCanonicalFile();
                     copy.deleteOnExit();
                 }
-                InputStream is = fo.getInputStream();
-                try {
-                    OutputStream os = new FileOutputStream(copy);
-                    try {
-                        FileUtil.copy(is, os);
-                    } finally {
-                        os.close();
-                    }
-                } finally {
-                    is.close();
+                try (InputStream is = fo.getInputStream(); OutputStream os = Files.newOutputStream(copy.toPath())) {
+                    FileUtil.copy(is, os);
                 }
                 copiedJARs.put(archiveFileURI, copy);
             }

--- a/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
@@ -20,7 +20,6 @@
 package org.netbeans.core.startup.layers;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,6 +28,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.UnknownServiceException;
+import java.nio.file.Files;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
@@ -140,7 +140,7 @@ public class NbinstURLStreamHandler extends URLStreamHandler {
         public InputStream getInputStream() throws IOException {
             this.connect();
             if (iStream == null) {
-                iStream = new FileInputStream(f);
+                iStream = Files.newInputStream(f.toPath());
             }
             return iStream;
         }

--- a/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
@@ -19,8 +19,8 @@
 package org.netbeans.core.startup.logging;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -84,8 +84,8 @@ final class MessagesHandler extends StreamHandler {
     
     private void initStream() {
         try {
-            setOutputStream(new FileOutputStream(files[0], false));
-        } catch (FileNotFoundException ex) {
+            setOutputStream(Files.newOutputStream(files[0].toPath()));
+        } catch (IOException ex) {
             setOutputStream(System.err);
         }
     }

--- a/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
@@ -19,9 +19,10 @@
 package org.netbeans.core.startup.logging;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.logging.Handler;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -43,8 +44,8 @@ public final class NbLogging {
             try {
                 File debugLog = new File(System.getProperty("java.io.tmpdir"), "TopLogging.log"); // NOI18N
                 System.err.println("Logging sent to: " + debugLog); // NOI18N
-                _D = new PrintStream(new FileOutputStream(debugLog), true);
-            } catch (FileNotFoundException x) {
+                _D = new PrintStream(Files.newOutputStream(debugLog.toPath(), StandardOpenOption.APPEND));
+            } catch (IOException x) {
                 x.printStackTrace();
             }
         }

--- a/csl.api/anttask/build.xml
+++ b/csl.api/anttask/build.xml
@@ -33,7 +33,7 @@
 
   <target name="compile">
     <mkdir dir="build/classes"/>
-    <javac srcdir="src" destdir="build/classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" target="1.6" source="1.6" >
+    <javac srcdir="src" destdir="build/classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" target="1.7" source="1.7" >
 	  <classpath>
                 <!-- cmdline Ant -->
                 <pathelement location="${ant.core.lib}"/>

--- a/csl.api/anttask/src/org/netbeans/modules/csl/CslJar.java
+++ b/csl.api/anttask/src/org/netbeans/modules/csl/CslJar.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.csl;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -37,6 +36,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -97,9 +97,8 @@ public class CslJar extends JarWithModuleAttributes {
     protected void zipFile(File file, ZipOutputStream zOut, String vPath, int mode) throws IOException {
         if (vPath.equals(layer)) {
             System.setProperty("CslJar", Boolean.TRUE.toString());
-            try {
                 // Create a tempfile and trick it!
-                InputStream is = new FileInputStream(file);
+            try (InputStream is = Files.newInputStream(file.toPath())) {
                 String modifiedLayer = getModifiedLayer(is);
                 if (modifiedLayer != null) {
                     File tmpFile = File.createTempFile("csl", "tmp"); // NOI18N

--- a/csl.api/src/org/netbeans/modules/csl/editor/FileObjectAccessor.java
+++ b/csl.api/src/org/netbeans/modules/csl/editor/FileObjectAccessor.java
@@ -21,9 +21,11 @@
 package org.netbeans.modules.csl.editor;
 
 import java.io.EOFException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 
 import org.netbeans.editor.ext.DataAccessor;
 import org.openide.filesystems.FileObject;
@@ -44,7 +46,7 @@ public class FileObjectAccessor implements DataAccessor {
 
     FileObject fo;
     InputStream inputStream;
-    FileOutputStream fos;
+    OutputStream fos;
     int actOff;
 
     public FileObjectAccessor(FileObject fo) {
@@ -58,11 +60,9 @@ public class FileObjectAccessor implements DataAccessor {
      * @param  len    the number of bytes to append.
      */
     public void append(byte[] buffer, int off, int len) throws IOException {
-        fos = new FileOutputStream(FileUtil.toFile(fo).getPath(), true);
-        fos.write(buffer, off, len);
-        fos.flush();
-        fos.close();
-        fos = null;
+        try (OutputStream fos = Files.newOutputStream(FileUtil.toFile(fo).toPath(), StandardOpenOption.APPEND)) {
+            fos.write(buffer, off, len);
+        }
     }
     
     /**

--- a/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
+++ b/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
@@ -21,10 +21,10 @@ package org.netbeans.modules.csl.spi;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.EventObject;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -299,7 +299,7 @@ public final class GsfUtilities {
 
     public static void extractZip(final FileObject extract, final FileObject dest) throws IOException {
         File extractFile = FileUtil.toFile(extract);
-        extractZip(dest, new BufferedInputStream(new FileInputStream(extractFile)));
+        extractZip(dest, new BufferedInputStream(Files.newInputStream(extractFile.toPath())));
     }
 
     // Based on openide/fs' FileUtil.extractJar


### PR DESCRIPTION
This change drops the usage of FileInputStream and FileOutputStream
in cluster modules "a*" through "c*".
The FIS/FOS are putting unnecesary pressure on the GC because of their finalize() method.
I've measured small, but fairly consistent improvements in GC pauses during the startup of the IDE with couple of projects opened:
Before: http://gceasy.io/my-gc-report.jsp?p=c2hhcmVkLzIwMTcvMTEvMjYvLS1nYXJiYWdlLWNvbGxlY3Rpb24tYmVmb3JlLXN0YXJ0dXAubG9nLS0yMC0xMS01OQ==
After: http://gceasy.io/my-gc-report.jsp?p=c2hhcmVkLzIwMTcvMTEvMjYvLS1nYXJiYWdlLWNvbGxlY3Rpb24tYWZ0ZXIxY29tbWl0LXN0YXJ0dXAubG9nLS0yMC0xMy01Mw==
In every module that required it (for the "Files" class workaround), theres a bump in javac source to version 7. Where appropriate I took the liberty of using try with resources blocks.
I may have also fixed a resource leak somewhere in there.
Further references: see JDK-8080225, HDFS-8526, JENKINS-42934