### PR TITLE
[NETBEANS-71] Change product name

### DIFF
--- a/core.startup/src/org/netbeans/core/startup/Bundle.properties
+++ b/core.startup/src/org/netbeans/core/startup/Bundle.properties
@@ -26,7 +26,7 @@ OpenIDE-Module-Long-Description=\
 
 # VERSIONING (TopLogging, MainWindow)
 # {0} - build number
-currentVersion=NetBeans Platform Dev (Build {0})
+currentVersion=Apache NetBeans Platform Dev (Build {0})
 
 ERR_no_user_directory=netbeans.user is not set.\nPlease check your NetBeans startup script.
 # {0} - userdir full path
@@ -35,7 +35,7 @@ ERR_user_dir_is_inside_home=Your user directory ({0}) cannot reside inside your 
 
 #Splash
 # title of the splash window; shown perhaps in window tray of e.g. Gnome
-LBL_splash_window_title=Starting NetBeans Platform
+LBL_splash_window_title=Starting Apache NetBeans Platform
 # The Title of the About Box
 CTL_About_Title=About
 CTL_About_Detail=Detail

--- a/core.windows/src/org/netbeans/core/windows/view/ui/Bundle.properties
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/Bundle.properties
@@ -23,8 +23,8 @@ LBL_EditorAreaFrameTitle=Editor
 ACSD_MainWindow=Main Window
 # {0} build number
 # {1} project name
-CTL_MainWindow_Title=NetBeans Platform {0}
-CTL_MainWindow_Title_No_Project=NetBeans Platform {0}
+CTL_MainWindow_Title=Apache NetBeans Platform {0}
+CTL_MainWindow_Title_No_Project=Apache NetBeans Platform {0}
 
 # DocumentsDlg
 LBL_Documents=&Documents:

--- a/ide.branding/core.startup/src/org/netbeans/core/startup/Bundle_nb.properties
+++ b/ide.branding/core.startup/src/org/netbeans/core/startup/Bundle_nb.properties
@@ -48,8 +48,8 @@ AboutTextBounds=78, 60, 362, 20
 #NOI18N
 AboutTextColor=0x000000
 
-LBL_splash_window_title=Starting NetBeans IDE
-currentVersion=NetBeans IDE Dev (Build {0})
+LBL_splash_window_title=Starting Apache NetBeans IDE
+currentVersion=Apache NetBeans IDE Dev (Build {0})
 
 MSG_warning=NetBeans IDE - Warning
 MSG_info=NetBeans IDE - Information

--- a/ide.branding/core.windows/src/org/netbeans/core/windows/view/ui/Bundle_nb.properties
+++ b/ide.branding/core.windows/src/org/netbeans/core/windows/view/ui/Bundle_nb.properties
@@ -17,5 +17,5 @@
 
 # {0} build number
 # {1} project name
-CTL_MainWindow_Title={1} - NetBeans IDE Dev {0}
-CTL_MainWindow_Title_No_Project=NetBeans IDE Dev {0}
+CTL_MainWindow_Title={1} - Apache NetBeans IDE Dev {0}
+CTL_MainWindow_Title_No_Project=Apache NetBeans IDE Dev {0}


### PR DESCRIPTION
The product name, i.e. 'NetBeans Platform' or 'NetBeans IDE', is changed to reflect the new Apache home, in a couple of locations. This is done to distinguish the product from the pre-Apache era.

These changes are expected to be permanent. As for any actual release, such release will be expected to brand these variables, e.g. insert the word "(incubating)" for releases done while in Apache incubating phase, etc. This is similar to the existing release process prior to NB9.

It doesn't make sense to change every occurrence of "NetBeans Platform" or "NetBeans IDE". It only makes sense in the most prominent locations, IMO. The ones I've chosen are outlined below.  There are a few other locations where I think it makes sense to change as well, but they are all related to the IDE's Installer, and since that part hasn't been donated yet, it cannot be changed just yet.

## Changes in this PR

**1. The main window's title bar**

![titlebar](https://user-images.githubusercontent.com/32431476/33424207-60b15de8-d5bb-11e7-8ef3-8aa5ee3a8154.png)

**2. the product name in the About dialog.**
![about](https://user-images.githubusercontent.com/32431476/33424215-675e6910-d5bb-11e7-8f3b-2a0f2250f26e.png)


3. (less prominent because nobody notices) : The title of the splash window in the OS window tray / status line

