### PR TITLE
Javadoc build changes

### DIFF
--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -271,8 +271,8 @@ cause it to fail.
         <tstamp>
             <format property="YEAR" pattern="yyyy"/>
         </tstamp>
-        <property name="javadoc.footer" value='&lt;span class="footnote"&gt;Built on ${TODAY}.&amp;nbsp;&amp;nbsp;|&amp;nbsp;&amp;nbsp;Portions
-        Copyright 1997-${YEAR} Oracle. All rights reserved.&lt;/span&gt;'/>
+        <property name="javadoc.footer" value='&lt;span class="footnote"&gt;Built on ${TODAY}.&amp;nbsp;&amp;nbsp;|&amp;nbsp;&amp;nbsp;
+        Copyright &amp;#169; 2017-${YEAR} Apache Software Foundation. All Rights Reserved.&lt;/span&gt;'/>
     </target>
     
     <target name="javadoc-exec-packages" depends="javadoc-init,javadoc-generate-references,javadoc-generate-overview,javadoc-exec-condition,javadoc-check-timestamps,javadoc-make-plain-title,javadoc-make-hyperlinked-title,javadoc-exec-condition,-javadoc-set-footer" unless="javadoc.exec.packages">

--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -84,7 +84,7 @@ cause it to fail.
         
         <!-- Docs to link to: -->
         <property name="javadoc.web.root" value="http://root/"/>
-        <property name="javadoc.docs.jdk" value="http://download.oracle.com/javase/7/docs/api"/>
+        <property name="javadoc.docs.jdk" value="http://download.oracle.com/javase/8/docs/api"/>
         &properties;
         <!-- add more here as needed... -->
         <property name="javadoc.css.dir" location="."/>


### PR DESCRIPTION
Two minor changes to Javadoc build. Not worthy of a JIRA issue, I thought.


### Change Javadoc copyright notice from Oracle to ASF

The copyright notice at the footer of Javadoc is changed from Oracle to ASF. The new footer resembles what e.g. Apache Tomcat project uses. Here's how it will look now (enlarged):

![untitled](https://user-images.githubusercontent.com/32431476/33505295-1c246a22-d6eb-11e7-947d-09a266dcd535.png)

Look at http://bits.netbeans.org/dev/javadoc/ for what it used to look like.

### Javadoc links changed from JDK7 to JDK8

When links to standard JDK classes is used in the NB javadocs it will now point to JDK8 rather than JDK7. This means that links to classes/methods that have debuted in Java 8 will now actually work. 