### PR TITLE
Javashell fixes

### DIFF
--- a/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/ContentParserTest.java
+++ b/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/ContentParserTest.java
@@ -78,6 +78,9 @@ public class ContentParserTest extends NbTestCase {
             String s;
             
             while ((s = br.readLine()) != null) {
+                if (s.startsWith("#")) {
+                    continue;
+                }
                 sb.append(s).append("\n");
             }
         }
@@ -105,6 +108,9 @@ public class ContentParserTest extends NbTestCase {
             org.netbeans.modules.jshell.model.ConsoleSection.Type lastType = null;
             
             while ((s = br.readLine()) != null) {
+                if (s.startsWith("#")) {
+                    continue;
+                }
                 pos = next;
                 next = pos + s.length() + 1;
                 if (s.trim().isEmpty()) {
@@ -161,6 +167,9 @@ public class ContentParserTest extends NbTestCase {
             int next = 0;
             org.netbeans.modules.jshell.model.ConsoleSection.Type lastType = null;
             while ((s = br.readLine()) != null) {
+                if (s.startsWith("#")) {
+                    continue;
+                }
                 pos = next;
                 int start = s.indexOf(':') + 1;
                 int len = s.length() - start + 1; // count the newline

--- a/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/reploutput.txt
+++ b/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/reploutput.txt
@@ -1,3 +1,19 @@
+#    Licensed to the Apache Software Foundation (ASF) under one
+#    or more contributor license agreements.  See the NOTICE file
+#    distributed with this work for additional information
+#    regarding copyright ownership.  The ASF licenses this file
+#    to you under the Apache License, Version 2.0 (the
+#    "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing,
+#    software distributed under the License is distributed on an
+#    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied.  See the License for the
+#    specific language governing permissions and limitations
+#    under the License.
 Cannot start REPL, see IDE log for more details.
 |  Welcome to the Java REPL NetBeans integration
 |  Type /help for help

--- a/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/reploutput_golden.txt
+++ b/jshell.support/test/unit/src/org/netbeans/modules/jshell/support/reploutput_golden.txt
@@ -1,3 +1,19 @@
+#    Licensed to the Apache Software Foundation (ASF) under one
+#    or more contributor license agreements.  See the NOTICE file
+#    distributed with this work for additional information
+#    regarding copyright ownership.  The ASF licenses this file
+#    to you under the Apache License, Version 2.0 (the
+#    "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing,
+#    software distributed under the License is distributed on an
+#    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied.  See the License for the
+#    specific language governing permissions and limitations
+#    under the License.
 O:Cannot start REPL, see IDE log for more details.
 x:|  Welcome to the Java REPL NetBeans integration
 x:|  Type /help for help

--- a/lib.jshell.agent/nbproject/project.properties
+++ b/lib.jshell.agent/nbproject/project.properties
@@ -22,4 +22,4 @@ extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jsh
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
 agentsrc.asm.cp=${core.startup.dir}/core/asm-all-5.0.1.jar
-agentsrc.jshell.cp=${nb_all}/libs.jshell.compile/external/jshell.jar
+agentsrc.jshell.cp=${nb_all}/libs.jshell.compile/external/jshell-9.jar

--- a/libs.jshell.compile/external/binaries-list
+++ b/libs.jshell.compile/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-1CA9DE21C6E443E814CB56912BEE872EF7094C49 jshell.jar
+1CA9DE21C6E443E814CB56912BEE872EF7094C49 jshell-9.jar

--- a/libs.jshell.compile/external/jshell-9-license.txt
+++ b/libs.jshell.compile/external/jshell-9-license.txt
@@ -1,5 +1,6 @@
-Version: nb-7.2
-Name: Javac Compiler API
+Version: 9
+Type: compile-time
+Name: Javac Shell API
 License: GPL-2-CP
 Description: Javac Compiler API
 OSR: 6273

--- a/libs.jshell.compile/nbproject/project.xml
+++ b/libs.jshell.compile/nbproject/project.xml
@@ -62,7 +62,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path></runtime-relative-path>
-                <binary-origin>external/jshell.jar</binary-origin>
+                <binary-origin>external/jshell-9.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -2105,7 +2105,6 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
             <exclude name="javafx2.project/src/org/netbeans/modules/javafx2/project/templates/**" /> <!--license would be visible when users edit the templates inside their IDE-->
             <exclude name="jellytools.platform/src/org/netbeans/jellytools/version_info" /> <!--does not natively support comments-->
             <exclude name="jshell.support/src/org/netbeans/modules/jshell/resources/consoleExample.jsh" /> <!-- file is used as sample for syntax highlighting in GUI -->
-            <exclude name="jshell.support/test/unit/src/org/netbeans/modules/jshell/support/*.txt" /> <!--test data-->
             <exclude name="junit.ui/src/org/netbeans/modules/junit/ui/resources/*.template" /> <!--license would be visible when users edit the templates inside their IDE-->
             <exclude name="languages.diff/src/org/netbeans/modules/languages/diff/DiffExample.diff" /> <!--license would be visible to users in the Fonts/Colors settings-->
             <exclude name="languages.yaml/src/org/netbeans/modules/languages/yaml/*.yaml" /> <!--Files used in GUI as sample/starting point-->


### PR DESCRIPTION
Incidentally, I was working on NETBEANS-191 while in parallel matthiasblaesing authored 2be2f4c62f814f02593cc04ae73ebc4fa7655fc7. I didn't sync mo fork timely, so I didn't notice the change before I started to generated the PR; sorry.

I've decided to merge the changes - licenses can be added to test data at expense of a small change to the test class. Less exceptions for rat checks.

The second part is the jar rename + license file update to include versions, to satisfy verify libs ant task.