### PR TITLE
[NETBEANS-194] Don't return NULL from ShellProjectUtils#launchVMOptions and compilerPathOptions

### DIFF
--- a/jshell.support/src/org/netbeans/modules/jshell/env/JShellEnvironment.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/env/JShellEnvironment.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.jshell.env;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.FilterReader;
 import java.io.IOException;
@@ -29,9 +28,7 @@ import java.io.PrintStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import javax.swing.text.Document;
 import jdk.jshell.JShell;
 import jdk.jshell.spi.ExecutionControlProvider;
@@ -41,20 +38,16 @@ import org.netbeans.api.java.queries.SourceLevelQuery;
 import org.netbeans.api.java.queries.SourceLevelQuery.Result;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.ClasspathInfo.PathKind;
-import org.netbeans.api.java.source.SourceUtils;
-import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.jshell.model.ConsoleEvent;
 import org.netbeans.modules.jshell.model.ConsoleListener;
 import org.netbeans.modules.jshell.project.ShellProjectUtils;
 import org.netbeans.modules.jshell.support.ShellSession;
-import static org.netbeans.modules.jshell.tool.JShellLauncher.quote;
 import org.netbeans.spi.java.classpath.ClassPathFactory;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.filesystems.URLMapper;
 import org.openide.loaders.DataObject;
 import org.openide.modules.SpecificationVersion;
 import org.openide.util.Exceptions;
@@ -718,7 +711,7 @@ public class JShellEnvironment {
         return s == null ? null : s.getShell();
     }
     
-    class ShellL implements PropertyChangeListener {
+    private class ShellL implements PropertyChangeListener {
 
         @Override
         public void propertyChange(PropertyChangeEvent evt) {

--- a/jshell.support/src/org/netbeans/modules/jshell/j2se/JShellStartupExtender.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/j2se/JShellStartupExtender.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.jshell.j2se;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -81,12 +80,10 @@ public class JShellStartupExtender implements StartupExtenderImplementation {
         List<String> args = ShellProjectUtils.quoteCmdArgs(
                 ShellLaunchManager.buildLocalJVMAgentArgs(platform, agent, prjEval.evaluator()::getProperty)
         );
+
+        args.addAll(ShellProjectUtils.launchVMOptions(p));
+
         LOG.log(Level.FINE, "Final args: {0}", args);
-        
-        List<String> shellArgs = ShellProjectUtils.launchVMOptions(p);
-        if (shellArgs != null) {
-            args.addAll(shellArgs);
-        }
         return args;
     }
 }

--- a/jshell.support/src/org/netbeans/modules/jshell/maven/MavenShellLauncher.java
+++ b/jshell.support/src/org/netbeans/modules/jshell/maven/MavenShellLauncher.java
@@ -102,10 +102,7 @@ public class MavenShellLauncher implements PrerequisitesChecker, LateBoundPrereq
                 config.getProperties()::get
         );
         String agentString = args.get(args.size() -1);
-        List<String> vmArgs = ShellProjectUtils.launchVMOptions(project);
-        if (vmArgs != null) {
-            args.addAll(vmArgs);
-        }
+        args.addAll(ShellProjectUtils.launchVMOptions(project));
         String execArgs = config.getProperties().get(PROPERTY_EXEC_ARGS);
         if (execArgs != null) {
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
The two methods ShellProjectUtils#launchVMOptions and compilerPathOptions
both return NULL if the project the JShell integration is invoked in
is not a modular project or does not export any modules.

The callers interate directly on the return value and for this case this
leads to a NullPointerException. The other methods of ShellProjectUtils
return an empty Collection and not NULL, this adjusts the behaviour of
the two methods launchVMOptions and compilerPathOptions to also return
an empty collection instead of NULL.