### PR TITLE
Excluding svnkit

### DIFF
--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -409,7 +409,6 @@ nb.cluster.ide=\
         libs.smack,\
         libs.svnClientAdapter,\
         libs.svnClientAdapter.javahl,\
-        libs.svnClientAdapter.svnkit,\
         libs.xerces,\
         localhistory,\
         localtasks,\

--- a/subversion/nbproject/project.xml
+++ b/subversion/nbproject/project.xml
@@ -346,11 +346,6 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.libs.svnClientAdapter.svnkit</code-name-base>
-                        <recursive/>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.diff</code-name-base>
                         <recursive/>
                         <compile-dependency/>

--- a/subversion/src/org/netbeans/modules/subversion/client/SvnClientFactory.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/SvnClientFactory.java
@@ -128,6 +128,10 @@ public class SvnClientFactory {
         return factory.connectionType() == ConnectionType.svnkit;
     }
 
+    public static boolean hasSvnKit() {
+        return SvnClientAdapterFactory.getInstance(SvnClientAdapterFactory.Client.SVNKIT) != null;
+    }
+
     /**
      * Returns a SvnClient, which isn't configured in any way.
      * Knows no username, password, has no SvnProgressSupport<br/>

--- a/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
+++ b/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
@@ -37,6 +37,7 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JFileChooser;
 import javax.swing.JList;
+import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
@@ -97,7 +98,12 @@ public final class SvnOptionsController extends OptionsPanelController implement
                 return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             }
         });
-        panel.cmbPreferredClient.setModel(new DefaultComboBoxModel(new Object[] { panel.panelCLI, panel.panelJavahl, panel.panelSvnkit }));
+        List<JPanel> clients = new ArrayList<>();
+        clients.addAll(Arrays.asList(panel.panelCLI, panel.panelJavahl));
+        if (SvnClientFactory.hasSvnKit()) {
+            clients.add(panel.panelSvnkit);
+        }
+        panel.cmbPreferredClient.setModel(new DefaultComboBoxModel(clients.toArray(new Object[0])));
         panel.textPaneClient.addHyperlinkListener(new HyperlinkListener() {
             @Override
             public void hyperlinkUpdate (HyperlinkEvent e) {


### PR DESCRIPTION
Seems that SvnKit is under a license that does not match Apache requirements(?), so disabling the module here. There are other ways the IDE can work with subversion. Unfortunately, svnkit had some advantages, but hopefully we can work even without it.