### PR TITLE
Add the JavaFixUtilities.isPrimary() utility API

### DIFF
--- a/spi.java.hints/apichanges.xml
+++ b/spi.java.hints/apichanges.xml
@@ -25,6 +25,20 @@
         <apidef name="JavaHintsSPI">Java Hints SPI</apidef>
     </apidefs>
     <changes>
+        <change id="JavaFixUtilities.isPrimary">
+            <api name="JavaHintsSPI"/>
+            <summary>Added JavaFixUtilities.isPrimary() utility</summary>
+            <version major="1" minor="31"/>
+            <date day="15" month="1" year="2018"/>
+            <compatibility addition="yes"/>
+            <description>
+                <p>
+                    The utility method JavaFixUtilities.isPrimary() was added.
+                    This API checks whether a specified tree can be used in
+                    places where a Primary expression is required.
+                </p>
+            </description>
+        </change>
         <change id="Hint.minSourceVersion">
             <api name="JavaHintsSPI"/>
             <summary>Hint can specify minimum source version for operation</summary>

--- a/spi.java.hints/nbproject/project.properties
+++ b/spi.java.hints/nbproject/project.properties
@@ -17,7 +17,7 @@
 is.autoload=true
 javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.30.0
+spec.version.base=1.31.0
 requires.nb.javac=true
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
+++ b/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
@@ -73,7 +73,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
@@ -85,13 +84,13 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.classpath.ClassPath.PathConversionMode;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.ClasspathInfo.PathKind;
 import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.GeneratorUtilities;
 import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.java.source.TreeMaker;
@@ -1337,6 +1336,7 @@ public class JavaFixUtilities {
 
         OPERATOR_PRIORITIES.put(Kind.ARRAY_ACCESS, 1);
         OPERATOR_PRIORITIES.put(Kind.METHOD_INVOCATION, 1);
+        OPERATOR_PRIORITIES.put(Kind.MEMBER_REFERENCE, 1);
         OPERATOR_PRIORITIES.put(Kind.MEMBER_SELECT, 1);
         OPERATOR_PRIORITIES.put(Kind.POSTFIX_DECREMENT, 1);
         OPERATOR_PRIORITIES.put(Kind.POSTFIX_INCREMENT, 1);
@@ -1394,7 +1394,21 @@ public class JavaFixUtilities {
         OPERATOR_PRIORITIES.put(Kind.UNSIGNED_RIGHT_SHIFT_ASSIGNMENT, 15);
         OPERATOR_PRIORITIES.put(Kind.XOR_ASSIGNMENT, 15);
     }
-    
+
+    /**
+     * Checks whether {@code tree} can be used in places where a Primary is
+     * required (for instance, as the receiver expression of a method invocation).
+     * <p>This is a friend API intended to be used by the java.hints module.
+     * Other modules should not use this API because it might not be stabilized.
+     * @param tree the tree to check
+     * @return {@code true} iff {@code tree} can be used where a Primary is
+     * required.
+     * @since 1.31
+     */
+    public static boolean isPrimary(@NonNull Tree tree) {
+        final Integer treePriority = OPERATOR_PRIORITIES.get(tree.getKind());
+        return (treePriority != null && treePriority <= 1);
+    }
 
     /**Checks whether putting {@code inner} tree into {@code outter} tree,
      * when {@code original} is being replaced with {@code inner} requires parentheses.

--- a/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
+++ b/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
@@ -1126,6 +1126,49 @@ public class JavaFixUtilitiesTest extends TestBase {
 		           "}\n", "1.8");
     }
 
+    public void testChangeMemberRefs() throws Exception {
+        performRewriteTest("package test;\n" +
+                           "\n" +
+                           "import java.util.Objects;\n" +
+                           "import java.util.stream.Stream;\n" +
+                           "\n" +
+                           "public class Test {\n" +
+                           "\n" +
+                           "    public static <T> T identity(T t) {\n" +
+                           "        return t;\n" +
+                           "    }\n" +
+                           "\n" +
+                           "    public static String toString(Object o) {\n" +
+                           "        return Objects.toString(o);\n" +
+                           "    }\n" +
+                           "\n" +
+                           "    public <T> Stream<?> test(Stream<T> stream) {\n" +
+                           "        return stream.map(Test::identity);\n" +
+                           "    }\n" +
+                           "}",
+                           "$expr::identity => $expr::toString",
+                           "package test;\n" +
+                           "\n" +
+                           "import java.util.Objects;\n" +
+                           "import java.util.stream.Stream;\n" +
+                           "\n" +
+                           "public class Test {\n" +
+                           "\n" +
+                           "    public static <T> T identity(T t) {\n" +
+                           "        return t;\n" +
+                           "    }\n" +
+                           "\n" +
+                           "    public static String toString(Object o) {\n" +
+                           "        return Objects.toString(o);\n" +
+                           "    }\n" +
+                           "\n" +
+                           "    public <T> Stream<?> test(Stream<T> stream) {\n" +
+                           "        return stream.map(Test::toString);\n" +
+                           "    }\n" +
+                           "}",
+                           "1.8");
+    }
+
     public void testComments232298() throws Exception {
         performRewriteTest("package test;\n" +
                            "public class Test {\n" +


### PR DESCRIPTION
This utility method determines whether a Tree can be used in places
where a Primary is required (for instance, as the receiver expression of
a method invocation).