### PR TITLE
Migrate to Files.new* creation of I/O streams during IDE boot

### DIFF
--- a/core.netigso/nbproject/project.properties
+++ b/core.netigso/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/core.netigso/src/org/netbeans/core/netigso/Netigso.java
+++ b/core.netigso/src/org/netbeans/core/netigso/Netigso.java
@@ -22,10 +22,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,7 +36,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -453,9 +452,9 @@ implements Cloneable, Stamps.Updater {
             } else if (symbolicName != null) { // NOI18N
                 if (original != null) {
                     LOG.log(Level.FINE, "Updating bundle {0}", original.getLocation());
-                    FileInputStream is = new FileInputStream(m.getJarFile());
-                    original.update(is);
-                    is.close();
+                    try (InputStream is = Files.newInputStream(m.getJarFile().toPath())) {
+                        original.update(is);
+                    }
                     b = original;
                 } else {
                     BundleContext bc = framework.getBundleContext();

--- a/core.netigso/src/org/netbeans/core/netigso/Netigso.java
+++ b/core.netigso/src/org/netbeans/core/netigso/Netigso.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collection;
@@ -454,6 +455,8 @@ implements Cloneable, Stamps.Updater {
                     LOG.log(Level.FINE, "Updating bundle {0}", original.getLocation());
                     try (InputStream is = Files.newInputStream(m.getJarFile().toPath())) {
                         original.update(is);
+                    } catch (InvalidPathException ex) {
+                        throw new IOException(ex);
                     }
                     b = original;
                 } else {

--- a/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
+++ b/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
@@ -21,10 +21,11 @@ package org.netbeans.core.network.proxy;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -421,10 +422,9 @@ public final class NbProxySelector extends ProxySelector {
                 }
 
                 fname = netProperties.getCanonicalPath();
-                InputStream in = new FileInputStream(fname);
-                BufferedInputStream bin = new BufferedInputStream(in);
-                props.load(bin);
-                bin.close();
+                try (InputStream bin = new BufferedInputStream(Files.newInputStream(Paths.get(fname)))) {
+                    props.load(bin);
+                }
 
                 String val = props.getProperty(propertyKey);
                 val = System.getProperty(propertyKey, val);

--- a/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
@@ -19,12 +19,10 @@
 package org.netbeans.core.network.proxy.kde;
 
 import java.io.BufferedReader;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -133,10 +131,7 @@ public class KdeNetworkProxy implements NetworkProxyResolver {
         Map<String, String> map = new HashMap<String, String>();
 
         if (kioslavercFile.exists()) {
-            try {
-                FileInputStream fis = new FileInputStream(kioslavercFile);
-                DataInputStream dis = new DataInputStream(fis);
-                BufferedReader br = new BufferedReader(new InputStreamReader(dis));
+            try (BufferedReader br = Files.newBufferedReader(kioslavercFile.toPath())) {
                 String line;
                 boolean inGroup = false;
                 while ((line = br.readLine()) != null) {
@@ -153,7 +148,6 @@ public class KdeNetworkProxy implements NetworkProxyResolver {
                         inGroup = true;
                     }
                 }
-                dis.close();
             } catch (FileNotFoundException fnfe) {
                 LOGGER.log(Level.SEVERE, "Cannot read file: ", fnfe);
             } catch (IOException ioe) {

--- a/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
+++ b/core.network/src/org/netbeans/core/network/proxy/kde/KdeNetworkProxy.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -148,10 +149,8 @@ public class KdeNetworkProxy implements NetworkProxyResolver {
                         inGroup = true;
                     }
                 }
-            } catch (FileNotFoundException fnfe) {
-                LOGGER.log(Level.SEVERE, "Cannot read file: ", fnfe);
-            } catch (IOException ioe) {
-                LOGGER.log(Level.SEVERE, "Cannot read file: ", ioe);
+            } catch (IOException | InvalidPathException ex) {
+                LOGGER.log(Level.SEVERE, "Cannot read file: ", ex);
             }
         } else {
             LOGGER.log(Level.WARNING, "KDE system proxy resolver: The kioslaverc file not found ({0})", KIOSLAVERC_PATH);

--- a/core.osgi/nbproject/project.properties
+++ b/core.osgi/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 cp.extra=\
     ${nb_all}/libs.osgi/external/osgi.core-5.0.0.jar:\

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
@@ -20,12 +20,12 @@
 package org.netbeans.core.osgi;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -122,20 +122,13 @@ class OSGiInstalledFileLocator extends InstalledFileLocator {
                         if (!dir.isDirectory() && !dir.mkdirs()) {
                             throw new IOException("Could not make " + dir);
                         }
-                        InputStream is = resource.openStream();
-                        try {
-                            OutputStream os = new FileOutputStream(f2);
-                            try {
-                                byte[] buf = new byte[4096];
-                                int read;
-                                while ((read = is.read(buf)) != -1) {
-                                    os.write(buf, 0, read);
-                                }
-                            } finally {
-                                os.close();
+                        try (InputStream is = resource.openStream();
+                                OutputStream os = Files.newOutputStream(f2.toPath())) {
+                            byte[] buf = new byte[4096];
+                            int read;
+                            while ((read = is.read(buf)) != -1) {
+                                os.write(buf, 0, read);
                             }
-                        } finally {
-                            is.close();
                         }
                         if (execFiles.contains(name)) {
                             f2.setExecutable(true);

--- a/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
+++ b/core.osgi/src/org/netbeans/core/osgi/OSGiInstalledFileLocator.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -135,7 +136,7 @@ class OSGiInstalledFileLocator extends InstalledFileLocator {
                         }
                     }
                     return f;
-                } catch (IOException x) {
+                } catch (IOException | InvalidPathException x) {
                     Exceptions.printStackTrace(x);
                 }
             }

--- a/core.output2/nbproject/project.properties
+++ b/core.output2/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.7
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/core.output2/src/org/netbeans/core/output2/Controller.java
+++ b/core.output2/src/org/netbeans/core/output2/Controller.java
@@ -23,10 +23,10 @@ import java.awt.Container;
 import java.awt.Font;
 import java.io.CharConversionException;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -525,7 +525,7 @@ public class Controller {
                         f.delete();
                     }
                     f.createNewFile();
-                    logStream = new FileOutputStream(f);
+                    logStream = Files.newOutputStream(f.toPath());
                 } catch (Exception e) {
                     e.printStackTrace();
                     logStream = System.err;

--- a/core.startup.base/nbproject/project.properties
+++ b/core.startup.base/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.63.0
 module.jar.dir=core

--- a/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
@@ -20,7 +20,6 @@
 package org.netbeans.core.startup.layers;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,6 +29,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -241,16 +241,8 @@ public class ArchiveURLMapper extends URLMapper {
                     copy = copy.getCanonicalFile();
                     copy.deleteOnExit();
                 }
-                InputStream is = fo.getInputStream();
-                try {
-                    OutputStream os = new FileOutputStream(copy);
-                    try {
-                        FileUtil.copy(is, os);
-                    } finally {
-                        os.close();
-                    }
-                } finally {
-                    is.close();
+                try (InputStream is = fo.getInputStream(); OutputStream os = Files.newOutputStream(copy.toPath())) {
+                    FileUtil.copy(is, os);
                 }
                 copiedJARs.put(archiveFileURI, copy);
             }

--- a/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
@@ -30,6 +30,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -243,6 +244,8 @@ public class ArchiveURLMapper extends URLMapper {
                 }
                 try (InputStream is = fo.getInputStream(); OutputStream os = Files.newOutputStream(copy.toPath())) {
                     FileUtil.copy(is, os);
+                } catch (InvalidPathException ex) {
+                    throw new IOException(ex);
                 }
                 copiedJARs.put(archiveFileURI, copy);
             }

--- a/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
@@ -29,6 +29,7 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.UnknownServiceException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
@@ -140,7 +141,11 @@ public class NbinstURLStreamHandler extends URLStreamHandler {
         public InputStream getInputStream() throws IOException {
             this.connect();
             if (iStream == null) {
-                iStream = Files.newInputStream(f.toPath());
+                try {
+                    iStream = Files.newInputStream(f.toPath());
+                } catch (InvalidPathException ex) {
+                    throw new IOException(ex);
+                }
             }
             return iStream;
         }

--- a/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
+++ b/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
@@ -20,7 +20,6 @@
 package org.netbeans.core.startup.layers;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,6 +28,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.UnknownServiceException;
+import java.nio.file.Files;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
@@ -140,7 +140,7 @@ public class NbinstURLStreamHandler extends URLStreamHandler {
         public InputStream getInputStream() throws IOException {
             this.connect();
             if (iStream == null) {
-                iStream = new FileInputStream(f);
+                iStream = Files.newInputStream(f.toPath());
             }
             return iStream;
         }

--- a/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/SystemFileSystemTest.java
+++ b/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/SystemFileSystemTest.java
@@ -34,7 +34,6 @@ import org.netbeans.ModuleManager;
 import org.netbeans.core.startup.Main;
 import org.netbeans.core.startup.MainLookup;
 import org.netbeans.SetupHid;
-import org.netbeans.core.startup.layers.SystemFileSystem;
 import org.openide.filesystems.FileAttributeEvent;
 import org.openide.filesystems.FileChangeListener;
 import org.openide.filesystems.FileEvent;
@@ -236,17 +235,18 @@ implements InstanceContent.Convertor<FileSystem,FileSystem>, FileChangeListener 
     }
     
     private static void write(FileObject fo, String txt) throws IOException {
-        OutputStream os = fo.getOutputStream();
-        os.write(txt.getBytes());
-        os.close();
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(txt.getBytes());
+        }
     }
     
     private static String read(FileObject fo) throws IOException {
         byte[] arr = new byte[(int)fo.getSize()];
-        InputStream is = fo.getInputStream();
-        int len = is.read(arr);
-        assertEquals("Not enough read", arr.length, len);
-        return new String(arr);
+        try (InputStream is = fo.getInputStream()) {
+            int len = is.read(arr);
+            assertEquals("Not enough read", arr.length, len);
+            return new String(arr);
+        }
     }
 
     public FileSystem convert(FileSystem obj) {

--- a/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
@@ -21,6 +21,7 @@ package org.netbeans.core.startup.logging;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -85,7 +86,7 @@ final class MessagesHandler extends StreamHandler {
     private void initStream() {
         try {
             setOutputStream(Files.newOutputStream(files[0].toPath()));
-        } catch (IOException ex) {
+        } catch (IOException | InvalidPathException ex) {
             setOutputStream(System.err);
         }
     }

--- a/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/MessagesHandler.java
@@ -19,8 +19,8 @@
 package org.netbeans.core.startup.logging;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -84,8 +84,8 @@ final class MessagesHandler extends StreamHandler {
     
     private void initStream() {
         try {
-            setOutputStream(new FileOutputStream(files[0], false));
-        } catch (FileNotFoundException ex) {
+            setOutputStream(Files.newOutputStream(files[0].toPath()));
+        } catch (IOException ex) {
             setOutputStream(System.err);
         }
     }

--- a/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
@@ -18,12 +18,14 @@
  */
 package org.netbeans.core.startup.logging;
 
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.nio.file.StandardOpenOption;
 import java.util.logging.Handler;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -45,7 +47,7 @@ public final class NbLogging {
             try {
                 File debugLog = new File(System.getProperty("java.io.tmpdir"), "TopLogging.log"); // NOI18N
                 System.err.println("Logging sent to: " + debugLog); // NOI18N
-                _D = new PrintStream(Files.newOutputStream(debugLog.toPath(), StandardOpenOption.APPEND));
+                _D = new PrintStream(Files.newOutputStream(debugLog.toPath(), CREATE, APPEND));
             } catch (IOException | InvalidPathException x) {
                 x.printStackTrace();
             }

--- a/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
 import java.util.logging.Handler;
 import java.util.regex.Pattern;
@@ -45,7 +46,7 @@ public final class NbLogging {
                 File debugLog = new File(System.getProperty("java.io.tmpdir"), "TopLogging.log"); // NOI18N
                 System.err.println("Logging sent to: " + debugLog); // NOI18N
                 _D = new PrintStream(Files.newOutputStream(debugLog.toPath(), StandardOpenOption.APPEND));
-            } catch (IOException x) {
+            } catch (IOException | InvalidPathException x) {
                 x.printStackTrace();
             }
         }

--- a/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
+++ b/core.startup/src/org/netbeans/core/startup/logging/NbLogging.java
@@ -19,9 +19,10 @@
 package org.netbeans.core.startup.logging;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.logging.Handler;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -43,8 +44,8 @@ public final class NbLogging {
             try {
                 File debugLog = new File(System.getProperty("java.io.tmpdir"), "TopLogging.log"); // NOI18N
                 System.err.println("Logging sent to: " + debugLog); // NOI18N
-                _D = new PrintStream(new FileOutputStream(debugLog), true);
-            } catch (FileNotFoundException x) {
+                _D = new PrintStream(Files.newOutputStream(debugLog.toPath(), StandardOpenOption.APPEND));
+            } catch (IOException x) {
                 x.printStackTrace();
             }
         }

--- a/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
+++ b/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
@@ -37,6 +37,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.Policy;
@@ -707,8 +708,10 @@ public class JarClassLoader extends ProxyClassLoader {
                 while ((j = is.read(buf)) != -1) {
                     os.write(buf, 0, j);
                 }
+            } catch (InvalidPathException ex) {
+                throw new IOException(ex);
             }
- 
+
             doCloseJar();
             file = temp;
             dead = true;
@@ -858,7 +861,7 @@ public class JarClassLoader extends ProxyClassLoader {
             if (maniF.canRead()) {
                 try (InputStream istm = Files.newInputStream(maniF.toPath())) {
                     mf.read(istm);
-                } catch (IOException ex) {
+                } catch (IOException | InvalidPathException ex) {
                     Exceptions.printStackTrace(ex);
                 }
             }
@@ -886,6 +889,8 @@ public class JarClassLoader extends ProxyClassLoader {
                     count += is.read(data, count, len - count);
                 }
                 return data;
+            } catch (InvalidPathException ex) {
+                throw new IOException(ex);
             }
         }
         

--- a/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
+++ b/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
@@ -21,9 +21,7 @@ package org.netbeans;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,6 +36,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.file.Files;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.Policy;
@@ -701,20 +700,13 @@ public class JarClassLoader extends ProxyClassLoader {
             File temp = File.createTempFile(prefix, suffix);
             temp.deleteOnExit();
 
-            InputStream is = new FileInputStream(orig);
-            try {
-                OutputStream os = new FileOutputStream(temp);
-                try {
-                    byte[] buf = new byte[4096];
-                    int j;
-                    while ((j = is.read(buf)) != -1) {
-                        os.write(buf, 0, j);
-                    }
-                } finally {
-                    os.close();
+            try (InputStream is = Files.newInputStream(orig.toPath());
+                    OutputStream os = Files.newOutputStream(temp.toPath())) {
+                byte[] buf = new byte[4096];
+                int j;
+                while ((j = is.read(buf)) != -1) {
+                    os.write(buf, 0, j);
                 }
-            } finally {
-                is.close();
             }
  
             doCloseJar();
@@ -864,7 +856,7 @@ public class JarClassLoader extends ProxyClassLoader {
             File maniF = new File(new File(dir, "META-INF"), "MANIFEST.MF");
             mf = new Manifest();
             if (maniF.canRead()) {
-                try (InputStream istm = new FileInputStream(maniF)) {
+                try (InputStream istm = Files.newInputStream(maniF.toPath())) {
                     mf.read(istm);
                 } catch (IOException ex) {
                     Exceptions.printStackTrace(ex);
@@ -888,15 +880,12 @@ public class JarClassLoader extends ProxyClassLoader {
             
             int len = (int)clsFile.length();
             byte[] data = new byte[len];
-            InputStream is = new FileInputStream(clsFile);
-            try {
+            try (InputStream is = Files.newInputStream(clsFile.toPath())) {
                 int count = 0;
                 while (count < len) {
                     count += is.read(data, count, len - count);
                 }
                 return data;
-            } finally {
-                is.close();
             }
         }
         

--- a/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -26,7 +26,6 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -36,6 +35,7 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -435,7 +435,7 @@ public final class Stamps {
                 areCachesOK = len == read.length && is.available() == 0 && Arrays.equals(expected, read);
                 writeFile = !areCachesOK;
                 lastMod = file.lastModified();
-            } catch (FileNotFoundException notFoundEx) {
+            } catch (NoSuchFileException notFoundEx) {
                 // ok, running for the first time, no need to invalidate the cache
                 areCachesOK = true;
                 writeFile = true;
@@ -681,7 +681,8 @@ public final class Stamps {
                 cacheFile.getParentFile().mkdirs();
 
                 LOG.log(Level.FINE, "Storing cache {0}", cacheFile);
-                os = Files.newOutputStream(cacheFile.toPath(), StandardOpenOption.APPEND); //append new entries only
+                //append new entries only
+                os = Files.newOutputStream(cacheFile.toPath(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
                 DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(this, 1024 * 1024));
                 
                 this.delay = delay;

--- a/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -26,9 +26,7 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -36,6 +34,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -185,8 +185,7 @@ public final class Stamps {
             return null;
         }
         
-        try {
-            FileChannel fc = new FileInputStream(cacheFile).getChannel();
+        try (FileChannel fc = FileChannel.open(cacheFile.toPath(), StandardOpenOption.READ)){
             ByteBuffer master;
             if (mmap) {
                 master = fc.map(FileChannel.MapMode.READ_ONLY, 0, len[0]);
@@ -201,8 +200,6 @@ public final class Stamps {
                 master.flip();
             }
 
-            fc.close();
-            
             return master;
         } catch (IOException ex) {
             LOG.log(Level.WARNING, "Cannot read cache " + cacheFile, ex); // NOI18N
@@ -429,12 +426,10 @@ public final class Stamps {
         try {
             byte[] expected = content.getBytes("UTF-8"); // NOI18N
             byte[] read = new byte[expected.length];
-            FileInputStream is = null;
             boolean areCachesOK;
             boolean writeFile;
             long lastMod;
-            try {
-                is = new FileInputStream(file);
+            try (InputStream is = Files.newInputStream(file.toPath())) {
                 int len = is.read(read);
                 areCachesOK = len == read.length && is.available() == 0 && Arrays.equals(expected, read);
                 writeFile = !areCachesOK;
@@ -444,16 +439,12 @@ public final class Stamps {
                 areCachesOK = true;
                 writeFile = true;
                 lastMod = result.get();
-            } finally {
-                if (is != null) {
-                    is.close();
-                }
             }
             if (writeFile) {
                 file.getParentFile().mkdirs();
-                FileOutputStream os = new FileOutputStream(file);
-                os.write(expected);
-                os.close();
+                try (OutputStream os = Files.newOutputStream(file.toPath())) {
+                    os.write(expected);
+                }
                 if (areCachesOK) {
                     file.setLastModified(lastMod);
                 }
@@ -552,7 +543,6 @@ public final class Stamps {
             return;
         }
         ZipInputStream zip = null;
-        FileOutputStream os = null;
         try {
             byte[] arr = new byte[4096];
             LOG.log(Level.FINE, "Found populate.zip about to extract it into {0}", cache);
@@ -567,15 +557,15 @@ public final class Stamps {
                 }
                 File f = new File(cache, en.getName().replace('/', File.separatorChar));
                 f.getParentFile().mkdirs();
-                os = new FileOutputStream(f);
-                for (;;) {
-                    int len = zip.read(arr);
-                    if (len == -1) {
-                        break;
+                try (OutputStream os = Files.newOutputStream(f.toPath())) {
+                    for (;;) {
+                        int len = zip.read(arr);
+                        if (len == -1) {
+                            break;
+                        }
+                        os.write(arr, 0, len);
                     }
-                    os.write(arr, 0, len);
                 }
-                os.close();
             }
             zip.close();
         } catch (IOException ex) {
@@ -591,22 +581,12 @@ public final class Stamps {
         final String clustersCache = "all-clusters.dat"; // NOI18N
         File f = fileImpl(clustersCache, null, -1); // no timestamp check
         if (f != null) {
-            DataInputStream dis = null;
-            try {
-                dis = new DataInputStream(new FileInputStream(f));
+            try (DataInputStream dis = new DataInputStream(Files.newInputStream(f.toPath()))) {
                 if (Clusters.compareDirs(dis)) {
                     return false;
                 }
             } catch (IOException ex) {
                 return clustersChanged = true;
-            } finally {
-                if (dis != null) {
-                    try {
-                        dis.close();
-                    } catch (IOException ex) {
-                        LOG.log(Level.INFO, null, ex);
-                    }
-                }
             }
         } else {
             // missing cluster file signals caches are OK, for 
@@ -700,7 +680,7 @@ public final class Stamps {
                 cacheFile.getParentFile().mkdirs();
 
                 LOG.log(Level.FINE, "Storing cache {0}", cacheFile);
-                os = new FileOutputStream(cacheFile, append); //append new entries only
+                os = Files.newOutputStream(cacheFile.toPath(), StandardOpenOption.APPEND); //append new entries only
                 DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(this, 1024 * 1024));
                 
                 this.delay = delay;

--- a/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -35,6 +35,7 @@ import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -201,7 +202,7 @@ public final class Stamps {
             }
 
             return master;
-        } catch (IOException ex) {
+        } catch (IOException | InvalidPathException ex) {
             LOG.log(Level.WARNING, "Cannot read cache " + cacheFile, ex); // NOI18N
             return null;
         }
@@ -454,7 +455,7 @@ public final class Stamps {
                 }
             }
             return areCachesOK;
-        } catch (IOException ex) {
+        } catch (IOException | InvalidPathException ex) {
             ex.printStackTrace();
             return false;
         }
@@ -568,7 +569,7 @@ public final class Stamps {
                 }
             }
             zip.close();
-        } catch (IOException ex) {
+        } catch (IOException | InvalidPathException ex) {
             LOG.log(Level.INFO, "Failed to populate {0}", cache);
         }
     }
@@ -585,7 +586,7 @@ public final class Stamps {
                 if (Clusters.compareDirs(dis)) {
                     return false;
                 }
-            } catch (IOException ex) {
+            } catch (IOException | InvalidPathException ex) {
                 return clustersChanged = true;
             }
         } else {
@@ -688,7 +689,7 @@ public final class Stamps {
                 updater.flushCaches(dos);
                 dos.close();
                 LOG.log(Level.FINE, "Done Storing cache {0}", cacheFile);
-            } catch (IOException ex) {
+            } catch (IOException | InvalidPathException ex) {
                 LOG.log(Level.WARNING, "Error saving cache {0}", cacheFile);
                 LOG.log(Level.INFO, ex.getMessage(), ex); // NOI18N
                 delete = true;

--- a/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/o.n.bootstrap/src/org/netbeans/Util.java
@@ -21,6 +21,7 @@ package org.netbeans;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.util.*;
 import java.util.ArrayList;
 import java.util.logging.Level;
@@ -67,6 +68,8 @@ public final class Util {
             while ((i = is.read(buf)) != -1) {
                 os.write(buf, 0, i);
             }
+        } catch (InvalidPathException ex) {
+            throw new IOException(ex);
         }
         err.fine("Made " + physicalModuleFile);
         return physicalModuleFile;

--- a/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/o.n.bootstrap/src/org/netbeans/Util.java
@@ -20,6 +20,7 @@
 package org.netbeans;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.ArrayList;
 import java.util.logging.Level;
@@ -59,20 +60,13 @@ public final class Util {
         String suffix = "-test.jar"; // NOI18N
         File physicalModuleFile = File.createTempFile(prefix, suffix);
         physicalModuleFile.deleteOnExit();
-        InputStream is = new FileInputStream(moduleFile);
-        try {
-            OutputStream os = new FileOutputStream(physicalModuleFile);
-            try {
-                byte[] buf = new byte[4096];
-                int i;
-                while ((i = is.read(buf)) != -1) {
-                    os.write(buf, 0, i);
-                }
-            } finally {
-                os.close();
+        try (InputStream is = Files.newInputStream(moduleFile.toPath());
+                OutputStream os = Files.newOutputStream(physicalModuleFile.toPath())) {
+            byte[] buf = new byte[4096];
+            int i;
+            while ((i = is.read(buf)) != -1) {
+                os.write(buf, 0, i);
             }
-        } finally {
-            is.close();
         }
         err.fine("Made " + physicalModuleFile);
         return physicalModuleFile;

--- a/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -35,6 +34,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -505,6 +505,8 @@ public class JarFileSystem extends AbstractFileSystem {
             //is = j.getInputStream (je);
             try (InputStream is = getInputStream4336753(jf, je); OutputStream os = Files.newOutputStream(f.toPath())) {
                 FileUtil.copy(is, os);
+            } catch (InvalidPathException ex) {
+                throw new IOException(ex);
             }
         }
 

--- a/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
@@ -23,7 +23,6 @@ import java.beans.PropertyVetoException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -35,6 +34,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -503,24 +503,14 @@ public class JarFileSystem extends AbstractFileSystem {
         if (createContent || forceRecreate) {
             // JDK 1.3 contains bug #4336753
             //is = j.getInputStream (je);
-            InputStream is = getInputStream4336753(jf, je);
-
-            try {
-                OutputStream os = new FileOutputStream(f);
-
-                try {
-                    FileUtil.copy(is, os);
-                } finally {
-                    os.close();
-                }
-            } finally {
-                is.close();
+            try (InputStream is = getInputStream4336753(jf, je); OutputStream os = Files.newOutputStream(f.toPath())) {
+                FileUtil.copy(is, os);
             }
         }
 
         f.deleteOnExit();
 
-        return new FileInputStream(f);
+        return Files.newInputStream(f.toPath());
     }
 
     private static String temporaryName(String filePath, String entryPath) {

--- a/openide.filesystems/src/org/openide/filesystems/LocalFileSystem.java
+++ b/openide.filesystems/src/org/openide/filesystems/LocalFileSystem.java
@@ -401,13 +401,16 @@ public class LocalFileSystem extends AbstractFileSystem {
         File file = null;
 
         try {
-            fis = new BufferedInputStream(new FileInputStream(file = getFile(name)));
-        } catch (FileNotFoundException exc) {
+            file = getFile(name);
+            fis = new BufferedInputStream(Files.newInputStream(file.toPath()));
+        } catch (IOException exc) {
+            FileNotFoundException fnfException = new FileNotFoundException(exc.getMessage());
             if ((file == null) || !file.exists()) {
-                ExternalUtil.annotate(exc, NbBundle.getMessage(LocalFileSystem.class, "EXC_FileOutsideModified", getFile(name)));
+                ExternalUtil.annotate(fnfException,
+                        NbBundle.getMessage(LocalFileSystem.class, "EXC_FileOutsideModified", getFile(name)));
             }
 
-            throw exc;
+            throw fnfException;
         }
 
         return fis;
@@ -418,7 +421,7 @@ public class LocalFileSystem extends AbstractFileSystem {
         if (!f.exists()) {
             f.getParentFile().mkdirs();
         }
-        OutputStream retVal = new BufferedOutputStream(new FileOutputStream(f));
+        OutputStream retVal = new BufferedOutputStream(Files.newOutputStream(f.toPath()));
 
         // workaround for #42624
         if (BaseUtilities.isMac()) {


### PR DESCRIPTION
This change drops the usage of FileInputStream and FileOutputStream in classes that affect the boot up of the IDE in order to help relieve the pressure on the GC via circumventing the finalization.

I've measured the most notable offenders during the boot to reside in core, bootstrap and openide.filesystems modules:
![allocationhs_fis](https://user-images.githubusercontent.com/12681399/33808173-1e8ce318-dde2-11e7-8252-6b904bc60243.png)
![allocationhs_fos](https://user-images.githubusercontent.com/12681399/33808174-22e3e15a-dde2-11e7-9996-b182d1ad54d7.png)

However, the **vastly** more prominent and omnipresent case of finalizable input streams can be observed in the ZipFileInputStreams originating from ZipFile and JarFile objects:
![allocationhs_zipfis](https://user-images.githubusercontent.com/12681399/33808237-3fd9bffe-dde3-11e7-815e-f921351a3860.png)
As far as I know, there's no trivial solution to resolve those finalizations, but will look around for possible improvements there. 

As for the GC performance, I've repeatedly measured very small improvements in the GC invocations with default JVM settings:
Vanilla - http://gceasy.io/diamondgc-report.jsp?oTxnId_value=43107dc9-d949-4990-8585-684685aa4d02
PR - http://gceasy.io/diamondgc-report.jsp?oTxnId_value=3c5f83a2-05d6-4edf-9719-35d5fd14ff6c
The improvements are rather small, but please do note the measurements were taken on a new fairly powerful desktop PC with clean NB builds (zero projects imported, etc...). Therefore the gain might be bigger on lower end machines, where NB might be run (e.g. local schools?) or during real life usage scenarios. I encourage such tests, if in doubt.