### PR TITLE
NOTICE file

### DIFF
--- a/nbbuild/notice-stub.txt
+++ b/nbbuild/notice-stub.txt
@@ -1,9 +1,13 @@
 Apache NetBeans
-Copyright 2017-2017 The Apache Software Foundation
+Copyright 2017-2018 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-The code is based on NetBeans Copyright (c) Oracle Corp
-that has been kindly donated to the Apache Software Foundation.
+The code is based on NetBeans, that has been kindly donated to the Apache
+Software Foundation by Oracle.  
+
+The code was Copyright 1997-2016 Oracle and/or its affiliates.  The Initial
+Developer of the Original Software was Sun Microsystems, Inc. Portions
+Copyright 1997-2006 Sun Microsystems, Inc. 
 

--- a/o.apache.commons.codec/external/commons-codec-1.3-notice.txt
+++ b/o.apache.commons.codec/external/commons-codec-1.3-notice.txt
@@ -1,0 +1,3 @@
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+

--- a/o.apache.commons.httpclient/external/commons-httpclient-3.1-notice.txt
+++ b/o.apache.commons.httpclient/external/commons-httpclient-3.1-notice.txt
@@ -1,0 +1,5 @@
+Apache Jakarta HttpClient
+Copyright 1999-2007 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).

--- a/o.apache.commons.io/external/commons-io-1.4-notice.txt
+++ b/o.apache.commons.io/external/commons-io-1.4-notice.txt
@@ -1,0 +1,6 @@
+Apache Commons IO
+Copyright 2001-2008 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+

--- a/o.apache.commons.lang/external/commons-lang-2.6-notice.txt
+++ b/o.apache.commons.lang/external/commons-lang-2.6-notice.txt
@@ -1,0 +1,6 @@
+Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+

--- a/o.apache.commons.logging/external/commons-logging-1.1.1-notice.txt
+++ b/o.apache.commons.logging/external/commons-logging-1.1.1-notice.txt
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------
+// NOTICE file corresponding to the section 4d of The Apache License,
+// Version 2.0, in this case for Commons Logging
+// ------------------------------------------------------------------
+
+Commons Logging
+Copyright 2001-2007 The Apache Software Foundation
+
+This product includes/uses software(s) developed by 'an unknown organization'
+  - Unnamed - avalon-framework:avalon-framework:jar:4.1.3
+  - Unnamed - log4j:log4j:jar:1.2.12
+  - Unnamed - logkit:logkit:jar:1.0.1
+
+
+


### PR DESCRIPTION
- Added some missing notice files for some modules.
- Updated nbbuild/notice-stub.txt "preamble" to acknowledge previous copyright notices in the codebase.
- Updated build.xml and created CreateNoticeFile.java ant task to create the NOTICE file.

The NOTICE file depends on the build as follows:

- For source builds (binaryBuild="false") only the "preamble" and any "[module]/**notice.txt" are included in the NOTICE file.
- For binary builds (binaryBuild="true") the preamble, any "[module]/**notice.txt" and any "[module]/external/**notice.txt" files are included.

The list of modules to include depends on "nb.clusters.list" (if present) or "cluster.config.${cluster.config}.list". See "CreateNoticeFile.java" for the exact algorithm.

This task has to be reviewed. It seems to be working properly when running "ant build-platform", "ant" and "ant build-source-zips", generating different NOTICE files in each situation.