### PR TITLE
Missing dependency in libs.bytelist

### DIFF
--- a/libs.bytelist/external/binaries-list
+++ b/libs.bytelist/external/binaries-list
@@ -15,3 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 80294E59315B314D57782DC37F983AE5B29C2E4C org.jruby.extras:bytelist:1.0.15
+E2C76A19F00128BB1806207E2989139BFB45F49D org.jruby.jcodings:jcodings:1.0.18

--- a/libs.bytelist/external/jcodings-1.0.18-license.txt
+++ b/libs.bytelist/external/jcodings-1.0.18-license.txt
@@ -1,0 +1,24 @@
+Name: jcodings
+Version: 1.0.18
+Description: Java-based codings helper classes for Joni and JRuby
+License: MIT-nocopyright
+Origin: https://github.com/jruby/jcodings
+Comment: This library is required by bytelist 1.0.15
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs.bytelist/nbproject/project.properties
+++ b/libs.bytelist/nbproject/project.properties
@@ -17,4 +17,5 @@
 
 is.autoload=true
 release.external/bytelist-1.0.15.jar=modules/ext/bytelist-1.0.15.jar
+release.external/jcodings-1.0.18.jar=modules/ext/jcodings-1.0.18.jar
 spec.version.base=0.30.0

--- a/libs.bytelist/nbproject/project.xml
+++ b/libs.bytelist/nbproject/project.xml
@@ -25,7 +25,7 @@
         <data xmlns="http://www.netbeans.org/ns/nb-module-project/2">
             <code-name-base>org.netbeans.libs.bytelist</code-name-base>
             <module-dependencies/>
-<!--            
+            <!--            
             <friend-packages>
                 <friend>org.jruby</friend>
                 <friend>org.netbeans.modules.libs.jvyamlb</friend>
@@ -36,8 +36,12 @@
             </friend-packages>
 -->
             <public-packages>
-                <subpackages>org.jruby.util</subpackages>
+                <package>org.jruby.util</package>
             </public-packages>
+            <class-path-extension>
+                <runtime-relative-path>ext/jcodings-1.0.18.jar</runtime-relative-path>
+                <binary-origin>external/jcodings-1.0.18.jar</binary-origin>
+            </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/bytelist-1.0.15.jar</runtime-relative-path>
                 <binary-origin>external/bytelist-1.0.15.jar</binary-origin>

--- a/nbbuild/licenses/MIT-nocopyright
+++ b/nbbuild/licenses/MIT-nocopyright
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This solves issue #216
https://issues.apache.org/jira/browse/NETBEANS-216

We recently upgraded libs.bytelist to bytelist v1.0.15 due to unclear
licenses in previous versions. It seems bytelist v1.0.15 requires
jcodings v 1.0.18 (MIT), as per [1].

This adds the jcodings dependency. This is licensed as MIT, but
the license has not a copyright notice, so I added a MIT-COPYRIGHT in
nbbuild/licenses.

[1]
https://github.com/jruby/bytelist/blob/bytelist-1.0.15/pom.xml
[2]
https://raw.githubusercontent.com/jruby/jcodings/jcodings-1.0.18/LICENSE.txt