### PR TITLE
Updated references to osgi.cmpn-4.2.jar in project files, followup to NETBEANS-105

### DIFF
--- a/libs.osgi/nbproject/project.properties
+++ b/libs.osgi/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial
 
 release.external/osgi.core-5.0.0.jar=modules/ext/osgi.core-5.0.0.jar
-release.external/osgi.cmpn-4.2.jar=modules/ext/osgi.cmpn-4.2.jar
+release.external/org.osgi.compendium-4.2.0.jar=modules/ext/org.osgi.compendium-4.2.0.jar

--- a/libs.osgi/nbproject/project.xml
+++ b/libs.osgi/nbproject/project.xml
@@ -34,8 +34,8 @@
                 <binary-origin>external/osgi.core-5.0.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/osgi.cmpn-4.2.jar</runtime-relative-path>
-                <binary-origin>external/osgi.cmpn-4.2.jar</binary-origin>
+                <runtime-relative-path>ext/org.osgi.compendium-4.2.0.jar</runtime-relative-path>
+                <binary-origin>external/org.osgi.compendium-4.2.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
The changes introduced by commits 0f103bbcec20 and a1d379d1a118 were not complete. While the osgi.cmpn-4.2.jar was put into the distribution, the update_tracking information (made from manifest) had no such entry.  Applications built on top of the platform then lack the osgi.cmpn-4.2.jar (referenced from manifest) and fail on startup.

With this change, the osgi.cmpn-4.2.jar will disappear from platform/modules/ext, and org.osgi.compendium-4.2.0.jar will be distributed (and used bcs of change in project.xml propagated to MANIFEST).
